### PR TITLE
Bedre validering av Fnr og orgnr

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -103,6 +103,13 @@
             <version>2.4</version>
         </dependency>
 
+        <!-- Fnr og orngr-validering -->
+        <dependency>
+            <groupId>no.bekk.bekkopen</groupId>
+            <artifactId>nocommons</artifactId>
+            <version>0.8</version>
+        </dependency>
+
         <!-- OIDC Support -->
         <dependency>
             <groupId>no.nav.security</groupId>

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/domene/BedriftNr.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/domene/BedriftNr.java
@@ -1,11 +1,26 @@
 package no.nav.tag.tiltaksgjennomforing.domene;
 
+import static no.bekk.bekkopen.org.OrganisasjonsnummerValidator.isValid;
+
 import com.fasterxml.jackson.annotation.JsonValue;
 import lombok.Value;
+import no.nav.tag.tiltaksgjennomforing.domene.exceptions.TiltaksgjennomforingException;
 
 @Value
 public class BedriftNr implements Identifikator {
+
     private final String bedriftNr;
+
+    public BedriftNr(String bedriftNr) {
+        if (!erGyldigBedriftNr(bedriftNr)) {
+            throw new TiltaksgjennomforingException("Ugyldig bedriftsnummer.");
+        }
+        this.bedriftNr = bedriftNr;
+    }
+
+    public static boolean erGyldigBedriftNr(String bedriftNr) {
+        return isValid(bedriftNr);
+    }
 
     @Override
     @JsonValue

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/domene/Fnr.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/domene/Fnr.java
@@ -1,5 +1,7 @@
 package no.nav.tag.tiltaksgjennomforing.domene;
 
+import static no.bekk.bekkopen.person.FodselsnummerValidator.isValid;
+
 import com.fasterxml.jackson.annotation.JsonValue;
 import lombok.Value;
 import no.nav.tag.tiltaksgjennomforing.domene.exceptions.TiltaksgjennomforingException;
@@ -11,13 +13,13 @@ public class Fnr implements Identifikator {
 
     public Fnr(String fnr) {
         if (!erGyldigFnr(fnr)) {
-            throw new TiltaksgjennomforingException("Ugyldig fødselsnummer. Må bestå av 11 tegn.");
+            throw new TiltaksgjennomforingException("Ugyldig fødselsnummer.");
         }
         this.fnr = fnr;
     }
 
     public static boolean erGyldigFnr(String fnr) {
-        return fnr.matches("^[0-9]{11}$");
+        return isValid(fnr);
     }
 
     @JsonValue

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/controller/AvtaleControllerTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/controller/AvtaleControllerTest.java
@@ -81,7 +81,7 @@ public class AvtaleControllerTest {
     @Test(expected = TilgangskontrollException.class)
     public void hentSkalKastTilgangskontrollExceptionHvisInnloggetSelvbetjeningBrukerIkkeHarTilgang() {
         Avtale avtale = TestData.enAvtale();
-        vaerInnloggetSom(new InnloggetSelvbetjeningBruker(new Fnr("55555566666")));
+        vaerInnloggetSom(new InnloggetSelvbetjeningBruker(TestData.etFodselsnummer()));
         when(avtaleRepository.findById(avtale.getId())).thenReturn(Optional.of(avtale));
         avtaleController.hent(avtale.getId());
     }
@@ -129,7 +129,7 @@ public class AvtaleControllerTest {
     @Test
     public void hentAlleAvtalerInnloggetBrukerHarTilgangTilSkalIkkeReturnereAvtalerManIkkeHarTilgangTil() {
         Avtale avtaleMedTilgang = TestData.enAvtale();
-        Avtale avtaleUtenTilgang = Avtale.nyAvtale(new OpprettAvtale(new Fnr("89898989898"), new BedriftNr("111222333")), new NavIdent("X643564"));
+        Avtale avtaleUtenTilgang = Avtale.nyAvtale(new OpprettAvtale(TestData.etFodselsnummer(), new BedriftNr(TestData.GYLDIG_BEDRIFTSNR)), new NavIdent("X643564"));
 
         InnloggetSelvbetjeningBruker selvbetjeningBruker = TestData.innloggetSelvbetjeningBrukerUtenOrganisasjon(TestData.enDeltaker(avtaleMedTilgang));
         vaerInnloggetSom(selvbetjeningBruker);
@@ -183,7 +183,7 @@ public class AvtaleControllerTest {
     public void opprettAvtale__skal_feile_hvis_bruker_ikke_er_i_pilotering() {
         vaerInnloggetSom(TestData.enNavAnsatt());
         doThrow(TilgangskontrollException.class).when(tilgangUnderPilotering).sjekkTilgang(any());
-        avtaleController.opprettAvtale(new OpprettAvtale(new Fnr("11111100000"), new BedriftNr("111222333")));
+        avtaleController.opprettAvtale(new OpprettAvtale(new Fnr(TestData.GYLDIG_FNR), new BedriftNr(TestData.GYLDIG_BEDRIFTSNR)));
     }
 
     private void vaerInnloggetSom(InnloggetBruker innloggetBruker) {

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/domene/AvtaleRepositoryTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/domene/AvtaleRepositoryTest.java
@@ -108,7 +108,7 @@ public class AvtaleRepositoryTest {
 
     @Test
     public void opprettAvtale__skal_publisere_domainevent() {
-        Avtale nyAvtale = Avtale.nyAvtale(new OpprettAvtale(new Fnr("10101033333"), new BedriftNr("101033333")), new NavIdent("Q000111"));
+        Avtale nyAvtale = Avtale.nyAvtale(new OpprettAvtale(TestData.etFodselsnummer(), new BedriftNr(TestData.GYLDIG_BEDRIFTSNR)), new NavIdent("Q000111"));
         avtaleRepository.save(nyAvtale);
         verify(metrikkRegistrering).avtaleOpprettet(any());
     }

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/domene/AvtaleTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/domene/AvtaleTest.java
@@ -8,16 +8,17 @@ import org.junit.Test;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
+import static no.nav.tag.tiltaksgjennomforing.domene.TestData.GYLDIG_BEDRIFTSNR;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class AvtaleTest {
 
     @Test
     public void nyAvtaleFactorySkalReturnereRiktigeStandardverdier() {
-        Fnr deltakerFnr = new Fnr("01234567890");
+        Fnr deltakerFnr = TestData.etFodselsnummer();
 
         NavIdent veilederNavIdent = new NavIdent("X123456");
-        BedriftNr bedriftNr = new BedriftNr("000111222");
+        BedriftNr bedriftNr = new BedriftNr(TestData.GYLDIG_BEDRIFTSNR);
         Avtale avtale = Avtale.nyAvtale(new OpprettAvtale(deltakerFnr, bedriftNr), veilederNavIdent);
         SoftAssertions.assertSoftly(softly -> {
             softly.assertThat(avtale.getOpprettetTidspunkt()).isNull();
@@ -48,17 +49,17 @@ public class AvtaleTest {
 
     @Test(expected = TiltaksgjennomforingException.class)
     public void nyAvtaleSkalFeileHvisManglerDeltaker() {
-        Avtale.nyAvtale(new OpprettAvtale(null, new BedriftNr("111222333")), new NavIdent("X12345"));
+        Avtale.nyAvtale(new OpprettAvtale(null, new BedriftNr(GYLDIG_BEDRIFTSNR)), new NavIdent("X12345"));
     }
 
     @Test(expected = TiltaksgjennomforingException.class)
     public void nyAvtaleSkalFeileHvisManglerArbeidsgiver() {
-        Avtale.nyAvtale(new OpprettAvtale(new Fnr("12345678901"), null), new NavIdent("X12345"));
+        Avtale.nyAvtale(new OpprettAvtale(TestData.etFodselsnummer(), null), new NavIdent("X12345"));
     }
 
     @Test(expected = TiltaksgjennomforingException.class)
     public void nyAvtaleSkalFeileHvisManglerVeileder() {
-        Avtale.nyAvtale(new OpprettAvtale(new Fnr("11223344555"), new BedriftNr("000111222")), null);
+        Avtale.nyAvtale(new OpprettAvtale(TestData.etFodselsnummer(), new BedriftNr(GYLDIG_BEDRIFTSNR)), null);
     }
 
     @Test(expected = SamtidigeEndringerException.class)

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/domene/BedriftNrTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/domene/BedriftNrTest.java
@@ -1,0 +1,42 @@
+package no.nav.tag.tiltaksgjennomforing.domene;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+import no.nav.tag.tiltaksgjennomforing.domene.exceptions.TiltaksgjennomforingException;
+
+public class BedriftNrTest {
+
+    
+    @Test(expected = TiltaksgjennomforingException.class)
+    public void bedriftNrSkalIkkeVaereTomt() {
+        new BedriftNr("");
+    }
+
+    @Test(expected = TiltaksgjennomforingException.class)
+    public void bedriftNrSkalIkkeHaMindreEnn9Siffer() {
+        new BedriftNr("123");
+    }
+
+    @Test(expected = TiltaksgjennomforingException.class)
+    public void bedriftNrSkalIkkeHaMerEnn9Siffer() {
+        new BedriftNr("1234567890123");
+    }
+
+    @Test(expected = TiltaksgjennomforingException.class)
+    public void bedriftNrSkalIkkeInneholdeBokstaver() {
+        new BedriftNr("12345678a");
+    }
+
+    @Test(expected = TiltaksgjennomforingException.class)
+    public void bedriftNrSkalIkkeInneholdeAndreTingEnnTall() {
+        new BedriftNr("12345678 ");
+    }
+
+    @Test
+    public void gyldigBedriftNr() {
+        String gyldigBedriftNr = "156544825";
+        assertThat(new BedriftNr(gyldigBedriftNr).getBedriftNr()).isEqualTo(gyldigBedriftNr);
+    }
+}

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/domene/BedriftNrTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/domene/BedriftNrTest.java
@@ -8,7 +8,6 @@ import no.nav.tag.tiltaksgjennomforing.domene.exceptions.TiltaksgjennomforingExc
 
 public class BedriftNrTest {
 
-    
     @Test(expected = TiltaksgjennomforingException.class)
     public void bedriftNrSkalIkkeVaereTomt() {
         new BedriftNr("");
@@ -36,7 +35,6 @@ public class BedriftNrTest {
 
     @Test
     public void gyldigBedriftNr() {
-        String gyldigBedriftNr = "156544825";
-        assertThat(new BedriftNr(gyldigBedriftNr).getBedriftNr()).isEqualTo(gyldigBedriftNr);
+        assertThat(new BedriftNr(TestData.GYLDIG_BEDRIFTSNR).getBedriftNr()).isEqualTo(TestData.GYLDIG_BEDRIFTSNR);
     }
 }

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/domene/FnrTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/domene/FnrTest.java
@@ -9,32 +9,37 @@ public class FnrTest {
 
     @Test(expected = TiltaksgjennomforingException.class)
     public void fnrSkalIkkeVaereTomt() {
-        Fnr fnr = new Fnr("");
+        new Fnr("");
     }
 
     @Test(expected = TiltaksgjennomforingException.class)
     public void fnrSkalIkkeHaMindreEnn11Siffer() {
-        Fnr fnr = new Fnr("123");
+        new Fnr("123");
     }
 
     @Test(expected = TiltaksgjennomforingException.class)
     public void fnrSkalIkkeHaMerEnn11Siffer() {
-        Fnr fnr = new Fnr("1234567890123");
+        new Fnr("1234567890123");
     }
 
     @Test(expected = TiltaksgjennomforingException.class)
     public void fnrSkalIkkeInneholdeBokstaver() {
-        Fnr fnr = new Fnr("1234567890a");
+        new Fnr("1234567890a");
     }
 
     @Test(expected = TiltaksgjennomforingException.class)
     public void fnrSkalIkkeInneholdeAndreTingEnnTall() {
-        Fnr fnr = new Fnr("12345678900 ");
+        new Fnr("12345678900 ");
     }
 
+    @Test(expected = TiltaksgjennomforingException.class)
+    public void fnrKanIkkeHaUgyldigMnd() {
+        new Fnr("01234567890");
+    }
+    
     @Test
-    public void fnrSkalInneholde11Tall() {
-        String gyldigFnr = "01234567890";
+    public void gyldigFnr() {
+        String gyldigFnr = "12089512415";
         assertThat(new Fnr(gyldigFnr).getFnr()).isEqualTo(gyldigFnr);
     }
 }

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/domene/FnrTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/domene/FnrTest.java
@@ -39,7 +39,6 @@ public class FnrTest {
     
     @Test
     public void gyldigFnr() {
-        String gyldigFnr = "12089512415";
-        assertThat(new Fnr(gyldigFnr).getFnr()).isEqualTo(gyldigFnr);
+        assertThat(new Fnr(TestData.GYLDIG_FNR).getFnr()).isEqualTo(TestData.GYLDIG_FNR);
     }
 }

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/domene/TestData.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/domene/TestData.java
@@ -3,12 +3,22 @@ package no.nav.tag.tiltaksgjennomforing.domene;
 import no.nav.tag.tiltaksgjennomforing.domene.autorisasjon.InnloggetNavAnsatt;
 import no.nav.tag.tiltaksgjennomforing.domene.autorisasjon.InnloggetSelvbetjeningBruker;
 
+import static java.time.LocalDate.of;
+import static no.bekk.bekkopen.person.FodselsnummerCalculator.getFodselsnummerForDate;
+
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneOffset;
 import java.util.Arrays;
+import java.util.Date;
 import java.util.List;
 
 public class TestData {
+    
+    public static final String GYLDIG_FNR = "12089512415";
+    public static final String GYLDIG_BEDRIFTSNR = "156544825";
+
     public static Avtale enAvtale() {
         NavIdent veilderNavIdent = new NavIdent("Z123456");
         return Avtale.nyAvtale(lagOpprettAvtale(), veilderNavIdent);
@@ -28,8 +38,8 @@ public class TestData {
     }
 
     private static OpprettAvtale lagOpprettAvtale() {
-        Fnr deltakerFnr = new Fnr("88888899999");
-        BedriftNr bedriftNr = new BedriftNr("12345678");
+        Fnr deltakerFnr = new Fnr(GYLDIG_FNR);
+        BedriftNr bedriftNr = new BedriftNr(GYLDIG_BEDRIFTSNR);
         return new OpprettAvtale(deltakerFnr, bedriftNr);
     }
 
@@ -43,7 +53,7 @@ public class TestData {
         endreAvtale.setDeltakerEtternavn("Etternavn");
         endreAvtale.setDeltakerTlf("22334455");
         endreAvtale.setBedriftNavn("Bedriftnavn");
-        endreAvtale.setBedriftNr(new BedriftNr("12345678"));
+        endreAvtale.setBedriftNr(new BedriftNr(GYLDIG_BEDRIFTSNR));
         endreAvtale.setArbeidsgiverFornavn("AG fornavn");
         endreAvtale.setArbeidsgiverEtternavn("AG etternavn");
         endreAvtale.setArbeidsgiverTlf("AG tlf");
@@ -61,7 +71,7 @@ public class TestData {
     }
 
     static Deltaker enDeltaker() {
-        return new Deltaker(new Fnr("01234567890"), enAvtale());
+        return new Deltaker(etFodselsnummer(), enAvtale());
     }
 
     public static Deltaker enDeltaker(Avtale avtale) {
@@ -69,7 +79,7 @@ public class TestData {
     }
 
     public static InnloggetSelvbetjeningBruker enSelvbetjeningBruker() {
-        return new InnloggetSelvbetjeningBruker(new Fnr("99999999999"));
+        return new InnloggetSelvbetjeningBruker(etFodselsnummer());
     }
 
     public static InnloggetNavAnsatt enNavAnsatt() {
@@ -77,7 +87,7 @@ public class TestData {
     }
 
     public static Arbeidsgiver enArbeidsgiver() {
-        return new Arbeidsgiver(new Fnr("12345678901"), enAvtale());
+        return new Arbeidsgiver(etFodselsnummer(), enAvtale());
     }
 
     public static Arbeidsgiver enArbeidsgiver(Avtale avtale) {
@@ -85,9 +95,12 @@ public class TestData {
     }
 
     public static Fnr etFodselsnummer() {
-        return new Fnr("00000000000");
+        return etFodselsnummerForDato(1992, 9, 17);
     }
 
+    public static Fnr etFodselsnummerForDato(int year, int month, int dayOfMonth) {
+        return new Fnr(getFodselsnummerForDate(new Date((of(year, month, dayOfMonth).toEpochSecond(LocalTime.now(), ZoneOffset.UTC)*1000))).toString());
+    }
     public static Veileder enVeileder() {
         return new Veileder(new NavIdent("X123456"), enAvtale());
     }
@@ -134,4 +147,5 @@ public class TestData {
             }
         };
     }
+
 }

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/domene/autorisasjon/InnloggetBrukerTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/domene/autorisasjon/InnloggetBrukerTest.java
@@ -6,20 +6,19 @@ import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-
 public class InnloggetBrukerTest {
 
     private Fnr deltaker;
-    private NavIdent navIdent;
+    private Fnr fnrSomIkkeErDeltaker;
     private Avtale avtale;
     private BedriftNr bedriftNr;
 
     @Before
     public void setup() {
-        deltaker = new Fnr("10000000000");
-        navIdent = new NavIdent("X100000");
-        bedriftNr = new BedriftNr("12345678901");
-        avtale = Avtale.nyAvtale(new OpprettAvtale(deltaker, bedriftNr), navIdent);
+        deltaker = TestData.etFodselsnummerForDato(1990, 5, 5);
+        fnrSomIkkeErDeltaker = TestData.etFodselsnummerForDato(1990, 6, 6);
+        bedriftNr = new BedriftNr(TestData.GYLDIG_BEDRIFTSNR);
+        avtale = Avtale.nyAvtale(new OpprettAvtale(deltaker, bedriftNr), new NavIdent("X100000"));
     }
 
     @Test
@@ -50,12 +49,7 @@ public class InnloggetBrukerTest {
 
     @Test
     public void harTilgang__veileder_skal_ha_tilgang_til_avtale() {
-        assertThat(new InnloggetNavAnsatt(navIdent).harTilgang(avtale)).isTrue();
-    }
-
-    @Test
-    public void harTilgang__arbeidsgiver_skal_ikke_ha_tilgang_til_avtale() {
-        assertThat(new InnloggetSelvbetjeningBruker(TestData.etFodselsnummer()).harTilgang(avtale)).isFalse();
+        assertThat(new InnloggetNavAnsatt(TestData.enVeileder(avtale).getIdentifikator()).harTilgang(avtale)).isTrue();
     }
 
     @Test
@@ -65,12 +59,12 @@ public class InnloggetBrukerTest {
 
     @Test
     public void harTilgang__ikkepart_selvbetjeningsbruker_skal_ikke_ha_tilgang() {
-        assertThat(new InnloggetSelvbetjeningBruker(new Fnr("00000000001")).harTilgang(avtale)).isFalse();
+        assertThat(new InnloggetSelvbetjeningBruker(fnrSomIkkeErDeltaker).harTilgang(avtale)).isFalse();
     }
 
     @Test
     public void harTilgang__arbeidsgiver_skal_kunne_representere_bedrift_uten_Fnr() {
-        InnloggetSelvbetjeningBruker innloggetSelvbetjeningBruker = new InnloggetSelvbetjeningBruker(new Fnr("00000000009"));
+        InnloggetSelvbetjeningBruker innloggetSelvbetjeningBruker = new InnloggetSelvbetjeningBruker(fnrSomIkkeErDeltaker);
         innloggetSelvbetjeningBruker.getOrganisasjoner().add(new Organisasjon(bedriftNr, "Testbutikken"));
         assertThat(innloggetSelvbetjeningBruker.harTilgang(avtale)).isTrue();
     }

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/integrasjon/AltinnServiceTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/integrasjon/AltinnServiceTest.java
@@ -1,7 +1,6 @@
 package no.nav.tag.tiltaksgjennomforing.integrasjon;
 
 import no.nav.tag.tiltaksgjennomforing.domene.BedriftNr;
-import no.nav.tag.tiltaksgjennomforing.domene.Fnr;
 import no.nav.tag.tiltaksgjennomforing.domene.Organisasjon;
 import no.nav.tag.tiltaksgjennomforing.domene.TestData;
 import no.nav.tag.tiltaksgjennomforing.integrasjon.altinn.AltinnService;
@@ -29,19 +28,19 @@ public class AltinnServiceTest {
 
     @Test
     public void hentOrganisasjoner__gyldig_fnr_en_forste_bedrift() {
-        List<Organisasjon> organisasjoner = altinnService.hentOrganisasjoner(new Fnr("10000000000"));
+        List<Organisasjon> organisasjoner = altinnService.hentOrganisasjoner(TestData.etFodselsnummerForDato(1990, 10, 10));
         assertThat(organisasjoner).extracting("bedriftNr").containsOnly(new BedriftNr("975959171"));
     }
 
     @Test
     public void hentOrganisasjoner__gyldig_fnr_en_andre_bedrift() {
-        List<Organisasjon> organisasjoner = altinnService.hentOrganisasjoner(new Fnr("20000000000"));
+        List<Organisasjon> organisasjoner = altinnService.hentOrganisasjoner(TestData.etFodselsnummerForDato(1990, 10, 20));
         assertThat(organisasjoner).extracting("bedriftNr").containsOnly(new BedriftNr("910909088"));
     }
 
     @Test
     public void hentOrganisasjoner__gyldig_fnr_tom_liste() {
-        List<Organisasjon> organisasjoner = altinnService.hentOrganisasjoner(new Fnr("00000000000"));
+        List<Organisasjon> organisasjoner = altinnService.hentOrganisasjoner(TestData.etFodselsnummerForDato(1990, 10, 1));
         assertThat(organisasjoner).hasSize(0);
     }
 

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/integrasjon/EregServiceTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/integrasjon/EregServiceTest.java
@@ -2,6 +2,7 @@ package no.nav.tag.tiltaksgjennomforing.integrasjon;
 
 import no.nav.tag.tiltaksgjennomforing.domene.BedriftNr;
 import no.nav.tag.tiltaksgjennomforing.domene.Organisasjon;
+import no.nav.tag.tiltaksgjennomforing.domene.TestData;
 import no.nav.tag.tiltaksgjennomforing.domene.exceptions.EnhetFinnesIkkeException;
 import no.nav.tag.tiltaksgjennomforing.integrasjon.ereg.EregService;
 import org.junit.Test;
@@ -31,6 +32,6 @@ public class EregServiceTest {
 
     @Test(expected = EnhetFinnesIkkeException.class)
     public void hentBedriftNavn__kaster_exception_ved_404() {
-        eregService.hentVirksomhet(new BedriftNr("899999999"));
+        eregService.hentVirksomhet(new BedriftNr(TestData.GYLDIG_BEDRIFTSNR));
     }
 }


### PR DESCRIPTION
Grundigere validering av Fnr og orgnr.
Spesielt Fnr-valideringen kan være nyttig, siden den vil hindre tastefeil osv, som vil slippe igjennom med dagens validering som bare sjekker 11 sifre. Så lenge vi ikke sjekker/slår opp fnr mot andre systemer vil det i dag være mulig å opprette avtaler som ikke vil matche noen personer.

Orgnr-valideringen er mindre nyttig, siden vi uansett slår dette opp i ereg, men det er uansett ikke dumt å avvise matematisk uygldige orgnr så tidlig som mulig.

Bedre validering kan naturligvis gjøre testing vanskeligere, siden det kreves gyldige numre selv ved testing, så vi får vurdere om det skaper problemer. Det går evt. an å lage noen nye rest-endepunkter som kan levere test-fnr omtrent på samme måte som for test-tokens.

Merk også at denne PR-en drar inn et bibliotek for validering. Det kunne gått an å bare kopiere de nødvendige kodesnuttene for validering, men biblioteket er ikke spesielt tungt.