### PR TITLE
TAG-53: Ny tabell for bjellevarsel

### DIFF
--- a/src/main/resources/db/migration/V10__ny_tabell_bjellevarsel.sql
+++ b/src/main/resources/db/migration/V10__ny_tabell_bjellevarsel.sql
@@ -1,0 +1,10 @@
+create table bjelle_varsel
+(
+    id                uuid primary key,
+    varslbar_hendelse uuid references varslbar_hendelse (id),
+    lest              boolean,
+    identifikator     varchar(11),
+    varslingstekst    varchar,
+    avtale_id         uuid references avtale (id),
+    tidspunkt         timestamp without time zone not null default now()
+);


### PR DESCRIPTION
Legger denne endringen utenom kodeendring, slik at kodeendring eventuelt kan reverteres. Denne nye tabellen påvirker ikke andre data om den ikke tas i bruk.