### PR TITLE
Logger med correlationId

### DIFF
--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/CorrelationIdSupplier.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/CorrelationIdSupplier.java
@@ -1,0 +1,29 @@
+package no.nav.tag.tiltaksgjennomforing;
+
+import lombok.experimental.UtilityClass;
+import org.slf4j.MDC;
+import org.springframework.util.Assert;
+
+import java.util.UUID;
+
+@UtilityClass
+public class CorrelationIdSupplier {
+    private static final String MDC_TOKEN_KEY = "correlationId";
+
+    public static void generateToken() {
+        MDC.put(MDC_TOKEN_KEY, UUID.randomUUID().toString());
+    }
+
+    public static void set(String token) {
+        Assert.hasLength(token, "Token kan ikke være blank");
+        MDC.put(MDC_TOKEN_KEY, token);
+    }
+
+    public static String get() {
+        return MDC.get(MDC_TOKEN_KEY);
+    }
+
+    public static void remove() {
+        MDC.remove(MDC_TOKEN_KEY);
+    }
+}

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/integrasjon/CorrelationIdFilter.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/integrasjon/CorrelationIdFilter.java
@@ -1,0 +1,35 @@
+package no.nav.tag.tiltaksgjennomforing.integrasjon;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import no.nav.tag.tiltaksgjennomforing.CorrelationIdSupplier;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Optional;
+
+@Data
+@EqualsAndHashCode(callSuper = false)
+@Component
+public class CorrelationIdFilter extends OncePerRequestFilter {
+    private static final String HEADER_NAME = "X-Correlation-Id";
+
+    @Override
+    protected void doFilterInternal(final HttpServletRequest request, final HttpServletResponse response, final FilterChain chain) throws ServletException, IOException {
+        try {
+            Optional.ofNullable(request.getHeader(HEADER_NAME))
+                    .filter(StringUtils::isNotBlank)
+                    .ifPresentOrElse(CorrelationIdSupplier::set, CorrelationIdSupplier::generateToken);
+            response.addHeader(HEADER_NAME, CorrelationIdSupplier.get());
+            chain.doFilter(request, response);
+        } finally {
+            CorrelationIdSupplier.remove();
+        }
+    }
+}

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/integrasjon/axsys/AxsysService.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/integrasjon/axsys/AxsysService.java
@@ -1,6 +1,7 @@
 package no.nav.tag.tiltaksgjennomforing.integrasjon.axsys;
 
 import lombok.extern.slf4j.Slf4j;
+import no.nav.tag.tiltaksgjennomforing.CorrelationIdSupplier;
 import no.nav.tag.tiltaksgjennomforing.domene.NavEnhet;
 import no.nav.tag.tiltaksgjennomforing.domene.NavIdent;
 import no.nav.tag.tiltaksgjennomforing.domene.exceptions.TiltaksgjennomforingException;
@@ -13,7 +14,6 @@ import org.springframework.web.util.UriComponentsBuilder;
 import java.net.URI;
 import java.util.Collections;
 import java.util.List;
-import java.util.UUID;
 import java.util.stream.Collectors;
 
 @Component
@@ -26,7 +26,7 @@ public class AxsysService {
         this.axsysProperties = axsysProperties;
         restTemplate = new RestTemplate();
         restTemplate.setInterceptors(Collections.singletonList((request, body, execution) -> {
-            request.getHeaders().add("Nav-Call-Id", UUID.randomUUID().toString());
+            request.getHeaders().add("Nav-Call-Id", CorrelationIdSupplier.get());
             request.getHeaders().add("Nav-Consumer-Id", axsysProperties.getNavConsumerId());
             return execution.execute(request, body);
         }));

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/CorrelationIdSupplierTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/CorrelationIdSupplierTest.java
@@ -1,0 +1,49 @@
+package no.nav.tag.tiltaksgjennomforing;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CorrelationIdSupplierTest {
+    @Test
+    public void set__egendefinert_token_kan_returneres_flere_ganger() {
+        String egendefinertToken = "foo";
+        CorrelationIdSupplier.set(egendefinertToken);
+        String token1 = CorrelationIdSupplier.get();
+        String token2 = CorrelationIdSupplier.get();
+        assertThat(token1).isEqualTo(egendefinertToken);
+        assertThat(token2).isEqualTo(egendefinertToken);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void set__blank_fungerer_ikke() {
+        CorrelationIdSupplier.set("");
+    }
+
+    @Test
+    public void generate__token_kan_returneres_flere_ganger() {
+        CorrelationIdSupplier.generateToken();
+        String token1 = CorrelationIdSupplier.get();
+        String token2 = CorrelationIdSupplier.get();
+        assertThat(token1).isNotNull().isEqualTo(token2);
+    }
+
+    @Test
+    public void generate__ny_genereres() {
+        CorrelationIdSupplier.generateToken();
+        String token1 = CorrelationIdSupplier.get();
+        CorrelationIdSupplier.generateToken();
+        String token2 = CorrelationIdSupplier.get();
+        assertThat(token1).isNotEqualTo(token2);
+    }
+
+    @Test
+    public void remove__fjerner_token() {
+        CorrelationIdSupplier.generateToken();
+        String token1 = CorrelationIdSupplier.get();
+        CorrelationIdSupplier.remove();
+        String token2 = CorrelationIdSupplier.get();
+        assertThat(token1).isNotNull();
+        assertThat(token2).isNull();
+    }
+}


### PR DESCRIPTION
Filter som genererer ny correlationId ved hver request, slik at alle loggmeldinger blir logget med kallkjedeidentifikator. Bruker den samme id-en i kallet til Axsys.