### PR TITLE
Unleash for pilottilgang

### DIFF
--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/pilottilgang/AxsysService.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/pilottilgang/AxsysService.java
@@ -2,7 +2,6 @@ package no.nav.tag.tiltaksgjennomforing.autorisasjon.pilottilgang;
 
 import lombok.extern.slf4j.Slf4j;
 import no.nav.tag.tiltaksgjennomforing.avtale.NavIdent;
-import no.nav.tag.tiltaksgjennomforing.exceptions.TiltaksgjennomforingException;
 import no.nav.tag.tiltaksgjennomforing.infrastruktur.CorrelationIdSupplier;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClientException;
@@ -12,6 +11,7 @@ import org.springframework.web.util.UriComponentsBuilder;
 import java.net.URI;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 @Component
 @Slf4j
@@ -29,7 +29,7 @@ public class AxsysService {
         }));
     }
 
-    public List<NavEnhet> hentEnheterVeilederHarTilgangTil(NavIdent ident) {
+    public Optional<List<NavEnhet>> hentEnheterVeilederHarTilgangTil(NavIdent ident) {
         URI uri = UriComponentsBuilder.fromUri(axsysProperties.getUri())
                 .pathSegment(ident.asString())
                 .queryParam("inkluderAlleEnheter", "false")
@@ -38,10 +38,10 @@ public class AxsysService {
 
         try {
             AxsysRespons respons = restTemplate.getForObject(uri, AxsysRespons.class);
-            return respons.tilEnheter();
+            return Optional.of(respons.tilEnheter());
         } catch (RestClientException exception) {
-            log.warn("Feil ved henting av tilganger for ident " + ident, exception);
-            throw new TiltaksgjennomforingException("Feil ved tilgangskontrollsjekk for ident " + ident.asString(), exception);
+            log.warn("Feil ved henting av enheter for ident " + ident, exception);
+            return Optional.empty();
         }
     }
 }

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/pilottilgang/TilgangUnderPilotering.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/pilottilgang/TilgangUnderPilotering.java
@@ -3,6 +3,8 @@ package no.nav.tag.tiltaksgjennomforing.autorisasjon.pilottilgang;
 import lombok.Data;
 import no.nav.tag.tiltaksgjennomforing.avtale.NavIdent;
 import no.nav.tag.tiltaksgjennomforing.exceptions.TilgangskontrollException;
+import no.nav.tag.tiltaksgjennomforing.featuretoggles.FeatureToggleService;
+
 import org.springframework.stereotype.Component;
 
 import java.util.List;
@@ -14,16 +16,32 @@ import static java.util.Collections.disjoint;
 @Component
 public class TilgangUnderPilotering {
 
+    static final String TAG_TILTAK_PILOTTILGANG = "tag.tiltak.pilottilgang";
+    static final String TAG_TILTAK_BRUK_UNLEASH_FOR_PILOTTILGANG = "tag.tiltak.bruk.unleash.for.pilottilgang";
+
     private final PilotProperties pilotProperties;
     private final AxsysService axsysService;
+    private final FeatureToggleService featureToggleService;
 
     public void sjekkTilgang(NavIdent ident) {
+        boolean tilgangOk = featureToggleService.isEnabled(TAG_TILTAK_BRUK_UNLEASH_FOR_PILOTTILGANG) ? sjekkPilotTilgangMedUnleash() : sjekkPilottilgangMedVault(ident);
+        if(!tilgangOk) {
+            throw new TilgangskontrollException("Ident " + ident.asString() + " er ikke lagt til i lista over brukere med tilgang.");
+        }
+    }
+
+    private boolean sjekkPilotTilgangMedUnleash() {
+        return featureToggleService.isEnabled(TAG_TILTAK_PILOTTILGANG);
+    }
+
+    private boolean sjekkPilottilgangMedVault(NavIdent ident) {
         if (pilotProperties.isEnabled() && !pilotProperties.getIdenter().contains(ident)) {
             List<NavEnhet> enheterInnloggetVeilederHarTilgangTil = axsysService.hentEnheterVeilederHarTilgangTil(ident);
             if (disjoint(pilotProperties.getEnheter(), enheterInnloggetVeilederHarTilgangTil)) {
-                throw new TilgangskontrollException("Ident " + ident.asString() + " er ikke lagt til i lista over brukere med tilgang.");
+                return false;
             }
         }
+        return true;
     }
 
 }

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/pilottilgang/TilgangUnderPilotering.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/pilottilgang/TilgangUnderPilotering.java
@@ -7,8 +7,6 @@ import no.nav.tag.tiltaksgjennomforing.featuretoggles.FeatureToggleService;
 
 import org.springframework.stereotype.Component;
 
-import java.util.List;
-
 import static java.util.Collections.disjoint;
 
 
@@ -36,10 +34,7 @@ public class TilgangUnderPilotering {
 
     private boolean sjekkPilottilgangMedVault(NavIdent ident) {
         if (pilotProperties.isEnabled() && !pilotProperties.getIdenter().contains(ident)) {
-            List<NavEnhet> enheterInnloggetVeilederHarTilgangTil = axsysService.hentEnheterVeilederHarTilgangTil(ident);
-            if (disjoint(pilotProperties.getEnheter(), enheterInnloggetVeilederHarTilgangTil)) {
-                return false;
-            }
+            return axsysService.hentEnheterVeilederHarTilgangTil(ident).map(enheter -> !disjoint(pilotProperties.getEnheter(), enheter)).orElse(false);
         }
         return true;
     }

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/featuretoggles/ByEnhetStrategy.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/featuretoggles/ByEnhetStrategy.java
@@ -38,10 +38,9 @@ public class ByEnhetStrategy implements Strategy {
     @Override
     public boolean isEnabled(Map<String, String> parameters, UnleashContext unleashContext) {
         return unleashContext.getUserId()
-                .map(currentUserId -> Optional.ofNullable(parameters.get(PARAM))
+                .flatMap(currentUserId -> Optional.ofNullable(parameters.get(PARAM))
                         .map(enheterString -> Set.of(enheterString.split(",\\s?")))
                         .map(enabledeEnheter -> !Collections.disjoint(enabledeEnheter, brukersEnheter(currentUserId))))
-                .orElse(Optional.of(false))
                 .orElse(false);
 
     }

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/featuretoggles/ByEnhetStrategy.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/featuretoggles/ByEnhetStrategy.java
@@ -1,0 +1,53 @@
+package no.nav.tag.tiltaksgjennomforing.featuretoggles;
+
+import no.finn.unleash.UnleashContext;
+import no.finn.unleash.strategy.Strategy;
+import no.nav.tag.tiltaksgjennomforing.avtale.NavIdent;
+import no.nav.tag.tiltaksgjennomforing.autorisasjon.pilottilgang.AxsysService;
+
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+
+import static java.util.stream.Collectors.toList;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+@Component
+@RequiredArgsConstructor
+public class ByEnhetStrategy implements Strategy {
+
+    static final String PARAM = "valgtEnhet";
+    private final AxsysService axsysService;
+
+    @Override
+    public String getName() {
+        return "byEnhet";
+    }
+
+    @Override
+    public boolean isEnabled(Map<String, String> parameters) {
+        return false;
+    }
+
+    @Override
+    public boolean isEnabled(Map<String, String> parameters, UnleashContext unleashContext) {
+        return unleashContext.getUserId()
+                .map(currentUserId -> Optional.ofNullable(parameters.get(PARAM))
+                        .map(enheterString -> Set.of(enheterString.split(",\\s?")))
+                        .map(enabledeEnheter -> !Collections.disjoint(enabledeEnheter, brukersEnheter(currentUserId))))
+                .orElse(Optional.of(false))
+                .orElse(false);
+
+    }
+
+    private List<String> brukersEnheter(String currentUserId) {
+        return axsysService.hentEnheterVeilederHarTilgangTil(new NavIdent(currentUserId)).stream()
+                .map(enhet -> enhet.getVerdi()).collect(toList());
+    }
+
+}

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/featuretoggles/ByEnhetStrategy.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/featuretoggles/ByEnhetStrategy.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Component;
 
 import lombok.RequiredArgsConstructor;
 
+import static java.util.Collections.emptyList;
 import static java.util.stream.Collectors.toList;
 
 import java.util.Collections;
@@ -46,7 +47,7 @@ public class ByEnhetStrategy implements Strategy {
     }
 
     private List<String> brukersEnheter(String currentUserId) {
-        return axsysService.hentEnheterVeilederHarTilgangTil(new NavIdent(currentUserId)).stream()
+        return axsysService.hentEnheterVeilederHarTilgangTil(new NavIdent(currentUserId)).orElse(emptyList()).stream()
                 .map(enhet -> enhet.getVerdi()).collect(toList());
     }
 

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/featuretoggles/FeatureToggleConfig.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/featuretoggles/FeatureToggleConfig.java
@@ -3,7 +3,6 @@ package no.nav.tag.tiltaksgjennomforing.featuretoggles;
 import no.finn.unleash.DefaultUnleash;
 import no.finn.unleash.Unleash;
 import no.finn.unleash.util.UnleashConfig;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -14,23 +13,15 @@ import org.springframework.context.annotation.Profile;
 @Profile(value= {"prod", "preprod"})
 public class FeatureToggleConfig {
 
-    private final String APP_NAME = "tiltaksgjennomforing-api";
-    private final ByEnvironmentStrategy byEnvironmentStrategy;
-    private final String profile;
-
-    @Value("${tiltaksgjennomforing.unleash.unleash-uri}") private String unleashUrl;
-
-    @Autowired
-    public FeatureToggleConfig(ByEnvironmentStrategy byEnvironmentStrategy) {
-        this.byEnvironmentStrategy = byEnvironmentStrategy;
-        this.profile = byEnvironmentStrategy.getEnvironment();
-    }
+    private static final String APP_NAME = "tiltaksgjennomforing-api";
 
     @Bean
-    public Unleash initializeUnleash() {
+    public Unleash initializeUnleash(@Value(
+            "${tiltaksgjennomforing.unleash.unleash-uri}") String unleashUrl, 
+            ByEnvironmentStrategy byEnvironmentStrategy) {
         UnleashConfig config = UnleashConfig.builder()
                 .appName(APP_NAME)
-                .instanceId(APP_NAME + "-" + profile)
+                .instanceId(APP_NAME + "-" + byEnvironmentStrategy.getEnvironment())
                 .unleashAPI(unleashUrl)
                 .build();
 

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/pilottilgang/AxsysServiceTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/pilottilgang/AxsysServiceTest.java
@@ -25,19 +25,19 @@ public class AxsysServiceTest {
 
     @Test
     public void hentEnheter__returnerer_riktige_enheter() {
-        List<NavEnhet> enheter = axsysService.hentEnheterVeilederHarTilgangTil(new NavIdent("X123456"));
+        List<NavEnhet> enheter = axsysService.hentEnheterVeilederHarTilgangTil(new NavIdent("X123456")).get();
         assertThat(enheter).containsOnly(new NavEnhet("0906"), new NavEnhet("0904"));
     }
 
     @Test
     public void hentEnheter__ugyldig_ident_skal_ikke_ha_enheter() {
-        List<NavEnhet> enheter = axsysService.hentEnheterVeilederHarTilgangTil(new NavIdent("X999999"));
+        List<NavEnhet> enheter = axsysService.hentEnheterVeilederHarTilgangTil(new NavIdent("X999999")).get();
         assertThat(enheter).isEmpty();
     }
 
     @Test
     public void pilotEnheter__inneholder_hentetEnheter() {
-        List<NavEnhet> enheter = axsysService.hentEnheterVeilederHarTilgangTil(new NavIdent("X123456"));
+        List<NavEnhet> enheter = axsysService.hentEnheterVeilederHarTilgangTil(new NavIdent("X123456")).get();
         List<NavEnhet> pilotEnheter = asList(new NavEnhet("0906"));
         assertThat(pilotEnheter).containsAnyElementsOf(enheter);
     }

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/pilottilgang/TilgangUnderPiloteringTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/pilottilgang/TilgangUnderPiloteringTest.java
@@ -1,7 +1,8 @@
-package no.nav.tag.tiltaksgjennomforing.autorisasjon;
+package no.nav.tag.tiltaksgjennomforing.autorisasjon.pilottilgang;
 
 import no.nav.tag.tiltaksgjennomforing.avtale.NavIdent;
 import no.nav.tag.tiltaksgjennomforing.exceptions.TilgangskontrollException;
+import no.nav.tag.tiltaksgjennomforing.featuretoggles.FeatureToggleService;
 import no.nav.tag.tiltaksgjennomforing.autorisasjon.pilottilgang.AxsysService;
 import no.nav.tag.tiltaksgjennomforing.autorisasjon.pilottilgang.PilotProperties;
 import no.nav.tag.tiltaksgjennomforing.autorisasjon.pilottilgang.NavEnhet;
@@ -19,6 +20,7 @@ public class TilgangUnderPiloteringTest {
     private AxsysService axsysService;
     private PilotProperties pilotProperties;
     private TilgangUnderPilotering tilgangUnderPilotering;
+    private FeatureToggleService featureToggleService;
 
     @Before
     public void setUp() {
@@ -26,7 +28,8 @@ public class TilgangUnderPiloteringTest {
         pilotProperties = new PilotProperties();
         pilotProperties.setEnabled(true);
         pilotProperties.setEnheter(asList(new NavEnhet("1111"), new NavEnhet("2222")));
-        tilgangUnderPilotering = new TilgangUnderPilotering(pilotProperties, axsysService);
+        featureToggleService = mock(FeatureToggleService.class);
+        tilgangUnderPilotering = new TilgangUnderPilotering(pilotProperties, axsysService, featureToggleService);
     }
 
     @Test
@@ -61,6 +64,20 @@ public class TilgangUnderPiloteringTest {
     @Test
     public void sjekkTilgang__enabled__og_gitt_bruker_har_tilgang_til_kontor() {
         when(axsysService.hentEnheterVeilederHarTilgangTil(new NavIdent("Q000111"))).thenReturn(asList(new NavEnhet("1111"), new NavEnhet("5678")));
+        tilgangUnderPilotering.sjekkTilgang(new NavIdent("Q000111"));
+    }
+    
+    @Test
+    public void sjekkTilgang_enablet_i_unleash_skal_gi_tilgang() {
+        when(featureToggleService.isEnabled(TilgangUnderPilotering.TAG_TILTAK_BRUK_UNLEASH_FOR_PILOTTILGANG)).thenReturn(true);
+        when(featureToggleService.isEnabled(TilgangUnderPilotering.TAG_TILTAK_PILOTTILGANG)).thenReturn(true);
+        tilgangUnderPilotering.sjekkTilgang(new NavIdent("Q000111"));
+    }
+    
+    @Test(expected = TilgangskontrollException.class)
+    public void sjekkTilgang_enablet_i_unleash_skal_feile() {
+        when(featureToggleService.isEnabled(TilgangUnderPilotering.TAG_TILTAK_BRUK_UNLEASH_FOR_PILOTTILGANG)).thenReturn(true);
+        when(featureToggleService.isEnabled(TilgangUnderPilotering.TAG_TILTAK_PILOTTILGANG)).thenReturn(false);
         tilgangUnderPilotering.sjekkTilgang(new NavIdent("Q000111"));
     }
 }

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/pilottilgang/TilgangUnderPiloteringTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/pilottilgang/TilgangUnderPiloteringTest.java
@@ -15,6 +15,8 @@ import static java.util.Collections.emptyList;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.util.Optional;
+
 public class TilgangUnderPiloteringTest {
 
     private AxsysService axsysService;
@@ -51,19 +53,19 @@ public class TilgangUnderPiloteringTest {
 
     @Test(expected = TilgangskontrollException.class)
     public void sjekkTilgang__enabled__og_gitt_bruker_har_ikke_tilgang_til_kontor_skal_feile() {
-        when(axsysService.hentEnheterVeilederHarTilgangTil(new NavIdent("Q000111"))).thenReturn(asList(new NavEnhet("1234"), new NavEnhet("5678")));
+        when(axsysService.hentEnheterVeilederHarTilgangTil(new NavIdent("Q000111"))).thenReturn(Optional.of(asList(new NavEnhet("1234"), new NavEnhet("5678"))));
         tilgangUnderPilotering.sjekkTilgang(new NavIdent("Q000111"));
     }
 
     @Test(expected = TilgangskontrollException.class)
     public void sjekkTilgang__enabled__og_gitt_bruker_har_ingen_kontor_skal_feile() {
-        when(axsysService.hentEnheterVeilederHarTilgangTil(new NavIdent("Q000111"))).thenReturn(emptyList());
+        when(axsysService.hentEnheterVeilederHarTilgangTil(new NavIdent("Q000111"))).thenReturn(Optional.of(emptyList()));
         tilgangUnderPilotering.sjekkTilgang(new NavIdent("Q000111"));
     }
 
     @Test
     public void sjekkTilgang__enabled__og_gitt_bruker_har_tilgang_til_kontor() {
-        when(axsysService.hentEnheterVeilederHarTilgangTil(new NavIdent("Q000111"))).thenReturn(asList(new NavEnhet("1111"), new NavEnhet("5678")));
+        when(axsysService.hentEnheterVeilederHarTilgangTil(new NavIdent("Q000111"))).thenReturn(Optional.of(asList(new NavEnhet("1111"), new NavEnhet("5678"))));
         tilgangUnderPilotering.sjekkTilgang(new NavIdent("Q000111"));
     }
     

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/featuretoggles/ByEnhetStrategyTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/featuretoggles/ByEnhetStrategyTest.java
@@ -7,6 +7,7 @@ import no.nav.tag.tiltaksgjennomforing.autorisasjon.pilottilgang.NavEnhet;
 import no.nav.tag.tiltaksgjennomforing.autorisasjon.pilottilgang.AxsysService;
 
 import java.util.Map;
+import java.util.Optional;
 
 import static com.google.common.collect.Lists.newArrayList;
 import static java.util.Collections.emptyMap;
@@ -44,19 +45,19 @@ public class ByEnhetStrategyTest {
 
     @Test
     public void skal_være_disablet_hvis_bruker_har_definerte_enheter_men_ingen_er_i_listen() {
-        when(axsysService.hentEnheterVeilederHarTilgangTil(any())).thenReturn(newArrayList(new NavEnhet("1111"), new NavEnhet("2222")));
+        when(axsysService.hentEnheterVeilederHarTilgangTil(any())).thenReturn(Optional.of(newArrayList(new NavEnhet("1111"), new NavEnhet("2222"))));
         assertThat(new ByEnhetStrategy(axsysService).isEnabled(Map.of(PARAM, "1234"), unleashContext)).isEqualTo(false);
     }
     
     @Test
     public void skal_være_enablet_hvis_bruker_har_definert_enhet() {
-        when(axsysService.hentEnheterVeilederHarTilgangTil(any())).thenReturn(newArrayList(new NavEnhet("1234")));
+        when(axsysService.hentEnheterVeilederHarTilgangTil(any())).thenReturn(Optional.of(newArrayList(new NavEnhet("1234"))));
         assertThat(new ByEnhetStrategy(axsysService).isEnabled(Map.of(PARAM, "1234"), unleashContext)).isEqualTo(true);
     }
 
     @Test
     public void skal_være_enablet_hvis_en_av_brukers_enheter_er_i_listen() {
-        when(axsysService.hentEnheterVeilederHarTilgangTil(any())).thenReturn(newArrayList(new NavEnhet("1111"), new NavEnhet("1234")));
+        when(axsysService.hentEnheterVeilederHarTilgangTil(any())).thenReturn(Optional.of(newArrayList(new NavEnhet("1111"), new NavEnhet("1234"))));
         assertThat(new ByEnhetStrategy(axsysService).isEnabled(Map.of(PARAM, "1234,5678"), unleashContext)).isEqualTo(true);
     }
     

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/featuretoggles/ByEnhetStrategyTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/featuretoggles/ByEnhetStrategyTest.java
@@ -13,7 +13,7 @@ import static com.google.common.collect.Lists.newArrayList;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonMap;
 import static no.nav.tag.tiltaksgjennomforing.featuretoggles.ByEnhetStrategy.PARAM;
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 public class ByEnhetStrategyTest {
@@ -28,37 +28,37 @@ public class ByEnhetStrategyTest {
     
     @Test
     public void skal_være_disablet_hvis_det_ikke_finnes_bruker_i_konteksten() {
-        assertThat(new ByEnhetStrategy(axsysService).isEnabled(Map.of(PARAM, "1234"), UnleashContext.builder().build())).isEqualTo(false);
+        assertThat(new ByEnhetStrategy(axsysService).isEnabled(Map.of(PARAM, "1234"), UnleashContext.builder().build())).isFalse();
     }
     
     @Test
     public void skal_være_disablet_hvis_det_ikke_finnes_definerte_enheter() {
-        assertThat(new ByEnhetStrategy(axsysService).isEnabled(emptyMap(), unleashContext)).isEqualTo(false);
-        assertThat(new ByEnhetStrategy(axsysService).isEnabled(singletonMap(PARAM, null), unleashContext)).isEqualTo(false); //Map.of() tåler ikke null
-        assertThat(new ByEnhetStrategy(axsysService).isEnabled(Map.of(PARAM, ""), unleashContext)).isEqualTo(false);
+        assertThat(new ByEnhetStrategy(axsysService).isEnabled(emptyMap(), unleashContext)).isFalse();
+        assertThat(new ByEnhetStrategy(axsysService).isEnabled(singletonMap(PARAM, null), unleashContext)).isFalse(); //Map.of() tåler ikke null
+        assertThat(new ByEnhetStrategy(axsysService).isEnabled(Map.of(PARAM, ""), unleashContext)).isFalse();
     }
 
     @Test
     public void skal_være_disablet_hvis_bruker_ikke_har_definerte_enheter() {
-        assertThat(new ByEnhetStrategy(axsysService).isEnabled(Map.of(PARAM, "1234"), unleashContext)).isEqualTo(false);
+        assertThat(new ByEnhetStrategy(axsysService).isEnabled(Map.of(PARAM, "1234"), unleashContext)).isFalse();
     }
 
     @Test
     public void skal_være_disablet_hvis_bruker_har_definerte_enheter_men_ingen_er_i_listen() {
         when(axsysService.hentEnheterVeilederHarTilgangTil(any())).thenReturn(Optional.of(newArrayList(new NavEnhet("1111"), new NavEnhet("2222"))));
-        assertThat(new ByEnhetStrategy(axsysService).isEnabled(Map.of(PARAM, "1234"), unleashContext)).isEqualTo(false);
+        assertThat(new ByEnhetStrategy(axsysService).isEnabled(Map.of(PARAM, "1234"), unleashContext)).isFalse();
     }
     
     @Test
     public void skal_være_enablet_hvis_bruker_har_definert_enhet() {
         when(axsysService.hentEnheterVeilederHarTilgangTil(any())).thenReturn(Optional.of(newArrayList(new NavEnhet("1234"))));
-        assertThat(new ByEnhetStrategy(axsysService).isEnabled(Map.of(PARAM, "1234"), unleashContext)).isEqualTo(true);
+        assertThat(new ByEnhetStrategy(axsysService).isEnabled(Map.of(PARAM, "1234"), unleashContext)).isTrue();
     }
 
     @Test
     public void skal_være_enablet_hvis_en_av_brukers_enheter_er_i_listen() {
         when(axsysService.hentEnheterVeilederHarTilgangTil(any())).thenReturn(Optional.of(newArrayList(new NavEnhet("1111"), new NavEnhet("1234"))));
-        assertThat(new ByEnhetStrategy(axsysService).isEnabled(Map.of(PARAM, "1234,5678"), unleashContext)).isEqualTo(true);
+        assertThat(new ByEnhetStrategy(axsysService).isEnabled(Map.of(PARAM, "1234,5678"), unleashContext)).isTrue();
     }
     
 }

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/featuretoggles/ByEnhetStrategyTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/featuretoggles/ByEnhetStrategyTest.java
@@ -1,0 +1,63 @@
+package no.nav.tag.tiltaksgjennomforing.featuretoggles;
+
+import org.junit.Test;
+
+import no.finn.unleash.UnleashContext;
+import no.nav.tag.tiltaksgjennomforing.autorisasjon.pilottilgang.NavEnhet;
+import no.nav.tag.tiltaksgjennomforing.autorisasjon.pilottilgang.AxsysService;
+
+import java.util.Map;
+
+import static com.google.common.collect.Lists.newArrayList;
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.singletonMap;
+import static no.nav.tag.tiltaksgjennomforing.featuretoggles.ByEnhetStrategy.PARAM;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+public class ByEnhetStrategyTest {
+
+    private AxsysService axsysService = mock(AxsysService.class);
+    private UnleashContext unleashContext = UnleashContext.builder().userId("brukerId").build();
+
+    @Test
+    public void skal_være_disablet_hvis_det_toggle_evalueres_uten_kontekst() {
+        assertThat(new ByEnhetStrategy(axsysService).isEnabled(Map.of(PARAM, "1234"))).isEqualTo(false);
+    }
+    
+    @Test
+    public void skal_være_disablet_hvis_det_ikke_finnes_bruker_i_konteksten() {
+        assertThat(new ByEnhetStrategy(axsysService).isEnabled(Map.of(PARAM, "1234"), UnleashContext.builder().build())).isEqualTo(false);
+    }
+    
+    @Test
+    public void skal_være_disablet_hvis_det_ikke_finnes_definerte_enheter() {
+        assertThat(new ByEnhetStrategy(axsysService).isEnabled(emptyMap(), unleashContext)).isEqualTo(false);
+        assertThat(new ByEnhetStrategy(axsysService).isEnabled(singletonMap(PARAM, null), unleashContext)).isEqualTo(false); //Map.of() tåler ikke null
+        assertThat(new ByEnhetStrategy(axsysService).isEnabled(Map.of(PARAM, ""), unleashContext)).isEqualTo(false);
+    }
+
+    @Test
+    public void skal_være_disablet_hvis_bruker_ikke_har_definerte_enheter() {
+        assertThat(new ByEnhetStrategy(axsysService).isEnabled(Map.of(PARAM, "1234"), unleashContext)).isEqualTo(false);
+    }
+
+    @Test
+    public void skal_være_disablet_hvis_bruker_har_definerte_enheter_men_ingen_er_i_listen() {
+        when(axsysService.hentEnheterVeilederHarTilgangTil(any())).thenReturn(newArrayList(new NavEnhet("1111"), new NavEnhet("2222")));
+        assertThat(new ByEnhetStrategy(axsysService).isEnabled(Map.of(PARAM, "1234"), unleashContext)).isEqualTo(false);
+    }
+    
+    @Test
+    public void skal_være_enablet_hvis_bruker_har_definert_enhet() {
+        when(axsysService.hentEnheterVeilederHarTilgangTil(any())).thenReturn(newArrayList(new NavEnhet("1234")));
+        assertThat(new ByEnhetStrategy(axsysService).isEnabled(Map.of(PARAM, "1234"), unleashContext)).isEqualTo(true);
+    }
+
+    @Test
+    public void skal_være_enablet_hvis_en_av_brukers_enheter_er_i_listen() {
+        when(axsysService.hentEnheterVeilederHarTilgangTil(any())).thenReturn(newArrayList(new NavEnhet("1111"), new NavEnhet("1234")));
+        assertThat(new ByEnhetStrategy(axsysService).isEnabled(Map.of(PARAM, "1234,5678"), unleashContext)).isEqualTo(true);
+    }
+    
+}


### PR DESCRIPTION
Støtte for å bruke ByEnhet-strategien til unleash. 
Denne fungerer slik at en toggle blir `true` dersom innlogget veileder har tilgang til minst ett av kontorene som er definert i `byEnhet`-strategi på togglen i unleash. Veilederkontor blir slått opp gjennom axsysservice.

Har også lagt inn støtte for å benytte unleash til å styre pilottilgangen. Det er to toggler som styrer dette:
- _tag.tiltak.bruk.unleash.for.pilottilgang_ - angir om tilgangen skal styres gjennom unleash (hvis true) eller gjennom vault som tidligere (hvis false)
- _tag.tiltak.pilottilgang_ - om pilot er enablet eller ikke (brukes kun hvis togglen over er true). Pr nå inneholder denne alle brukere og nav-enheter som var lagt inn for preprod og prod i vault