### PR TITLE
TAG-512 Krever at selvbetjeningsbrukere er på nivå 4

### DIFF
--- a/src/main/java/no/nav/security/oidc/test/support/JwtTokenGenerator.java
+++ b/src/main/java/no/nav/security/oidc/test/support/JwtTokenGenerator.java
@@ -15,7 +15,7 @@ import java.util.concurrent.TimeUnit;
 
 public class JwtTokenGenerator {
 
-    private static final String ACR = "Level4";
+    public static final String ACR_LEVEL_4 = "Level4";
     public static final long EXPIRY = 60 * 60 * 3600;
 
     private JwtTokenGenerator() {
@@ -26,11 +26,11 @@ public class JwtTokenGenerator {
     }
 
     public static SignedJWT createSignedJWT(String subject, String issuer, String audience) {
-        return createSignedJWT(subject, EXPIRY, new HashMap<>(), issuer, audience);
+        return createSignedJWT(subject, EXPIRY, new HashMap<>(), issuer, audience, ACR_LEVEL_4);
     }
 
-    public static SignedJWT createSignedJWT(String subject, long expiryInMinutes, Map<String, Object> claims, String issuer, String audience) {
-        JWTClaimsSet claimsSet = buildClaimSet(subject, issuer, audience, ACR, TimeUnit.MINUTES.toMillis(expiryInMinutes), claims);
+    public static SignedJWT createSignedJWT(String subject, long expiryInMinutes, Map<String, Object> claims, String issuer, String audience, String acrLevel) {
+        JWTClaimsSet claimsSet = buildClaimSet(subject, issuer, audience, acrLevel, TimeUnit.MINUTES.toMillis(expiryInMinutes), claims);
         return createSignedJWT(JwkGenerator.getDefaultRSAKey(), claimsSet);
     }
 

--- a/src/main/java/no/nav/security/oidc/test/support/spring/TokenGeneratorController.java
+++ b/src/main/java/no/nav/security/oidc/test/support/spring/TokenGeneratorController.java
@@ -11,6 +11,9 @@ import org.springframework.web.bind.annotation.*;
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+
+import static no.nav.security.oidc.test.support.JwtTokenGenerator.ACR_LEVEL_4;
+
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.util.Collections;
@@ -32,10 +35,11 @@ public class TokenGeneratorController {
             HttpServletResponse response,
             Map<String, Object> claims,
             String issuer,
-            String audience
+            String audience, 
+            String acrLevel
     ) throws IOException {
         long expiryTime = expiry != null ? Long.parseLong(expiry) : JwtTokenGenerator.EXPIRY;
-        SignedJWT token = JwtTokenGenerator.createSignedJWT(subject, expiryTime, claims, issuer, audience);
+        SignedJWT token = JwtTokenGenerator.createSignedJWT(subject, expiryTime, claims, issuer, audience, acrLevel);
         Cookie cookie = new Cookie(cookieName, token.serialize());
         cookie.setPath("/");
         response.addCookie(cookie);
@@ -79,10 +83,11 @@ public class TokenGeneratorController {
     @GetMapping("/selvbetjening-login")
     public void addSelvbetjeningCookie(@RequestHeader(value = "selvbetjening-id", defaultValue = "00000000000") String subject,
                                        @RequestParam(value = "cookiename", defaultValue = SELVBETJENING_IDTOKEN) String cookieName,
+                                       @RequestParam(value = "acr-level", defaultValue = ACR_LEVEL_4) String acrLevel,
                                        @RequestParam(value = "redirect", required = false) String redirect,
                                        @RequestParam(value = "expiry", required = false) String expiry,
                                        HttpServletResponse response) throws IOException {
-        bakeCookie(subject, cookieName, redirect, expiry, response, new HashMap<>(), "selvbetjening", "aud-selvbetjening");
+        bakeCookie(subject, cookieName, redirect, expiry, response, new HashMap<>(), "selvbetjening", "aud-selvbetjening", acrLevel);
     }
 
     @Unprotected
@@ -94,7 +99,7 @@ public class TokenGeneratorController {
                              @RequestParam(value = "expiry", required = false) String expiry,
                              HttpServletResponse response
     ) throws IOException {
-        bakeCookie(subject, cookieName, redirect, expiry, response, Collections.singletonMap("NAVident", navIdent), "isso", "aud-isso");
+        bakeCookie(subject, cookieName, redirect, expiry, response, Collections.singletonMap("NAVident", navIdent), "isso", "aud-isso", null);
     }
 
     @Unprotected

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/TokenUtils.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/TokenUtils.java
@@ -17,6 +17,9 @@ import java.util.Optional;
 @RequiredArgsConstructor
 public class TokenUtils {
         
+    private static final String ACR = "acr";
+    private static final String LEVEL4 = "Level4";
+
     static enum Issuer {
         
         ISSUER_ISSO("isso"),
@@ -43,17 +46,21 @@ public class TokenUtils {
     private final OIDCRequestContextHolder contextHolder;
 
     public Optional<BrukerOgIssuer> hentBrukerOgIssuer() {
-        return hentClaim(ISSUER_SELVBETJENING.issuerName, "sub").map(sub -> new BrukerOgIssuer(ISSUER_SELVBETJENING, sub))
-                .or(() -> hentClaim(ISSUER_ISSO.issuerName, "NAVident").map(sub -> new BrukerOgIssuer(ISSUER_ISSO, sub)))
-                .or(() -> hentClaim(ISSUER_SYSTEM.issuerName, "sub").map(sub -> new BrukerOgIssuer(ISSUER_SYSTEM, sub)));
+        return hentClaim(ISSUER_SELVBETJENING, "sub").map(sub -> new BrukerOgIssuer(ISSUER_SELVBETJENING, sub))
+                .or(() -> hentClaim(ISSUER_ISSO, "NAVident").map(sub -> new BrukerOgIssuer(ISSUER_ISSO, sub)))
+                .or(() -> hentClaim(ISSUER_SYSTEM, "sub").map(sub -> new BrukerOgIssuer(ISSUER_SYSTEM, sub)));
     }
 
-    private Optional<String> hentClaim(String issuer, String claim) {
-        return hentClaimSet(issuer).map(jwtClaimsSet -> String.valueOf(jwtClaimsSet.getClaim(claim)));
+    private Optional<String> hentClaim(Issuer issuer, String claim) {
+        return hentClaimSet(issuer).filter(jwtClaimsSet -> innloggingsNivaOK(issuer, jwtClaimsSet)).map(jwtClaimsSet -> String.valueOf(jwtClaimsSet.getClaim(claim)));
     }
 
-    private Optional<JWTClaimsSet> hentClaimSet(String issuer) {
-        return Optional.ofNullable(contextHolder.getOIDCValidationContext().getClaims(issuer))
+    private boolean innloggingsNivaOK(Issuer issuer, JWTClaimsSet jwtClaimsSet) {
+        return issuer != ISSUER_SELVBETJENING || LEVEL4.equals(jwtClaimsSet.getClaim(ACR));
+    }
+
+    private Optional<JWTClaimsSet> hentClaimSet(Issuer issuer) {
+        return Optional.ofNullable(contextHolder.getOIDCValidationContext().getClaims(issuer.issuerName))
                 .map(claims -> claims.getClaimSet());
     }
 


### PR DESCRIPTION
Enkel, men kanskje litt lite eksplisitt håndtering av kravet om innloggingsnivå 4 for sluttbrukere.
I stedet for å bruke `@ProtectedWithClaims` på controlleren har jeg lagt det inn i TokenUtils, som ikke vil "finne" en innlogget selvbetjeningsbruker med mindre det finnes et _acr-claim_ som er _Level4_