### PR TITLE
Deler opp tilgang for kontor vs. tilgang for ident for å kunne logge riktig

### DIFF
--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/pilottilgang/TilgangUnderPilotering.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/pilottilgang/TilgangUnderPilotering.java
@@ -14,8 +14,9 @@ import static java.util.Collections.disjoint;
 @Component
 public class TilgangUnderPilotering {
 
-    static final String TAG_TILTAK_PILOTTILGANG = "tag.tiltak.pilottilgang";
-    static final String TAG_TILTAK_BRUK_UNLEASH_FOR_PILOTTILGANG = "tag.tiltak.bruk.unleash.for.pilottilgang";
+    public static final String TAG_TILTAK_PILOTTILGANG_IDENT = "tag.tiltak.pilottilgang.ident";
+    public static final String TAG_TILTAK_PILOTTILGANG_KONTOR = "tag.tiltak.pilottilgang.kontor";
+    public static final String TAG_TILTAK_BRUK_UNLEASH_FOR_PILOTTILGANG = "tag.tiltak.bruk.unleash.for.pilottilgang";
 
     private final PilotProperties pilotProperties;
     private final AxsysService axsysService;
@@ -29,7 +30,7 @@ public class TilgangUnderPilotering {
     }
 
     private boolean sjekkPilotTilgangMedUnleash() {
-        return featureToggleService.isEnabled(TAG_TILTAK_PILOTTILGANG);
+        return featureToggleService.isEnabled(TAG_TILTAK_PILOTTILGANG_IDENT) || featureToggleService.isEnabled(TAG_TILTAK_PILOTTILGANG_KONTOR);
     }
 
     private boolean sjekkPilottilgangMedVault(NavIdent ident) {

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/metrikker/MetrikkRegistrering.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/metrikker/MetrikkRegistrering.java
@@ -9,8 +9,10 @@ import no.nav.tag.tiltaksgjennomforing.avtale.Avtalerolle;
 import no.nav.tag.tiltaksgjennomforing.avtale.Identifikator;
 import no.nav.tag.tiltaksgjennomforing.avtale.Tiltaktype;
 import no.nav.tag.tiltaksgjennomforing.avtale.events.*;
+import no.nav.tag.tiltaksgjennomforing.featuretoggles.FeatureToggleService;
 import no.nav.tag.tiltaksgjennomforing.varsel.SmsVarselRepository;
 import no.nav.tag.tiltaksgjennomforing.autorisasjon.pilottilgang.PilotProperties;
+import no.nav.tag.tiltaksgjennomforing.autorisasjon.pilottilgang.TilgangUnderPilotering;
 import no.nav.tag.tiltaksgjennomforing.varsel.events.SmsVarselResultatMottatt;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
@@ -24,6 +26,7 @@ public class MetrikkRegistrering {
     private final MeterRegistry meterRegistry;
     private final PilotProperties pilotProperties;
     private final SmsVarselRepository smsVarselRepository;
+    private final FeatureToggleService featureToggleService;
 
     @PostConstruct
     public void init() {
@@ -52,7 +55,9 @@ public class MetrikkRegistrering {
     }
 
     private boolean pilotFylke(Identifikator utfortAv) {
-        return !pilotProperties.getIdenter().contains(utfortAv);
+        return featureToggleService.isEnabled(TilgangUnderPilotering.TAG_TILTAK_BRUK_UNLEASH_FOR_PILOTTILGANG)
+                ? featureToggleService.isEnabled(TilgangUnderPilotering.TAG_TILTAK_PILOTTILGANG_KONTOR)
+                : !pilotProperties.getIdenter().contains(utfortAv);
     }
 
     @EventListener

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/pilottilgang/TilgangUnderPiloteringTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/pilottilgang/TilgangUnderPiloteringTest.java
@@ -70,16 +70,22 @@ public class TilgangUnderPiloteringTest {
     }
     
     @Test
-    public void sjekkTilgang_enablet_i_unleash_skal_gi_tilgang() {
+    public void sjekkTilgang_enablet_i_unleash_skal_gi_tilgang_for_ident() {
         when(featureToggleService.isEnabled(TilgangUnderPilotering.TAG_TILTAK_BRUK_UNLEASH_FOR_PILOTTILGANG)).thenReturn(true);
-        when(featureToggleService.isEnabled(TilgangUnderPilotering.TAG_TILTAK_PILOTTILGANG)).thenReturn(true);
+        when(featureToggleService.isEnabled(TilgangUnderPilotering.TAG_TILTAK_PILOTTILGANG_IDENT)).thenReturn(true);
+        tilgangUnderPilotering.sjekkTilgang(new NavIdent("Q000111"));
+    }
+    
+    @Test
+    public void sjekkTilgang_enablet_i_unleash_skal_gi_tilgang_for_kontor() {
+        when(featureToggleService.isEnabled(TilgangUnderPilotering.TAG_TILTAK_BRUK_UNLEASH_FOR_PILOTTILGANG)).thenReturn(true);
+        when(featureToggleService.isEnabled(TilgangUnderPilotering.TAG_TILTAK_PILOTTILGANG_KONTOR)).thenReturn(true);
         tilgangUnderPilotering.sjekkTilgang(new NavIdent("Q000111"));
     }
     
     @Test(expected = TilgangskontrollException.class)
     public void sjekkTilgang_enablet_i_unleash_skal_feile() {
         when(featureToggleService.isEnabled(TilgangUnderPilotering.TAG_TILTAK_BRUK_UNLEASH_FOR_PILOTTILGANG)).thenReturn(true);
-        when(featureToggleService.isEnabled(TilgangUnderPilotering.TAG_TILTAK_PILOTTILGANG)).thenReturn(false);
         tilgangUnderPilotering.sjekkTilgang(new NavIdent("Q000111"));
     }
 }

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/metrikker/MetrikkRegistreringTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/metrikker/MetrikkRegistreringTest.java
@@ -4,9 +4,12 @@ import io.micrometer.core.instrument.MeterRegistry;
 import no.nav.tag.tiltaksgjennomforing.TestData;
 import no.nav.tag.tiltaksgjennomforing.avtale.NavIdent;
 import no.nav.tag.tiltaksgjennomforing.avtale.events.AvtaleOpprettet;
+import no.nav.tag.tiltaksgjennomforing.featuretoggles.FeatureToggleService;
 import no.nav.tag.tiltaksgjennomforing.metrikker.MetrikkRegistrering;
 import no.nav.tag.tiltaksgjennomforing.varsel.SmsVarselRepository;
 import no.nav.tag.tiltaksgjennomforing.autorisasjon.pilottilgang.PilotProperties;
+import no.nav.tag.tiltaksgjennomforing.autorisasjon.pilottilgang.TilgangUnderPilotering;
+
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -16,31 +19,49 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
-import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.*;
 
 public class MetrikkRegistreringTest {
 
     @Rule
     public OutputCapture capture = new OutputCapture();
     private PilotProperties pilotProperties;
+    private FeatureToggleService featureToggleService = mock(FeatureToggleService.class);
     private MetrikkRegistrering metrikkRegistrering;
 
     @Before
     public void setUp() throws Exception {
         pilotProperties = new PilotProperties();
         pilotProperties.setIdenter(List.of(new NavIdent("X123456")));
-        metrikkRegistrering = new MetrikkRegistrering(mock(MeterRegistry.class, RETURNS_DEEP_STUBS), pilotProperties, mock(SmsVarselRepository.class));
+        metrikkRegistrering = new MetrikkRegistrering(mock(MeterRegistry.class, RETURNS_DEEP_STUBS), pilotProperties, mock(SmsVarselRepository.class), featureToggleService);
     }
 
     @Test
-    public void opprettAvtale__skal_logge_pilotfylke() {
+    public void opprettAvtale__pilottilgang_gjennom_vault__skal_logge_pilotfylke() {
         metrikkRegistrering.avtaleOpprettet(new AvtaleOpprettet(TestData.enAvtale(), new NavIdent("X123459")));
         assertThat(capture.toString()).contains("PilotFylke=true");
     }
 
     @Test
-    public void opprettAvtale__skal_ikke_logge_pilotfylke() {
+    public void opprettAvtale__pilottilgang_gjennom_vault__skal_ikke_logge_pilotfylke() {
         metrikkRegistrering.avtaleOpprettet(new AvtaleOpprettet(TestData.enAvtale(), new NavIdent("X123456")));
         assertThat(capture.toString()).contains("PilotFylke=false");
     }
+    
+    @Test
+    public void opprettAvtale__pilottilgang_gjennom_unleash__skal_logge_pilotfylke() {
+        when(featureToggleService.isEnabled(TilgangUnderPilotering.TAG_TILTAK_BRUK_UNLEASH_FOR_PILOTTILGANG)).thenReturn(true);
+        when(featureToggleService.isEnabled(TilgangUnderPilotering.TAG_TILTAK_PILOTTILGANG_KONTOR)).thenReturn(true);
+        metrikkRegistrering.avtaleOpprettet(new AvtaleOpprettet(TestData.enAvtale(), new NavIdent("X123459")));
+        assertThat(capture.toString()).contains("PilotFylke=true");
+    }
+
+    @Test
+    public void opprettAvtale__pilottilgang_gjennom_unleash__skal_ikke_logge_pilotfylke() {
+        when(featureToggleService.isEnabled(TilgangUnderPilotering.TAG_TILTAK_BRUK_UNLEASH_FOR_PILOTTILGANG)).thenReturn(true);
+        when(featureToggleService.isEnabled(TilgangUnderPilotering.TAG_TILTAK_PILOTTILGANG_KONTOR)).thenReturn(false);
+        metrikkRegistrering.avtaleOpprettet(new AvtaleOpprettet(TestData.enAvtale(), new NavIdent("X123456")));
+        assertThat(capture.toString()).contains("PilotFylke=false");
+    }
+
 }


### PR DESCRIPTION
Siden metrikk-logging logger ulikt dersom brukeren får pilottilgang pga. enkelt-ident vs brukere som får tilgang pga. kontor-tilgang, måtte jeg endre litt på hvordan dette settes opp. I stedet for én toggle som gir begge tilganger, brukes én toggle for ident-tilgang og en annen for kontor-tilgang - dermed blir det mulig å vite hva slags type tilgang brukeren får. Dette forutsetter at vi ikke blander sammen ulike strategier på togglene i unleash :)