### PR TITLE
Sørger for at Unleash tar hensyn til ByEnhetStrategy

### DIFF
--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/featuretoggles/FeatureToggleConfig.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/featuretoggles/FeatureToggleConfig.java
@@ -18,7 +18,8 @@ public class FeatureToggleConfig {
     @Bean
     public Unleash initializeUnleash(@Value(
             "${tiltaksgjennomforing.unleash.unleash-uri}") String unleashUrl, 
-            ByEnvironmentStrategy byEnvironmentStrategy) {
+            ByEnvironmentStrategy byEnvironmentStrategy,
+            ByEnhetStrategy byEnhetStrategy) {
         UnleashConfig config = UnleashConfig.builder()
                 .appName(APP_NAME)
                 .instanceId(APP_NAME + "-" + byEnvironmentStrategy.getEnvironment())
@@ -27,7 +28,8 @@ public class FeatureToggleConfig {
 
         return new DefaultUnleash(
                 config,
-                byEnvironmentStrategy
+                byEnvironmentStrategy,
+                byEnhetStrategy
         );
     }
 }


### PR DESCRIPTION
Hadde glemt å faktisk ta i bruk den nye _ByEnhetStrategy_, så toggler som benyttet denne ble aldri evaluert riktig.