### PR TITLE
System-tilgangsstyring

### DIFF
--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/InnloggingService.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/InnloggingService.java
@@ -38,7 +38,6 @@ public class InnloggingService {
     }
 
     public void validerSystembruker() {
-        TokenUtils.BrukerOgIssuer issuer =  tokenUtils.hentBrukerOgIssuer().get();
         tokenUtils.hentBrukerOgIssuer()
             .filter(t -> (Issuer.ISSUER_SYSTEM == t.getIssuer() && systembrukerProperties.getId().equals(t.getBrukerIdent())))
             .orElseThrow(() -> new TilgangskontrollException("Systemet har ikke tilgang til tjenesten"));

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/InnloggingService.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/InnloggingService.java
@@ -1,7 +1,6 @@
 package no.nav.tag.tiltaksgjennomforing.autorisasjon;
 
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import no.nav.tag.tiltaksgjennomforing.avtale.Fnr;
 import no.nav.tag.tiltaksgjennomforing.avtale.NavIdent;
 import no.nav.tag.tiltaksgjennomforing.exceptions.TilgangskontrollException;
@@ -14,7 +13,6 @@ import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
-@Slf4j
 public class InnloggingService {
 
     private final SystembrukerProperties systembrukerProperties;

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/TokenUtils.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/TokenUtils.java
@@ -43,9 +43,9 @@ public class TokenUtils {
     private final OIDCRequestContextHolder contextHolder;
 
     public Optional<BrukerOgIssuer> hentBrukerOgIssuer() {
-        return hentClaim(ISSUER_SELVBETJENING.issuerName, "sub").map(sub -> new BrukerOgIssuer(ISSUER_SELVBETJENING, sub))
-                .or(() -> hentClaim(ISSUER_ISSO.issuerName, "NAVident").map(sub -> new BrukerOgIssuer(ISSUER_ISSO, sub)))
-                .or(() -> hentClaim(ISSUER_SYSTEM.issuerName, "sub").map(sub -> new BrukerOgIssuer(ISSUER_SYSTEM, sub)));
+        return hentClaim(ISSUER_SYSTEM.issuerName, "sub").map(sub -> new BrukerOgIssuer(ISSUER_SYSTEM, sub))
+                .or(() -> hentClaim(ISSUER_SELVBETJENING.issuerName, "sub").map(sub -> new BrukerOgIssuer(ISSUER_SELVBETJENING, sub)))
+                .or(() -> hentClaim(ISSUER_ISSO.issuerName, "NAVident").map(sub -> new BrukerOgIssuer(ISSUER_ISSO, sub)));
     }
 
     private Optional<String> hentClaim(String issuer, String claim) {

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/journalfoering/InternalAvtaleController.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/journalfoering/InternalAvtaleController.java
@@ -2,7 +2,7 @@ package no.nav.tag.tiltaksgjennomforing.journalfoering;
 
 import io.micrometer.core.annotation.Timed;
 import lombok.RequiredArgsConstructor;
-import no.nav.security.oidc.api.Unprotected;
+import no.nav.security.oidc.api.ProtectedWithClaims;
 import no.nav.tag.tiltaksgjennomforing.autorisasjon.InnloggingService;
 import no.nav.tag.tiltaksgjennomforing.avtale.Avtale;
 import no.nav.tag.tiltaksgjennomforing.avtale.AvtaleRepository;
@@ -19,7 +19,7 @@ import java.util.stream.Collectors;
 @RequestMapping("/internal/avtaler")
 @Timed
 @RequiredArgsConstructor
-@Unprotected
+@ProtectedWithClaims(issuer="system")
 public class InternalAvtaleController {
 
     private final AvtaleRepository avtaleRepository;

--- a/src/main/resources/config/application-dev.yaml
+++ b/src/main/resources/config/application-dev.yaml
@@ -49,4 +49,4 @@ tiltaksgjennomforing:
     veilarbabac-uri: http://localhost:8090/veilarbabac
   consumer:
     system:
-      id: ${tiltaksgjennomforing.consumer.system}
+      id: testsystem


### PR DESCRIPTION
Fjernet en linje som ga 500-feil i stedet for 403 ved feil servicebruker.
Går tilbake til å bruke `@ProtectedWithClaims`-annotasjonen på controller for å sikre at vi har en systembruker. Det ser ut som dette fungerer som det skal, men vil likevel gi 403 dersom man _både_ har en systembruker og et brukertoken (som cookie) på requesten. Dette er fordi `TokenUtils` kun returnerer én bruker, og vil ta servicebruker til slutt. ~~Vi kan vurdere å endre på rekkefølgen her, slik at systembrukere hentes først, eller evt. håndtere bedre at det er flere tokens samtidig.~~ Har endret dette i 5aaa47d, slik at systembruker velges først dersom den eksisterer på requesten

Å bruke `@UnProtected` vil også fungere så lenge vi alltid sjekker systembruker eksplisitt i etterkant, men alle tilfeller av ugyldig eller fraværende token vil da gi 403. med `@ProtectedWithClaims` vil api-et gi 401 dersom det ikke er et systembruker-token på requesten, og 403 dersom det er _feil_ systembruker (eller dersom det også finnes et sluttbruker-token)