### PR TITLE
Øker maksimalantallet connections for CP

### DIFF
--- a/src/main/resources/config/application-preprod.yaml
+++ b/src/main/resources/config/application-preprod.yaml
@@ -32,7 +32,7 @@ tiltaksgjennomforing:
     database-url: ${spring.datasource.url}
     vault-sti: postgresql/preprod-fss
     minimum-idle: 1
-    maximum-pool-size: 2
+    maximum-pool-size: 8
     max-lifetime: 300000
   altinn-tilgangsstyring:
     uri: https://api-gw-q1.adeo.no/ekstern/altinn/api/serviceowner/reportees

--- a/src/main/resources/config/application-prod.yaml
+++ b/src/main/resources/config/application-prod.yaml
@@ -32,7 +32,7 @@ tiltaksgjennomforing:
     database-url: ${spring.datasource.url}
     vault-sti: postgresql/prod-fss
     minimum-idle: 1
-    maximum-pool-size: 2
+    maximum-pool-size: 8
     max-lifetime: 300000
   altinn-tilgangsstyring:
     uri: https://api-gw.adeo.no/ekstern/altinn/api/serviceowner/reportees


### PR DESCRIPTION
Samme endring er testet runtime i preprod og prod tidligere vha. miljøvariable. Det har løst ytelsesproblemene vi har sett. Legger denne konfigurasjonen nå i koden.

Ved idle bruker vi som før kun 1 connection, og det skal derfor ikke være sånn at vi okkuperer flere connections enn nødvendig på databaseclusteret.