### PR TITLE
TAG-779 Hente avtaler for veileder

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -165,6 +165,9 @@
                 <configuration>
                     <source>11</source>
                     <target>11</target>
+                    <compilerArgs>
+                        <arg>-parameters</arg>
+                    </compilerArgs>
                     <annotationProcessorPaths>
                         <path>
                             <groupId>org.mapstruct</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -165,9 +165,6 @@
                 <configuration>
                     <source>11</source>
                     <target>11</target>
-                    <compilerArgs>
-                        <arg>-parameters</arg>
-                    </compilerArgs>
                     <annotationProcessorPaths>
                         <path>
                             <groupId>org.mapstruct</groupId>

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/InnloggetBruker.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/InnloggetBruker.java
@@ -1,5 +1,6 @@
 package no.nav.tag.tiltaksgjennomforing.autorisasjon;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 import no.nav.tag.tiltaksgjennomforing.avtale.Avtale;
 import no.nav.tag.tiltaksgjennomforing.avtale.Avtalepart;
@@ -23,7 +24,7 @@ public abstract class InnloggetBruker<T extends Identifikator> {
     }
 
     public abstract boolean harSkriveTilgang(Avtale avtale);
-    
+
     public void sjekkSkriveTilgang(Avtale avtale) {
         if (!harSkriveTilgang(avtale)) {
             throw new TilgangskontrollException("Har ikke tilgang til avtalen.");
@@ -33,4 +34,7 @@ public abstract class InnloggetBruker<T extends Identifikator> {
     public List<Identifikator> identifikatorer() {
         return List.of(identifikator);
     }
+
+    @JsonProperty("erNavAnsatt")
+    public abstract boolean erNavAnsatt();
 }

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/InnloggetNavAnsatt.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/InnloggetNavAnsatt.java
@@ -1,10 +1,10 @@
 package no.nav.tag.tiltaksgjennomforing.autorisasjon;
 
+import no.nav.tag.tiltaksgjennomforing.autorisasjon.veilarbabac.TilgangskontrollService;
 import no.nav.tag.tiltaksgjennomforing.avtale.Avtale;
 import no.nav.tag.tiltaksgjennomforing.avtale.NavIdent;
 import no.nav.tag.tiltaksgjennomforing.avtale.OpprettAvtale;
 import no.nav.tag.tiltaksgjennomforing.avtale.Veileder;
-import no.nav.tag.tiltaksgjennomforing.autorisasjon.veilarbabac.TilgangskontrollService;
 
 public class InnloggetNavAnsatt extends InnloggetBruker<NavIdent> {
 
@@ -25,7 +25,7 @@ public class InnloggetNavAnsatt extends InnloggetBruker<NavIdent> {
     }
 
     @Override
-    public boolean harLeseTilgang(Avtale avtale)  {
+    public boolean harLeseTilgang(Avtale avtale) {
         return tilgangskontrollService.harLesetilgangTilKandidat(this, avtale.getDeltakerFnr()).orElseGet(() -> harOpprettetAvtale(avtale));
     }
 
@@ -36,5 +36,9 @@ public class InnloggetNavAnsatt extends InnloggetBruker<NavIdent> {
     @Override
     public boolean harSkriveTilgang(Avtale avtale) {
         return tilgangskontrollService.harSkrivetilgangTilKandidat(this, avtale.getDeltakerFnr()).orElseGet(() -> harOpprettetAvtale(avtale));
+    }
+
+    public boolean erNavAnsatt() {
+        return true;
     }
 }

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/InnloggetSelvbetjeningBruker.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/InnloggetSelvbetjeningBruker.java
@@ -10,7 +10,7 @@ import java.util.stream.Collectors;
 
 @EqualsAndHashCode(callSuper = true)
 public class InnloggetSelvbetjeningBruker extends InnloggetBruker<Fnr> {
-    
+
     private final List<Organisasjon> organisasjoner;
 
     public InnloggetSelvbetjeningBruker(Fnr identifikator, List<Organisasjon> organisasjoner) {
@@ -30,12 +30,12 @@ public class InnloggetSelvbetjeningBruker extends InnloggetBruker<Fnr> {
     }
 
     @Override
-    public boolean harLeseTilgang(Avtale avtale)  {
+    public boolean harLeseTilgang(Avtale avtale) {
         return avtalepart(avtale) != null;
     }
 
     @Override
-    public boolean harSkriveTilgang(Avtale avtale)  {
+    public boolean harSkriveTilgang(Avtale avtale) {
         return avtalepart(avtale) != null;
     }
 
@@ -47,7 +47,14 @@ public class InnloggetSelvbetjeningBruker extends InnloggetBruker<Fnr> {
         return identifikatorer;
     }
 
+    @Override
+    public boolean erNavAnsatt() {
+        return false;
+    }
+
     private List<BedriftNr> arbeidsgiverIdentifikatorer() {
         return organisasjoner.stream().map(Organisasjon::getBedriftNr).collect(Collectors.toList());
     }
+
+
 }

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleController.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleController.java
@@ -2,7 +2,6 @@ package no.nav.tag.tiltaksgjennomforing.avtale;
 
 import io.micrometer.core.annotation.Timed;
 import lombok.RequiredArgsConstructor;
-import lombok.SneakyThrows;
 import no.nav.security.oidc.api.Protected;
 import no.nav.tag.tiltaksgjennomforing.autorisasjon.InnloggetBruker;
 import no.nav.tag.tiltaksgjennomforing.autorisasjon.InnloggetNavAnsatt;
@@ -45,7 +44,6 @@ public class AvtaleController {
     }
 
     @GetMapping
-    @SneakyThrows
     public Iterable<Avtale> hentAlleAvtalerInnloggetBrukerHarTilgangTil(AvtalePredicate queryParametre) {
         InnloggetBruker bruker = innloggingService.hentInnloggetBruker();
         return avtaleRepository.findAll().stream()

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleController.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleController.java
@@ -2,27 +2,24 @@ package no.nav.tag.tiltaksgjennomforing.avtale;
 
 import io.micrometer.core.annotation.Timed;
 import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
 import no.nav.security.oidc.api.Protected;
-import no.nav.tag.tiltaksgjennomforing.autorisasjon.InnloggingService;
-import no.nav.tag.tiltaksgjennomforing.autorisasjon.pilottilgang.TilgangUnderPilotering;
 import no.nav.tag.tiltaksgjennomforing.autorisasjon.InnloggetBruker;
 import no.nav.tag.tiltaksgjennomforing.autorisasjon.InnloggetNavAnsatt;
+import no.nav.tag.tiltaksgjennomforing.autorisasjon.InnloggingService;
+import no.nav.tag.tiltaksgjennomforing.autorisasjon.pilottilgang.TilgangUnderPilotering;
+import no.nav.tag.tiltaksgjennomforing.autorisasjon.veilarbabac.TilgangskontrollService;
 import no.nav.tag.tiltaksgjennomforing.exceptions.RessursFinnesIkkeException;
 import no.nav.tag.tiltaksgjennomforing.orgenhet.EregService;
-import no.nav.tag.tiltaksgjennomforing.autorisasjon.veilarbabac.TilgangskontrollService;
-
 import org.springframework.http.ResponseEntity;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.*;
 
 import java.net.URI;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.Comparator;
 import java.util.UUID;
 import java.util.stream.Collectors;
-import java.util.stream.StreamSupport;
 
-import static java.util.stream.Collectors.toList;
 import static no.nav.tag.tiltaksgjennomforing.utils.Utils.lagUri;
 
 @Protected
@@ -36,7 +33,7 @@ public class AvtaleController {
     private final InnloggingService innloggingService;
     private final EregService eregService;
     private final TilgangUnderPilotering tilgangUnderPilotering;
-    private final TilgangskontrollService tilgangskontrollService; 
+    private final TilgangskontrollService tilgangskontrollService;
 
     @GetMapping("/{avtaleId}")
     public ResponseEntity<Avtale> hent(@PathVariable("avtaleId") UUID id) {
@@ -48,35 +45,16 @@ public class AvtaleController {
     }
 
     @GetMapping
-    public Iterable<Avtale> hentAlleAvtalerInnloggetBrukerHarTilgangTil() {
+    @SneakyThrows
+    public Iterable<Avtale> hentAlleAvtalerInnloggetBrukerHarTilgangTil(AvtalePredicate queryParametre) {
         InnloggetBruker bruker = innloggingService.hentInnloggetBruker();
-        List<Avtale> avtaler = new ArrayList<>();
-        for (Avtale avtale : avtaleRepository.findAll()) {
-            if (bruker.harLeseTilgang(avtale)) {
-                avtaler.add(avtale);
-            }
-        }
-        return avtaler;
-    }
-    
-    @GetMapping(value = "/veileder/{veilederId}")
-    public Iterable<Avtale> hentAvtalerOpprettetAvVeileder(@PathVariable("veilederId") String veilederId) {
-        return hentAvtalerOpprettetAvVeileder(innloggingService.hentInnloggetBruker(), new NavIdent(veilederId));
+        return avtaleRepository.findAll().stream()
+                .filter(queryParametre)
+                .filter(bruker::harLeseTilgang)
+                .sorted(Comparator.nullsLast(Comparator.comparing(Avtale::getOpprettetTidspunkt).reversed()))
+                .collect(Collectors.toList());
     }
 
-    private Iterable<Avtale> hentAvtalerOpprettetAvVeileder(InnloggetBruker bruker, NavIdent navIdent) {
-        return StreamSupport.stream(avtaleRepository.findAll().spliterator(), false)
-            .filter(avtale -> avtale.getVeilederNavIdent().equals(navIdent))
-            .filter(avtale -> bruker.harLeseTilgang(avtale))
-            .collect(toList());
-    }
-
-    @GetMapping(value = "/veileder")
-    public Iterable<Avtale> hentAvtalerOpprettetAvInnloggetVeileder() {
-        InnloggetNavAnsatt InnloggetNavAnsatt = innloggingService.hentInnloggetNavAnsatt();
-        return hentAvtalerOpprettetAvVeileder(InnloggetNavAnsatt, InnloggetNavAnsatt.getIdentifikator());
-    }
-    
     @PostMapping
     @Transactional
     public ResponseEntity opprettAvtale(@RequestBody OpprettAvtale opprettAvtale) {
@@ -132,7 +110,7 @@ public class AvtaleController {
     public ResponseEntity godkjenn(@PathVariable("avtaleId") UUID avtaleId, @RequestHeader("If-Match") Integer versjon) {
         InnloggetBruker innloggetBruker = innloggingService.hentInnloggetBruker();
         Avtale avtale = avtaleRepository.findById(avtaleId).orElseThrow(RessursFinnesIkkeException::new);
-        innloggetBruker.sjekkSkriveTilgang(avtale); 
+        innloggetBruker.sjekkSkriveTilgang(avtale);
         Avtalepart avtalepart = innloggetBruker.avtalepart(avtale);
         avtalepart.godkjennAvtale(versjon);
         avtaleRepository.save(avtale);

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtalePredicate.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtalePredicate.java
@@ -1,0 +1,25 @@
+package no.nav.tag.tiltaksgjennomforing.avtale;
+
+import lombok.Data;
+import lombok.experimental.Accessors;
+
+import java.util.function.Predicate;
+
+@Data
+@Accessors(chain = true)
+public class AvtalePredicate implements Predicate<Avtale> {
+    private NavIdent veilederNavIdent;
+    private BedriftNr bedriftNr;
+    private Fnr deltakerFnr;
+
+    private static boolean erLiktHvisOppgitt(Object kriterie, Object avtaleVerdi) {
+        return kriterie == null || kriterie.equals(avtaleVerdi);
+    }
+
+    @Override
+    public boolean test(Avtale avtale) {
+        return erLiktHvisOppgitt(veilederNavIdent, avtale.getVeilederNavIdent())
+                && erLiktHvisOppgitt(bedriftNr, avtale.getBedriftNr())
+                && erLiktHvisOppgitt(deltakerFnr, avtale.getDeltakerFnr());
+    }
+}

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleRepository.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleRepository.java
@@ -13,5 +13,8 @@ public interface AvtaleRepository extends CrudRepository<Avtale, UUID> {
 
     @Override
     List<Avtale> findAllById(Iterable<UUID> idAvtaleTilJournalfoering);
+
+    @Override
+    List<Avtale> findAll();
 }
 

--- a/src/main/resources/db/testdata/V1000__testdata.sql
+++ b/src/main/resources/db/testdata/V1000__testdata.sql
@@ -4,7 +4,7 @@ insert into avtale (ID, OPPRETTET_TIDSPUNKT, VERSJON, DELTAKER_FORNAVN, DELTAKER
                     START_DATO, ARBEIDSTRENING_LENGDE, ARBEIDSTRENING_STILLINGPROSENT, GODKJENT_AV_DELTAKER,
                     GODKJENT_AV_ARBEIDSGIVER, GODKJENT_AV_VEILEDER)
 values ('6ae3be81-abcd-477e-a8f3-4a5eb5fe91e3', current_timestamp, 7, 'Didrik', 'Deltaker', '01093434109',
-        'Fiskebåten', '999999999', '29118923330', 'Filip', 'Fisker', '22334455', 'X123456', 'Vera', 'Veileder',
+        'Fiskebåten', '999999999', '29118923330', 'Filip', 'Fisker', '22334455', 'Z123456', 'Vera', 'Veileder',
         '33445566', 'Ingen', 'Ingen', '2019-03-25', 2, 100, null, null, null);
 
 insert into maal(ID, OPPRETTET_TIDSPUNKT, KATEGORI, BESKRIVELSE, AVTALE)

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleControllerTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleControllerTest.java
@@ -1,17 +1,16 @@
 package no.nav.tag.tiltaksgjennomforing.avtale;
 
-import no.nav.tag.tiltaksgjennomforing.*;
+import no.nav.tag.tiltaksgjennomforing.TestData;
 import no.nav.tag.tiltaksgjennomforing.autorisasjon.InnloggetBruker;
 import no.nav.tag.tiltaksgjennomforing.autorisasjon.InnloggetNavAnsatt;
 import no.nav.tag.tiltaksgjennomforing.autorisasjon.InnloggetSelvbetjeningBruker;
 import no.nav.tag.tiltaksgjennomforing.autorisasjon.InnloggingService;
-import no.nav.tag.tiltaksgjennomforing.orgenhet.Organisasjon;
+import no.nav.tag.tiltaksgjennomforing.autorisasjon.pilottilgang.TilgangUnderPilotering;
+import no.nav.tag.tiltaksgjennomforing.autorisasjon.veilarbabac.TilgangskontrollService;
 import no.nav.tag.tiltaksgjennomforing.exceptions.RessursFinnesIkkeException;
 import no.nav.tag.tiltaksgjennomforing.exceptions.TilgangskontrollException;
 import no.nav.tag.tiltaksgjennomforing.orgenhet.EregService;
-import no.nav.tag.tiltaksgjennomforing.autorisasjon.pilottilgang.TilgangUnderPilotering;
-import no.nav.tag.tiltaksgjennomforing.autorisasjon.veilarbabac.TilgangskontrollService;
-
+import no.nav.tag.tiltaksgjennomforing.orgenhet.Organisasjon;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
@@ -20,6 +19,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -43,7 +43,7 @@ public class AvtaleControllerTest {
 
     @Mock
     private TilgangskontrollService tilgangskontrollService;
-    
+
     @Mock
     private InnloggingService innloggingService;
 
@@ -56,6 +56,12 @@ public class AvtaleControllerTest {
             avtaler.add(avtale);
         }
         return avtaler;
+    }
+
+    private static OpprettAvtale lagOpprettAvtale() {
+        Fnr deltakerFnr = new Fnr("88888899999");
+        BedriftNr bedriftNr = new BedriftNr("12345678");
+        return new OpprettAvtale(deltakerFnr, bedriftNr);
     }
 
     @Test
@@ -86,48 +92,46 @@ public class AvtaleControllerTest {
 
     @Test
     public void hentAvtalerOpprettetAvVeileder_skal_returnere_avtaler_dersom_veileder_har_tilgang() {
-        String veilederSomSøkesEtter = "Z222222";
-        Avtale avtaleForVeilederSomSøkesEtter = Avtale.nyAvtale(lagOpprettAvtale(), new NavIdent(veilederSomSøkesEtter));
+        NavIdent veilederNavIdent = new NavIdent("Z222222");
+        Avtale avtaleForVeilederSomSøkesEtter = Avtale.nyAvtale(lagOpprettAvtale(), veilederNavIdent);
         Avtale avtaleForAnnenVeilder = Avtale.nyAvtale(lagOpprettAvtale(), new NavIdent("Z111111"));
         InnloggetNavAnsatt innloggetBruker = new InnloggetNavAnsatt(new NavIdent("Z333333"), tilgangskontrollService);
         vaerInnloggetSom(innloggetBruker);
         when(avtaleRepository.findAll()).thenReturn(asList(avtaleForVeilederSomSøkesEtter, avtaleForAnnenVeilder));
         when(tilgangskontrollService.harLesetilgangTilKandidat(eq(innloggetBruker), any(Fnr.class))).thenReturn(Optional.of(true));
-        Iterable<Avtale> avtaler = avtaleController.hentAvtalerOpprettetAvVeileder(veilederSomSøkesEtter);
-        assertThat(avtaler).contains(avtaleForVeilederSomSøkesEtter);
-        assertThat(avtaler).doesNotContain(avtaleForAnnenVeilder);
+        Iterable<Avtale> avtaler = avtaleController.hentAlleAvtalerInnloggetBrukerHarTilgangTil(new AvtalePredicate().setVeilederNavIdent(veilederNavIdent));
+        assertThat(avtaler)
+                .contains(avtaleForVeilederSomSøkesEtter)
+                .doesNotContain(avtaleForAnnenVeilder);
     }
-    
+
     @Test
     public void hentAvtalerOpprettetAvVeileder_skal_returnere_tom_liste_dersom_veileder_ikke_har_tilgang() {
-        String veilederSomSøkesEtter = "Z222222";
-        Avtale avtaleForVeilederSomSøkesEtter = Avtale.nyAvtale(lagOpprettAvtale(), new NavIdent(veilederSomSøkesEtter));
+        NavIdent veilederNavIdent = new NavIdent("Z222222");
+        Avtale avtaleForVeilederSomSøkesEtter = Avtale.nyAvtale(lagOpprettAvtale(), veilederNavIdent);
         InnloggetNavAnsatt innloggetBruker = new InnloggetNavAnsatt(new NavIdent("Z333333"), tilgangskontrollService);
         vaerInnloggetSom(innloggetBruker);
         when(avtaleRepository.findAll()).thenReturn(asList(avtaleForVeilederSomSøkesEtter));
         when(tilgangskontrollService.harLesetilgangTilKandidat(eq(innloggetBruker), any(Fnr.class))).thenReturn(Optional.of(false));
-        Iterable<Avtale> avtaler = avtaleController.hentAvtalerOpprettetAvVeileder(veilederSomSøkesEtter);
+        Iterable<Avtale> avtaler = avtaleController.hentAlleAvtalerInnloggetBrukerHarTilgangTil(new AvtalePredicate().setVeilederNavIdent(veilederNavIdent));
         assertThat(avtaler).doesNotContain(avtaleForVeilederSomSøkesEtter);
     }
-    
+
     @Test
     public void hentAvtalerOpprettetAvInnloggetVeileder_skal_returnere_avtaler_dersom_veileder_har_tilgang() {
         NavIdent innloggetVeileder = new NavIdent("Z333333");
         Avtale avtaleForInnloggetVeileder = Avtale.nyAvtale(lagOpprettAvtale(), innloggetVeileder);
+        avtaleForInnloggetVeileder.setOpprettetTidspunkt(LocalDateTime.now());
         Avtale avtaleForAnnenVeilder = Avtale.nyAvtale(lagOpprettAvtale(), new NavIdent("Z111111"));
+        avtaleForAnnenVeilder.setOpprettetTidspunkt(LocalDateTime.now());
         InnloggetNavAnsatt innloggetBruker = new InnloggetNavAnsatt(innloggetVeileder, tilgangskontrollService);
         vaerInnloggetSom(innloggetBruker);
         when(avtaleRepository.findAll()).thenReturn(asList(avtaleForInnloggetVeileder, avtaleForAnnenVeilder));
         when(tilgangskontrollService.harLesetilgangTilKandidat(eq(innloggetBruker), any(Fnr.class))).thenReturn(Optional.of(true));
-        Iterable<Avtale> avtaler = avtaleController.hentAvtalerOpprettetAvInnloggetVeileder();
-        assertThat(avtaler).contains(avtaleForInnloggetVeileder);
-        assertThat(avtaler).doesNotContain(avtaleForAnnenVeilder);
-    }
-    
-    private OpprettAvtale lagOpprettAvtale() {
-        Fnr deltakerFnr = new Fnr("88888899999");
-        BedriftNr bedriftNr = new BedriftNr("12345678");
-        return new OpprettAvtale(deltakerFnr, bedriftNr);
+        Iterable<Avtale> avtaler = avtaleController.hentAlleAvtalerInnloggetBrukerHarTilgangTil(new AvtalePredicate().setVeilederNavIdent(innloggetVeileder));
+        assertThat(avtaler)
+                .contains(avtaleForInnloggetVeileder)
+                .doesNotContain(avtaleForAnnenVeilder);
     }
 
     @Test(expected = TilgangskontrollException.class)
@@ -181,7 +185,9 @@ public class AvtaleControllerTest {
     @Test
     public void hentAlleAvtalerInnloggetBrukerHarTilgangTilSkalIkkeReturnereAvtalerManIkkeHarTilgangTil() {
         Avtale avtaleMedTilgang = TestData.enAvtale();
+        avtaleMedTilgang.setOpprettetTidspunkt(LocalDateTime.now());
         Avtale avtaleUtenTilgang = Avtale.nyAvtale(new OpprettAvtale(new Fnr("89898989898"), new BedriftNr("111222333")), new NavIdent("X643564"));
+        avtaleUtenTilgang.setOpprettetTidspunkt(LocalDateTime.now());
 
         InnloggetSelvbetjeningBruker selvbetjeningBruker = TestData.innloggetSelvbetjeningBrukerUtenOrganisasjon(TestData.enDeltaker(avtaleMedTilgang));
         vaerInnloggetSom(selvbetjeningBruker);
@@ -194,7 +200,7 @@ public class AvtaleControllerTest {
         when(avtaleRepository.findAll()).thenReturn(alleAvtaler);
 
         List<Avtale> hentedeAvtaler = new ArrayList<>();
-        for (Avtale avtale : avtaleController.hentAlleAvtalerInnloggetBrukerHarTilgangTil()) {
+        for (Avtale avtale : avtaleController.hentAlleAvtalerInnloggetBrukerHarTilgangTil(new AvtalePredicate())) {
             hentedeAvtaler.add(avtale);
         }
 
@@ -246,12 +252,12 @@ public class AvtaleControllerTest {
         doThrow(TilgangskontrollException.class).when(tilgangskontrollService).sjekkSkrivetilgangTilKandidat(enNavAnsatt, deltakerFnr);
         avtaleController.opprettAvtale(new OpprettAvtale(deltakerFnr, new BedriftNr("111222333")));
     }
-    
+
     private void vaerInnloggetSom(InnloggetBruker innloggetBruker) {
         when(innloggingService.hentInnloggetBruker()).thenReturn(innloggetBruker);
         if (innloggetBruker instanceof InnloggetNavAnsatt) {
             when(innloggingService.hentInnloggetNavAnsatt()).thenReturn((InnloggetNavAnsatt) innloggetBruker);
         }
     }
-    
+
 }

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtalePredicateTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtalePredicateTest.java
@@ -1,0 +1,48 @@
+package no.nav.tag.tiltaksgjennomforing.avtale;
+
+import no.nav.tag.tiltaksgjennomforing.TestData;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AvtalePredicateTest {
+    @Test
+    void veileder_nav_ident_oppgitt() {
+        Avtale avtale = TestData.enAvtale();
+        AvtalePredicate query = new AvtalePredicate();
+        query.setVeilederNavIdent(avtale.getVeilederNavIdent());
+        assertThat(query.test(avtale)).isTrue();
+    }
+
+    @Test
+    void deltaker_oppgitt() {
+        Avtale avtale = TestData.enAvtale();
+        AvtalePredicate query = new AvtalePredicate();
+        query.setDeltakerFnr(avtale.getDeltakerFnr());
+        assertThat(query.test(avtale)).isTrue();
+    }
+
+    @Test
+    void bedrift_oppgitt() {
+        Avtale avtale = TestData.enAvtale();
+        AvtalePredicate query = new AvtalePredicate();
+        query.setBedriftNr(avtale.getBedriftNr());
+        assertThat(query.test(avtale)).isTrue();
+    }
+
+    @Test
+    void kombinasjon_med_feil() {
+        Avtale avtale = TestData.enAvtale();
+        AvtalePredicate query = new AvtalePredicate();
+        query.setVeilederNavIdent(avtale.getVeilederNavIdent());
+        query.setBedriftNr(avtale.getBedriftNr());
+        query.setDeltakerFnr(new Fnr("66666666666"));
+        assertThat(query.test(avtale)).isFalse();
+    }
+
+    @Test
+    void ingenting_oppgitt() {
+        AvtalePredicate query = new AvtalePredicate();
+        assertThat(query.test(TestData.enAvtale())).isTrue();
+    }
+}


### PR DESCRIPTION
To nye operasjoner, en som henter avtaler for veileder ut fra url-parameter og en som henter avtaler for innlogget veileder ut fra innloggingstoken.