### PR TITLE
Oppdater til versjon 2.2.0 av Spring Boot

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.1.8.RELEASE</version>
+        <version>2.2.0.RELEASE</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 
@@ -150,7 +150,7 @@
             <version>3.2.8</version>
         </dependency>
 
-  </dependencies>
+    </dependencies>
 
     <build>
         <plugins>
@@ -181,33 +181,6 @@
             </plugin>
         </plugins>
     </build>
-
-    <profiles>
-        <profile>
-            <id>kopier-dependencies</id>
-            <activation>
-                <activeByDefault>false</activeByDefault>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-dependency-plugin</artifactId>
-                        <version>3.0.1</version>
-                        <executions>
-                            <execution>
-                                <id>copy-dependencies</id>
-                                <phase>package</phase>
-                                <goals>
-                                    <goal>copy-dependencies</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 
     <repositories>
         <repository>

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/infrastruktur/database/JdbcConvertersConfiguration.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/infrastruktur/database/JdbcConvertersConfiguration.java
@@ -1,25 +1,16 @@
 package no.nav.tag.tiltaksgjennomforing.infrastruktur.database;
 
 import no.nav.tag.tiltaksgjennomforing.avtale.Identifikator;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Primary;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.data.jdbc.core.convert.JdbcCustomConversions;
-import org.springframework.data.jdbc.repository.config.JdbcConfiguration;
-import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.data.jdbc.repository.config.AbstractJdbcConfiguration;
 import org.springframework.lang.Nullable;
 
-import javax.sql.DataSource;
 import java.util.Arrays;
 
 @Configuration
-public class JdbcConvertersConfiguration extends JdbcConfiguration {
-    @Bean
-    @Primary
-    public DataSourceTransactionManager dataSourceTransactionManager(DataSource dataSource) {
-        return new DataSourceTransactionManager(dataSource);
-    }
+public class JdbcConvertersConfiguration extends AbstractJdbcConfiguration {
 
     @Override
     public JdbcCustomConversions jdbcCustomConversions() {


### PR DESCRIPTION
I tillegg til tilpasninger til ny versjon av Spring Boot:
* Fjerner bean som ikke er nødvendig for å ha transaksjonsstøtte.
* Fjerner ubrukt maven-profil