### PR TITLE
Sist endret timestamp som optimistisk lås i stedet for versjonsnummer

### DIFF
--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/Arbeidstrening.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/Arbeidstrening.java
@@ -9,6 +9,7 @@ import javax.persistence.CascadeType;
 import javax.persistence.DiscriminatorValue;
 import javax.persistence.Entity;
 import javax.persistence.OneToMany;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -29,7 +30,7 @@ public class Arbeidstrening extends Avtale {
     }
 
     @Override
-    public void endreAvtale(Integer versjon, EndreAvtale nyAvtale, Avtalerolle utfortAv) {
+    public void endreAvtale(Instant sistEndret, EndreAvtale nyAvtale, Avtalerolle utfortAv) {
         maal.clear();
         maal.addAll(nyAvtale.getMaal());
         maal.forEach(m -> m.setAvtale(this));
@@ -38,7 +39,7 @@ public class Arbeidstrening extends Avtale {
         oppgaver.addAll(nyAvtale.getOppgaver());
         oppgaver.forEach(o -> o.setAvtale(this));
 
-        super.endreAvtale(versjon, nyAvtale, utfortAv);
+        super.endreAvtale(sistEndret, nyAvtale, utfortAv);
     }
 
     @Override

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/Avtalepart.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/Avtalepart.java
@@ -5,6 +5,7 @@ import lombok.Data;
 import no.nav.tag.tiltaksgjennomforing.exceptions.TilgangskontrollException;
 import no.nav.tag.tiltaksgjennomforing.exceptions.TiltaksgjennomforingException;
 
+import java.time.Instant;
 import java.time.format.DateTimeFormatter;
 
 @AllArgsConstructor
@@ -24,6 +25,7 @@ public abstract class Avtalepart<T extends Identifikator> {
     static String tekstHeaderAvtaleAvbrutt = "Tiltaket er avbrutt";
     static String tekstAvtaleAvbrutt = "Veilederen har bestemt at tiltaket og avtalen skal avbrytes.";
     static DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd.LLL.yyyy");
+
     abstract void godkjennForAvtalepart();
 
     abstract boolean kanEndreAvtale();
@@ -43,23 +45,22 @@ public abstract class Avtalepart<T extends Identifikator> {
 
     abstract void opphevGodkjenningerSomAvtalepart();
 
-    public void godkjennAvtale(Integer versjon) {
-        avtale.sjekkVersjon(versjon);
+    public void godkjennAvtale(Instant sistEndret) {
+        avtale.sjekkSistEndret(sistEndret);
         sjekkOmAvtaleKanGodkjennes();
         godkjennForAvtalepart();
     }
 
-
-    public void godkjennPaVegneAvDeltaker(GodkjentPaVegneGrunn paVegneAvGrunn, Integer versjon) {
-        avtale.sjekkVersjon(versjon);
+    public void godkjennPaVegneAvDeltaker(GodkjentPaVegneGrunn paVegneAvGrunn, Instant sistEndret) {
+        avtale.sjekkSistEndret(sistEndret);
         godkjennForVeilederOgDeltaker(paVegneAvGrunn);
     }
 
-    public void endreAvtale(Integer versjon, EndreAvtale endreAvtale) {
+    public void endreAvtale(Instant sistEndret, EndreAvtale endreAvtale) {
         if (!kanEndreAvtale()) {
             throw new TilgangskontrollException("Kan ikke endre avtale.");
         }
-        avtale.endreAvtale(versjon, endreAvtale, rolle());
+        avtale.endreAvtale(sistEndret, endreAvtale, rolle());
     }
 
     public void opphevGodkjenninger() {

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/Lonnstilskudd.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/Lonnstilskudd.java
@@ -6,6 +6,7 @@ import no.nav.tag.tiltaksgjennomforing.utils.Utils;
 
 import javax.persistence.Entity;
 import java.math.BigDecimal;
+import java.time.Instant;
 
 
 @NoArgsConstructor
@@ -25,7 +26,7 @@ public abstract class Lonnstilskudd extends Avtale {
     }
 
     @Override
-    public void endreAvtale(Integer versjon, EndreAvtale nyAvtale, Avtalerolle utfortAv) {
+    public void endreAvtale(Instant sistEndret, EndreAvtale nyAvtale, Avtalerolle utfortAv) {
         setArbeidsgiverKontonummer(nyAvtale.getArbeidsgiverKontonummer());
         setStillingtype(nyAvtale.getStillingtype());
         setStillingbeskrivelse(nyAvtale.getStillingbeskrivelse());
@@ -33,7 +34,7 @@ public abstract class Lonnstilskudd extends Avtale {
         setManedslonn(nyAvtale.getManedslonn());
         setFeriepengesats(nyAvtale.getFeriepengesats());
         setArbeidsgiveravgift(nyAvtale.getArbeidsgiveravgift());
-        super.endreAvtale(versjon, nyAvtale, utfortAv);
+        super.endreAvtale(sistEndret, nyAvtale, utfortAv);
     }
 
     @Override

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/Veileder.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/Veileder.java
@@ -2,6 +2,7 @@ package no.nav.tag.tiltaksgjennomforing.avtale;
 
 import no.nav.tag.tiltaksgjennomforing.exceptions.TiltaksgjennomforingException;
 
+import java.time.Instant;
 import java.time.LocalDate;
 
 public class Veileder extends Avtalepart<NavIdent> {
@@ -22,8 +23,8 @@ public class Veileder extends Avtalepart<NavIdent> {
         avtale.godkjennForVeileder(getIdentifikator());
     }
 
-    public void avbrytAvtale(Integer versjon) {
-        avtale.sjekkVersjon(versjon);
+    public void avbrytAvtale(Instant sistEndret) {
+        avtale.sjekkSistEndret(sistEndret);
         avtale.avbryt(this);
     }
 

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/journalfoering/AvtaleTilJournalfoering.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/journalfoering/AvtaleTilJournalfoering.java
@@ -20,7 +20,6 @@ public class AvtaleTilJournalfoering {
     private String veilederNavIdent;
 
     private LocalDate opprettet;
-    private Integer versjon;
     private String deltakerFornavn;
     private String deltakerEtternavn;
     private String deltakerTlf;

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/journalfoering/AvtaleTilJournalfoeringMapper.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/journalfoering/AvtaleTilJournalfoeringMapper.java
@@ -22,7 +22,6 @@ public class AvtaleTilJournalfoeringMapper {
         avtaleTilJournalfoering.setDeltakerFnr(identifikatorAsString(avtale.getDeltakerFnr()));
         avtaleTilJournalfoering.setBedriftNr(identifikatorAsString(avtale.getBedriftNr()));
         avtaleTilJournalfoering.setVeilederNavIdent(identifikatorAsString(avtale.getVeilederNavIdent()));
-        avtaleTilJournalfoering.setVersjon(avtale.getVersjon());
         avtaleTilJournalfoering.setDeltakerFornavn(avtale.getDeltakerFornavn());
         avtaleTilJournalfoering.setDeltakerEtternavn(avtale.getDeltakerEtternavn());
         avtaleTilJournalfoering.setDeltakerTlf(avtale.getDeltakerTlf());

--- a/src/main/resources/db/migration/V16__legg_til_sist_endret_slett_versjon.sql
+++ b/src/main/resources/db/migration/V16__legg_til_sist_endret_slett_versjon.sql
@@ -1,0 +1,2 @@
+alter table avtale add column sist_endret timestamp default now();
+alter table avtale drop column versjon;

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/TestData.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/TestData.java
@@ -10,6 +10,7 @@ import no.nav.tag.tiltaksgjennomforing.varsel.SmsVarsel;
 import no.nav.tag.tiltaksgjennomforing.varsel.VarslbarHendelse;
 import no.nav.tag.tiltaksgjennomforing.varsel.VarslbarHendelseType;
 
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Arrays;
@@ -27,7 +28,7 @@ public class TestData {
     public static Arbeidstrening enAvtaleMedAltUtfylt() {
         NavIdent veilderNavIdent = new NavIdent("Z123456");
         Avtale avtale = AvtaleFactory.nyAvtale(lagOpprettAvtale(), veilderNavIdent);
-        avtale.endreAvtale(avtale.getVersjon(), endringPaAlleFelt(), Avtalerolle.VEILEDER);
+        avtale.endreAvtale(Instant.now(), endringPaAlleFelt(), Avtalerolle.VEILEDER);
         return (Arbeidstrening) avtale;
     }
 

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleControllerTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleControllerTest.java
@@ -21,8 +21,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -161,7 +159,7 @@ public class AvtaleControllerTest {
         Avtale avtale = TestData.enAvtale();
         vaerInnloggetSom(TestData.innloggetNavAnsatt(TestData.enVeileder(avtale)));
         when(avtaleRepository.findById(avtale.getId())).thenReturn(Optional.empty());
-        avtaleController.endreAvtale(avtale.getId(), avtale.getVersjon(), TestData.ingenEndring());
+        avtaleController.endreAvtale(avtale.getId(), avtale.getSistEndret(), TestData.ingenEndring());
     }
 
     @Test
@@ -170,7 +168,7 @@ public class AvtaleControllerTest {
         vaerInnloggetSom(TestData.innloggetNavAnsatt(TestData.enVeileder(avtale)));
         when(avtaleRepository.findById(avtale.getId())).thenReturn(Optional.of(avtale));
         when(avtaleRepository.save(avtale)).thenReturn(avtale);
-        ResponseEntity svar = avtaleController.endreAvtale(avtale.getId(), avtale.getVersjon(), TestData.ingenEndring());
+        ResponseEntity svar = avtaleController.endreAvtale(avtale.getId(), avtale.getSistEndret(), TestData.ingenEndring());
         assertThat(svar.getStatusCode()).isEqualTo(HttpStatus.OK);
     }
 
@@ -179,7 +177,7 @@ public class AvtaleControllerTest {
         Avtale avtale = TestData.enAvtale();
         vaerInnloggetSom(TestData.enSelvbetjeningBruker());
         when(avtaleRepository.findById(avtale.getId())).thenReturn(Optional.of(avtale));
-        avtaleController.endreAvtale(avtale.getId(), avtale.getVersjon(), TestData.ingenEndring());
+        avtaleController.endreAvtale(avtale.getId(), avtale.getSistEndret(), TestData.ingenEndring());
     }
 
     @Test
@@ -323,7 +321,7 @@ public class AvtaleControllerTest {
         vaerInnloggetSom(innloggetNavAnsatt);
         when(avtaleRepository.findById(avtale.getId())).thenReturn(Optional.of(avtale));
         AvtaleStatusDetaljer avtaleStatusDetaljer = avtaleController.hentAvtaleStatusDetaljer(avtale.getId());
-        assertThat(avtaleStatusDetaljer.header).isEqualTo(veileder.tekstHeaderVentAndreGodkjenning);
+        assertThat(avtaleStatusDetaljer.header).isEqualTo(Avtalepart.tekstHeaderVentAndreGodkjenning);
         assertThat(avtaleStatusDetaljer.infoDel1).isEqualTo("");
         assertThat(avtaleStatusDetaljer.infoDel2).isEqualTo("");
     }
@@ -337,7 +335,7 @@ public class AvtaleControllerTest {
         vaerInnloggetSom(innloggetNavAnsatt);
         when(avtaleRepository.findById(avtale.getId())).thenReturn(Optional.of(avtale));
         AvtaleStatusDetaljer avtaleStatusDetaljer = avtaleController.hentAvtaleStatusDetaljer(avtale.getId());
-        assertThat(avtaleStatusDetaljer.header).isEqualTo(veileder.tekstHeaderVentAndreGodkjenning);
+        assertThat(avtaleStatusDetaljer.header).isEqualTo(Avtalepart.tekstHeaderVentAndreGodkjenning);
         assertThat(avtaleStatusDetaljer.infoDel1).isEqualTo("");
         assertThat(avtaleStatusDetaljer.infoDel2).isEqualTo("");
     }

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleRepositoryTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleRepositoryTest.java
@@ -12,6 +12,7 @@ import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 
+import java.time.Instant;
 import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.List;
@@ -54,7 +55,7 @@ public class AvtaleRepositoryTest {
         EndreAvtale endreAvtale = new EndreAvtale();
         Maal maal = TestData.etMaal();
         endreAvtale.setMaal(List.of(maal));
-        lagretAvtale.endreAvtale(1, endreAvtale, Avtalerolle.VEILEDER);
+        lagretAvtale.endreAvtale(Instant.now(), endreAvtale, Avtalerolle.VEILEDER);
         avtaleRepository.save(lagretAvtale);
 
         // Lage ny avtale
@@ -64,7 +65,7 @@ public class AvtaleRepositoryTest {
         EndreAvtale endreAvtale2 = new EndreAvtale();
         Maal maal2 = TestData.etMaal();
         endreAvtale2.setMaal(List.of(maal2));
-        lagretAvtale2.endreAvtale(1, endreAvtale2, Avtalerolle.VEILEDER);
+        lagretAvtale2.endreAvtale(Instant.now(), endreAvtale2, Avtalerolle.VEILEDER);
         avtaleRepository.save(lagretAvtale2);
     }
 
@@ -77,7 +78,7 @@ public class AvtaleRepositoryTest {
         EndreAvtale endreAvtale = new EndreAvtale();
         Oppgave oppgave = TestData.enOppgave();
         endreAvtale.setOppgaver(List.of(oppgave));
-        lagretAvtale.endreAvtale(1, endreAvtale, Avtalerolle.VEILEDER);
+        lagretAvtale.endreAvtale(Instant.now(), endreAvtale, Avtalerolle.VEILEDER);
         avtaleRepository.save(lagretAvtale);
 
         // Lage ny avtale
@@ -87,7 +88,7 @@ public class AvtaleRepositoryTest {
         EndreAvtale endreAvtale2 = new EndreAvtale();
         Oppgave oppgave2 = TestData.enOppgave();
         endreAvtale2.setOppgaver(List.of(oppgave2));
-        lagretAvtale2.endreAvtale(1, endreAvtale2, Avtalerolle.VEILEDER);
+        lagretAvtale2.endreAvtale(Instant.now(), endreAvtale2, Avtalerolle.VEILEDER);
         avtaleRepository.save(lagretAvtale2);
     }
 
@@ -129,7 +130,7 @@ public class AvtaleRepositoryTest {
         Avtale avtale = TestData.enAvtale();
         avtaleRepository.save(avtale);
         verify(metrikkRegistrering, never()).avtaleEndret(any());
-        avtale.endreAvtale(avtale.getVersjon(), TestData.ingenEndring(), Avtalerolle.VEILEDER);
+        avtale.endreAvtale(Instant.now(), TestData.ingenEndring(), Avtalerolle.VEILEDER);
         avtaleRepository.save(avtale);
         verify(metrikkRegistrering).avtaleEndret(any());
     }
@@ -137,7 +138,7 @@ public class AvtaleRepositoryTest {
     @Test
     public void godkjennForArbeidsgiver__skal_publisere_domainevent() {
         Avtale avtale = TestData.enAvtaleMedAltUtfylt();
-        TestData.enArbeidsgiver(avtale).godkjennAvtale(avtale.getVersjon());
+        TestData.enArbeidsgiver(avtale).godkjennAvtale(avtale.getSistEndret());
         avtaleRepository.save(avtale);
         verify(metrikkRegistrering).godkjentAvArbeidsgiver(any());
     }
@@ -145,7 +146,7 @@ public class AvtaleRepositoryTest {
     @Test
     public void godkjennForDeltaker__skal_publisere_domainevent() {
         Avtale avtale = TestData.enAvtaleMedAltUtfylt();
-        TestData.enDeltaker(avtale).godkjennAvtale(avtale.getVersjon());
+        TestData.enDeltaker(avtale).godkjennAvtale(avtale.getSistEndret());
         avtaleRepository.save(avtale);
         verify(metrikkRegistrering).godkjentAvDeltaker(any());
     }
@@ -155,7 +156,7 @@ public class AvtaleRepositoryTest {
         Avtale avtale = TestData.enAvtaleMedAltUtfylt();
         avtale.setGodkjentAvDeltaker(LocalDateTime.now());
         avtale.setGodkjentAvArbeidsgiver(LocalDateTime.now());
-        TestData.enVeileder(avtale).godkjennAvtale(avtale.getVersjon());
+        TestData.enVeileder(avtale).godkjennAvtale(avtale.getSistEndret());
         avtaleRepository.save(avtale);
         verify(metrikkRegistrering).godkjentAvVeileder(any());
     }
@@ -169,7 +170,7 @@ public class AvtaleRepositoryTest {
     }
 
     @Test
-    public void henter_avtaler_til_journalfoering(){
+    public void henter_avtaler_til_journalfoering() {
         Avtale ikkeKlar = TestData.enAvtaleMedAltUtfylt();
         Avtale klarTilJournalforing = TestData.enAvtaleMedAltUtfyltGodkjentAvVeileder();
         Avtale journalfoert = TestData.enAvtaleMedAltUtfyltGodkjentAvVeileder();
@@ -182,10 +183,10 @@ public class AvtaleRepositoryTest {
         assertEquals(avtaleIds.size(), faktiskAvtList.size());
         boolean allMatch = faktiskAvtList.stream()
                 .allMatch(avtale ->
-                     avtale.erGodkjentAvVeileder()
-                            && avtale.getJournalpostId() == null
-                            && avtaleIds.stream().anyMatch(uuid ->
-                             uuid.equals(avtale.getId()) && !uuid.equals(ikkeKlar.getId()) && !uuid.equals(journalfoert.getId()))
+                        avtale.erGodkjentAvVeileder()
+                                && avtale.getJournalpostId() == null
+                                && avtaleIds.stream().anyMatch(uuid ->
+                                uuid.equals(avtale.getId()) && !uuid.equals(ikkeKlar.getId()) && !uuid.equals(journalfoert.getId()))
                 );
         assertTrue(allMatch);
     }

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleTest.java
@@ -7,6 +7,7 @@ import no.nav.tag.tiltaksgjennomforing.exceptions.TiltaksgjennomforingException;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.Test;
 
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -67,26 +68,26 @@ public class AvtaleTest {
     @Test(expected = SamtidigeEndringerException.class)
     public void sjekkVersjon__ugyldig_versjon() {
         Avtale avtale = TestData.enAvtale();
-        avtale.sjekkVersjon(-1);
+        avtale.sjekkSistEndret(Instant.MIN);
     }
 
     @Test(expected = SamtidigeEndringerException.class)
     public void sjekkVersjon__null() {
         Avtale avtale = TestData.enAvtale();
-        avtale.sjekkVersjon(null);
+        avtale.sjekkSistEndret(null);
     }
 
     @Test
     public void sjekkVersjon__gyldig_versjon() {
         Avtale avtale = TestData.enAvtale();
-        avtale.sjekkVersjon(avtale.getVersjon());
+        avtale.sjekkSistEndret(Instant.now());
     }
 
     @Test
     public void endreAvtaleSkalOppdatereRiktigeFelt() {
         Arbeidstrening avtale = TestData.enAvtale();
         EndreAvtale endreAvtale = TestData.endringPaAlleFelt();
-        avtale.endreAvtale(avtale.getVersjon(), endreAvtale, Avtalerolle.VEILEDER);
+        avtale.endreAvtale(Instant.now(), endreAvtale, Avtalerolle.VEILEDER);
 
         SoftAssertions.assertSoftly(softly -> {
             softly.assertThat(avtale.getDeltakerFornavn()).isEqualTo(endreAvtale.getDeltakerFornavn());
@@ -116,7 +117,7 @@ public class AvtaleTest {
         etMaal.setBeskrivelse("Dette er en string pa 1024 tegn.Dette er en string pa 1024 tegn.Dette er en string pa 1024 tegn.Dette er en string pa 1024 tegn.Dette er en string pa 1024 tegn.Dette er en string pa 1024 tegn.Dette er en string pa 1024 tegn.Dette er en string pa 1024 tegn.Dette er en string pa 1024 tegn.Dette er en string pa 1024 tegn.Dette er en string pa 1024 tegn.Dette er en string pa 1024 tegn.Dette er en string pa 1024 tegn.Dette er en string pa 1024 tegn.Dette er en string pa 1024 tegn.Dette er en string pa 1024 tegn.Dette er en string pa 1024 tegn.Dette er en string pa 1024 tegn.Dette er en string pa 1024 tegn.Dette er en string pa 1024 tegn.Dette er en string pa 1024 tegn.Dette er en string pa 1024 tegn.Dette er en string pa 1024 tegn.Dette er en string pa 1024 tegn.Dette er en string pa 1024 tegn.Dette er en string pa 1024 tegn.Dette er en string pa 1024 tegn.Dette er en string pa 1024 tegn.Dette er en string pa 1024 tegn.Dette er en string pa 1024 tegn.Dette er en string pa 1024 tegn.Dette er en string pa 1024 tegn.");
         EndreAvtale endreAvtale = new EndreAvtale();
         endreAvtale.setMaal(List.of(etMaal));
-        avtale.endreAvtale(avtale.getVersjon(), endreAvtale, Avtalerolle.VEILEDER);
+        avtale.endreAvtale(Instant.now(), endreAvtale, Avtalerolle.VEILEDER);
     }
 
     @Test(expected = TiltaksgjennomforingException.class)
@@ -126,7 +127,7 @@ public class AvtaleTest {
         enOppgave.setBeskrivelse("Dette er en string pa 1024 tegn.Dette er en string pa 1024 tegn.Dette er en string pa 1024 tegn.Dette er en string pa 1024 tegn.Dette er en string pa 1024 tegn.Dette er en string pa 1024 tegn.Dette er en string pa 1024 tegn.Dette er en string pa 1024 tegn.Dette er en string pa 1024 tegn.Dette er en string pa 1024 tegn.Dette er en string pa 1024 tegn.Dette er en string pa 1024 tegn.Dette er en string pa 1024 tegn.Dette er en string pa 1024 tegn.Dette er en string pa 1024 tegn.Dette er en string pa 1024 tegn.Dette er en string pa 1024 tegn.Dette er en string pa 1024 tegn.Dette er en string pa 1024 tegn.Dette er en string pa 1024 tegn.Dette er en string pa 1024 tegn.Dette er en string pa 1024 tegn.Dette er en string pa 1024 tegn.Dette er en string pa 1024 tegn.Dette er en string pa 1024 tegn.Dette er en string pa 1024 tegn.Dette er en string pa 1024 tegn.Dette er en string pa 1024 tegn.Dette er en string pa 1024 tegn.Dette er en string pa 1024 tegn.Dette er en string pa 1024 tegn.Dette er en string pa 1024 tegn.");
         EndreAvtale endreAvtale = new EndreAvtale();
         endreAvtale.setOppgaver(List.of(enOppgave));
-        avtale.endreAvtale(avtale.getVersjon(), endreAvtale, Avtalerolle.VEILEDER);
+        avtale.endreAvtale(Instant.now(), endreAvtale, Avtalerolle.VEILEDER);
     }
 
     @Test
@@ -136,7 +137,7 @@ public class AvtaleTest {
         enOppgave.setBeskrivelse("Dette er en string på 1000 tegn Dette er en string på 1000 tegn Dette er en string på 1000 tegn Dette er en string på 1000 tegn Dette er en string på 1000 tegn Dette er en string på 1000 tegn Dette er en string på 1000 tegn Dette er en string på 1000 tegn Dette er en string på 1000 tegn Dette er en string på 1000 tegn Dette er en string på 1000 tegn Dette er en string på 1000 tegn Dette er en string på 1000 tegn Dette er en string på 1000 tegn Dette er en string på 1000 tegn Dette er en string på 1000 tegn Dette er en string på 1000 tegn Dette er en string på 1000 tegn Dette er en string på 1000 tegn Dette er en string på 1000 tegn Dette er en string på 1000 tegn Dette er en string på 1000 tegn Dette er en string på 1000 tegn Dette er en string på 1000 tegn Dette er en string på 1000 tegn Dette er en string på 1000 tegn Dette er en string på 1000 tegn Dette er en string på 1000 tegn Dette er en string på 1000 tegn Dette er en string på 1000 tegn Dette er en string på 1000 tegn Dette er");
         EndreAvtale endreAvtale = new EndreAvtale();
         endreAvtale.setOppgaver(List.of(enOppgave));
-        avtale.endreAvtale(avtale.getVersjon(), endreAvtale, Avtalerolle.VEILEDER);
+        avtale.endreAvtale(Instant.now(), endreAvtale, Avtalerolle.VEILEDER);
     }
 
     @Test
@@ -145,7 +146,7 @@ public class AvtaleTest {
         EndreAvtale endreAvtale = new EndreAvtale();
         LocalDate startDato = LocalDate.now();
         endreAvtale.setStartDato(startDato);
-        avtale.endreAvtale(avtale.getVersjon(), endreAvtale, Avtalerolle.VEILEDER);
+        avtale.endreAvtale(Instant.now(), endreAvtale, Avtalerolle.VEILEDER);
         assertThat(avtale.getStartDato()).isEqualTo(startDato);
     }
 
@@ -155,7 +156,7 @@ public class AvtaleTest {
         EndreAvtale endreAvtale = new EndreAvtale();
         LocalDate sluttDato = LocalDate.now();
         endreAvtale.setSluttDato(sluttDato);
-        avtale.endreAvtale(avtale.getVersjon(), endreAvtale, Avtalerolle.VEILEDER);
+        avtale.endreAvtale(Instant.now(), endreAvtale, Avtalerolle.VEILEDER);
         assertThat(avtale.getSluttDato()).isEqualTo(sluttDato);
     }
 
@@ -167,7 +168,7 @@ public class AvtaleTest {
         LocalDate sluttDato = startDato.plusMonths(3);
         endreAvtale.setStartDato(startDato);
         endreAvtale.setSluttDato(sluttDato);
-        avtale.endreAvtale(avtale.getVersjon(), endreAvtale, Avtalerolle.VEILEDER);
+        avtale.endreAvtale(Instant.now(), endreAvtale, Avtalerolle.VEILEDER);
         assertThat(avtale.getStartDato()).isEqualTo(startDato);
         assertThat(avtale.getSluttDato()).isEqualTo(sluttDato);
     }
@@ -180,7 +181,7 @@ public class AvtaleTest {
         LocalDate sluttDato = startDato.plusMonths(3).plusDays(1);
         endreAvtale.setStartDato(startDato);
         endreAvtale.setSluttDato(sluttDato);
-        avtale.endreAvtale(avtale.getVersjon(), endreAvtale, Avtalerolle.VEILEDER);
+        avtale.endreAvtale(Instant.now(), endreAvtale, Avtalerolle.VEILEDER);
     }
 
     @Test(expected = StartDatoErEtterSluttDatoException.class)
@@ -191,7 +192,7 @@ public class AvtaleTest {
         LocalDate sluttDato = startDato.minusDays(1);
         endreAvtale.setStartDato(startDato);
         endreAvtale.setSluttDato(sluttDato);
-        avtale.endreAvtale(avtale.getVersjon(), endreAvtale, Avtalerolle.VEILEDER);
+        avtale.endreAvtale(Instant.now(), endreAvtale, Avtalerolle.VEILEDER);
     }
 
     @Test
@@ -201,7 +202,7 @@ public class AvtaleTest {
         boolean arbeidsgiverGodkjenningFoerEndring = avtale.erGodkjentAvArbeidsgiver();
         boolean veilederGodkjenningFoerEndring = avtale.erGodkjentAvVeileder();
 
-        avtale.endreAvtale(avtale.getVersjon(), TestData.endringPaAlleFelt(), Avtalerolle.VEILEDER);
+        avtale.endreAvtale(Instant.now(), TestData.endringPaAlleFelt(), Avtalerolle.VEILEDER);
 
         SoftAssertions.assertSoftly(softly -> {
             softly.assertThat(deltakerGodkjenningFoerEndring).isEqualTo(avtale.erGodkjentAvDeltaker());
@@ -213,8 +214,9 @@ public class AvtaleTest {
     @Test
     public void endreAvtaleSkalInkrementereVersjon() {
         Avtale avtale = TestData.enAvtale();
-        avtale.endreAvtale(avtale.getVersjon(), TestData.ingenEndring(), Avtalerolle.VEILEDER);
-        assertThat(avtale.getVersjon()).isEqualTo(2);
+        Instant førstEndret = avtale.getSistEndret();
+        avtale.endreAvtale(førstEndret, TestData.ingenEndring(), Avtalerolle.VEILEDER);
+        assertThat(avtale.getSistEndret()).isAfter(førstEndret);
     }
 
     @Test(expected = TiltaksgjennomforingException.class)

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtalepartTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtalepartTest.java
@@ -5,6 +5,7 @@ import no.nav.tag.tiltaksgjennomforing.exceptions.TilgangskontrollException;
 import no.nav.tag.tiltaksgjennomforing.exceptions.TiltaksgjennomforingException;
 import org.junit.Test;
 
+import java.time.Instant;
 import java.time.LocalDateTime;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -14,7 +15,7 @@ public class AvtalepartTest {
     public void endreAvtale__skal_feile_for_deltaker() {
         Avtale avtale = TestData.enAvtaleMedAltUtfylt();
         Deltaker deltaker = TestData.enDeltaker(avtale);
-        deltaker.endreAvtale(avtale.getVersjon(), TestData.ingenEndring());
+        deltaker.endreAvtale(avtale.getSistEndret(), TestData.ingenEndring());
     }
 
     @Test(expected = TilgangskontrollException.class)
@@ -58,28 +59,28 @@ public class AvtalepartTest {
     public void endreAvtale__skal_fungere_for_arbeidsgiver() {
         Avtale avtale = TestData.enAvtaleMedAltUtfylt();
         Arbeidsgiver arbeidsgiver = TestData.enArbeidsgiver(avtale);
-        arbeidsgiver.endreAvtale(avtale.getVersjon(), TestData.ingenEndring());
+        arbeidsgiver.endreAvtale(Instant.now(), TestData.ingenEndring());
     }
 
     @Test
     public void endreAvtale__skal_fungere_for_veileder() {
         Avtale avtale = TestData.enAvtaleMedAltUtfylt();
         Veileder veileder = TestData.enVeileder(avtale);
-        veileder.endreAvtale(avtale.getVersjon(), TestData.ingenEndring());
+        veileder.endreAvtale(Instant.now(), TestData.ingenEndring());
     }
 
     @Test(expected = SamtidigeEndringerException.class)
     public void godkjennForAvtalepart__skal_ikke_fungere_hvis_versjon_er_feil() {
         Avtale avtale = TestData.enAvtaleMedAltUtfylt();
         Deltaker deltaker = TestData.enDeltaker(avtale);
-        deltaker.godkjennAvtale(-1);
+        deltaker.godkjennAvtale(avtale.getSistEndret().minusMillis(1));
     }
 
     @Test
     public void godkjennForAvtalepart__skal_fungere_for_deltaker() {
         Avtale avtale = TestData.enAvtaleMedAltUtfylt();
         Deltaker deltaker = TestData.enDeltaker(avtale);
-        deltaker.godkjennAvtale(avtale.getVersjon());
+        deltaker.godkjennAvtale(avtale.getSistEndret());
         assertThat(avtale.erGodkjentAvDeltaker()).isTrue();
         assertThat(avtale.erGodkjentAvArbeidsgiver()).isFalse();
         assertThat(avtale.erGodkjentAvVeileder()).isFalse();
@@ -89,7 +90,7 @@ public class AvtalepartTest {
     public void godkjennForAvtalepart__skal_fungere_for_arbeidsgiver() {
         Avtale avtale = TestData.enAvtaleMedAltUtfylt();
         Arbeidsgiver arbeidsgiver = TestData.enArbeidsgiver(avtale);
-        arbeidsgiver.godkjennAvtale(avtale.getVersjon());
+        arbeidsgiver.godkjennAvtale(avtale.getSistEndret());
         assertThat(avtale.erGodkjentAvArbeidsgiver()).isTrue();
         assertThat(avtale.erGodkjentAvVeileder()).isFalse();
         assertThat(avtale.erGodkjentAvDeltaker()).isFalse();
@@ -101,7 +102,7 @@ public class AvtalepartTest {
         avtale.setGodkjentAvDeltaker(LocalDateTime.now());
         avtale.setGodkjentAvArbeidsgiver(LocalDateTime.now());
         Veileder veileder = TestData.enVeileder(avtale);
-        veileder.godkjennAvtale(avtale.getVersjon());
+        veileder.godkjennAvtale(avtale.getSistEndret());
         assertThat(avtale.erGodkjentAvArbeidsgiver()).isTrue();
     }
 

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/VeilederTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/VeilederTest.java
@@ -1,8 +1,6 @@
 package no.nav.tag.tiltaksgjennomforing.avtale;
 
 import no.nav.tag.tiltaksgjennomforing.TestData;
-import no.nav.tag.tiltaksgjennomforing.avtale.Avtale;
-import no.nav.tag.tiltaksgjennomforing.avtale.Veileder;
 import no.nav.tag.tiltaksgjennomforing.exceptions.TiltaksgjennomforingException;
 import org.junit.Test;
 
@@ -15,7 +13,7 @@ public class VeilederTest {
     public void godkjennAvtale__kan_ikke_godkjenne_foerst() {
         Avtale avtale = TestData.enAvtaleMedAltUtfylt();
         Veileder veileder = TestData.enVeileder(avtale);
-        veileder.godkjennAvtale(avtale.getVersjon());
+        veileder.godkjennAvtale(avtale.getSistEndret());
     }
 
     @Test
@@ -24,7 +22,7 @@ public class VeilederTest {
         avtale.setGodkjentAvDeltaker(LocalDateTime.now());
         avtale.setGodkjentAvArbeidsgiver(LocalDateTime.now());
         Veileder veileder = TestData.enVeileder(avtale);
-        veileder.godkjennAvtale(avtale.getVersjon());
+        veileder.godkjennAvtale(avtale.getSistEndret());
         assertThat(avtale.erGodkjentAvVeileder()).isTrue();
     }
 
@@ -48,7 +46,7 @@ public class VeilederTest {
         avtale.setGodkjentAvDeltaker(LocalDateTime.now());
         avtale.setGodkjentAvArbeidsgiver(LocalDateTime.now());
         Veileder veileder = TestData.enVeileder(avtale);
-        veileder.avbrytAvtale(avtale.getVersjon());
+        veileder.avbrytAvtale(avtale.getSistEndret());
         assertThat(avtale.isAvbrutt()).isFalse();
     }
 
@@ -58,7 +56,7 @@ public class VeilederTest {
         avtale.setGodkjentAvDeltaker(LocalDateTime.now());
         avtale.setGodkjentAvArbeidsgiver(LocalDateTime.now());
         Veileder veileder = TestData.enVeileder(avtale);
-        veileder.avbrytAvtale(avtale.getVersjon());
+        veileder.avbrytAvtale(avtale.getSistEndret());
         assertThat(avtale.isAvbrutt()).isTrue();
     }
 }

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/journalfoering/AvtaleTilJournalfoeringMapperTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/journalfoering/AvtaleTilJournalfoeringMapperTest.java
@@ -47,7 +47,6 @@ public class AvtaleTilJournalfoeringMapperTest {
         assertEquals(avtale.getBedriftNr().asString(), tilJournalfoering.getBedriftNr());
         assertEquals(avtale.getVeilederNavIdent().asString(), tilJournalfoering.getVeilederNavIdent());
         assertEquals(avtale.getOpprettetTidspunkt().toLocalDate(), tilJournalfoering.getOpprettet());
-        assertEquals(avtale.getVersjon(), tilJournalfoering.getVersjon());
         assertEquals(avtale.getDeltakerFornavn(), tilJournalfoering.getDeltakerFornavn());
         assertEquals(avtale.getDeltakerEtternavn(), tilJournalfoering.getDeltakerEtternavn());
         assertEquals(avtale.getDeltakerTlf(), tilJournalfoering.getDeltakerTlf());


### PR DESCRIPTION
Det blir begrepskollisjon når vi innfører versjonering av avtale. Så for å forenkle endrer jeg til timestamp til optimistisk lås, i stedet for versjonummer. I tillegg vil vi kunne bruke feltet `sistEndret` til noe fornuftig, for eksempel til å sortere avtaleoversikten.

PR i frontend: https://github.com/navikt/tiltaksgjennomforing/pull/203

Frontend og backend må deployes samtidig.