### PR TITLE
Endrer defaultverdi på sist_endret til opprettet_tidspunkt

### DIFF
--- a/src/main/resources/db/migration/V17__sist_endret_defaultverdi.sql
+++ b/src/main/resources/db/migration/V17__sist_endret_defaultverdi.sql
@@ -1,0 +1,1 @@
+update avtale set sist_endret=opprettet_tidspunkt;


### PR DESCRIPTION
Kolonnen brukes bare til optimistisk lås per i dag, og er derfor ikke synlig. På et senere tidspunkt kan det være aktuelt å vise tidspunktet. For avtaler som allerede er inngått, og som ikke endres senere, vil nok opprettet tidspunkt være en bedre default. 