### PR TITLE
Tar hoyde for at adressebeskyttelse array er tom ved ugradert person

### DIFF
--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleController.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleController.java
@@ -63,7 +63,7 @@ public class AvtaleController {
         InnloggetNavAnsatt innloggetNavAnsatt = innloggingService.hentInnloggetNavAnsatt();
         tilgangUnderPilotering.sjekkTilgang(innloggetNavAnsatt.getIdentifikator());
         tilgangskontrollService.sjekkSkrivetilgangTilKandidat(innloggetNavAnsatt, opprettAvtale.getDeltakerFnr());
-        // persondataService.sjekkGradering(opprettAvtale.getDeltakerFnr());
+        persondataService.sjekkGradering(opprettAvtale.getDeltakerFnr());
         Avtale avtale = innloggetNavAnsatt.opprettAvtale(opprettAvtale);
         avtale.setBedriftNavn(eregService.hentVirksomhet(avtale.getBedriftNr()).getBedriftNavn());
         Avtale opprettetAvtale = avtaleRepository.save(avtale);

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/persondata/PersondataService.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/persondata/PersondataService.java
@@ -43,7 +43,11 @@ public class PersondataService {
         if (pdlPerson.getData().getHentPerson() == null) {
             // Person finnes ikke
             return new Adressebeskyttelse("");
-        } else {
+        } else if (pdlPerson.getData().getHentPerson().getAdressebeskyttelse().length == 0) {
+            // Ugradert
+            return new Adressebeskyttelse("");
+        }
+        else {
             return pdlPerson.getData().getHentPerson().getAdressebeskyttelse()[0];
         }
     }

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/persondata/PersondataServiceTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/persondata/PersondataServiceTest.java
@@ -2,7 +2,6 @@ package no.nav.tag.tiltaksgjennomforing.persondata;
 
 import no.nav.tag.tiltaksgjennomforing.avtale.Fnr;
 import no.nav.tag.tiltaksgjennomforing.exceptions.TilgangskontrollException;
-import no.nav.tag.tiltaksgjennomforing.exceptions.TiltaksgjennomforingException;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -23,7 +22,8 @@ public class PersondataServiceTest {
 
     private Fnr strengtFortroligPerson = new Fnr("16053900422");
     private Fnr fortroligPerson = new Fnr("26067114433");
-    private Fnr ugradertPErson = new Fnr("00000000000");
+    private Fnr ugradertPerson = new Fnr("00000000000");
+    private Fnr getUgradertPersonTomResponse = new Fnr("27030960020");
     private Fnr uspesifisertGradertPerson = new Fnr("18076641842");
     private Fnr personFinnesIkke = new Fnr("24080687881");
     private Fnr personForResponsUtenData = new Fnr("23097010706");
@@ -58,6 +58,12 @@ public class PersondataServiceTest {
         assertThat(adressebeskyttelse.getGradering().equals("null"));
     }
 
+    @Test
+    public void hentGradering__returnerer_ugradert_tom_gradering() {
+        Adressebeskyttelse adressebeskyttelse = persondataService.hentGradering(getUgradertPersonTomResponse);
+        assertThat(adressebeskyttelse.getGradering().equals(""));
+    }
+
     @Test(expected = NullPointerException.class)
     public void hentGradering_person_far_respons_uten_Data() {
         Adressebeskyttelse adressebeskyttelse = persondataService.hentGradering(personForResponsUtenData);
@@ -73,8 +79,11 @@ public class PersondataServiceTest {
 
     @Test
     public void sjekkGradering__skal_ikke_kaste_feil_ugradert() {
-        persondataService.sjekkGradering(ugradertPErson);
+        persondataService.sjekkGradering(ugradertPerson);
     }
+
+    @Test
+    public void sjekkGradering_skal_ikke_kaste_feil_ugradertTom() { persondataService.sjekkGradering(getUgradertPersonTomResponse); }
 
     @Test
     public void sjekkGradering__skal_ikke_kaste_feil_uspesifisert_gradering() { persondataService.sjekkGradering(uspesifisertGradertPerson); }

--- a/src/test/resources/mappings/pdl_gradering.json
+++ b/src/test/resources/mappings/pdl_gradering.json
@@ -128,6 +128,29 @@
           "Content-Type": "application/json"
         }
       }
+    },
+    {
+      "priority": 7,
+      "request": {
+        "method": "POST",
+        "urlPath": "/persondata",
+        "headers": {
+          "Content-Type": {
+            "equalTo": "application/json",
+            "caseInsensitive": true
+          }
+        },
+        "bodyPatterns" : [ {
+          "equalToJson" : "{\"query\" : \"query{ hentPerson( ident: \\\"27030960020\\\") {adressebeskyttelse {gradering} } }\" }"
+        } ]
+      },
+      "response": {
+        "status": 200,
+        "body": "{\"data\": {\"hentPerson\": {\"adressebeskyttelse\": []}}}≤",
+        "headers": {
+          "Content-Type": "application/json"
+        }
+      }
     }
   ]
 }

--- a/src/test/resources/mappings/pdl_gradering.json
+++ b/src/test/resources/mappings/pdl_gradering.json
@@ -3,6 +3,19 @@
     {
       "request": {
         "method": "POST",
+        "urlPath": "/persondata"
+      },
+      "response": {
+        "status": 200,
+        "body": "{\"errors\": [{\"message\": \"Fant ikke person\", \"locations\": [{\"line\": 1, \"column\": 8}], \"path\": [\"hentPerson\"], \"extensions\": {\"code\": \"not_found\", \"classification\": \"ExecutionAborted\"}}], \"data\": {\"hentPerson\": null}}",
+        "headers": {
+          "Content-Type": "application/json"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "POST",
         "urlPath": "/persondata",
         "headers": {
           "Content-Type": {
@@ -105,19 +118,6 @@
       "response": {
         "status": 200,
         "body": "{\"errors\": [{\"message\": \"Fant ikke person\", \"locations\": [{\"line\": 1, \"column\": 8}], \"path\": [\"hentPerson\"], \"extensions\": {\"code\": \"not_found\", \"classification\": \"ExecutionAborted\"}}]}",
-        "headers": {
-          "Content-Type": "application/json"
-        }
-      }
-    },
-    {
-      "request": {
-        "method": "POST",
-        "urlPath": "/persondata"
-      },
-      "response": {
-        "status": 200,
-        "body": "{\"errors\": [{\"message\": \"Fant ikke person\", \"locations\": [{\"line\": 1, \"column\": 8}], \"path\": [\"hentPerson\"], \"extensions\": {\"code\": \"not_found\", \"classification\": \"ExecutionAborted\"}}], \"data\": {\"hentPerson\": null}}",
         "headers": {
           "Content-Type": "application/json"
         }

--- a/src/test/resources/mappings/pdl_gradering.json
+++ b/src/test/resources/mappings/pdl_gradering.json
@@ -1,7 +1,6 @@
 {
   "mappings": [
     {
-      "priority": 1,
       "request": {
         "method": "POST",
         "urlPath": "/persondata",
@@ -24,7 +23,6 @@
       }
     },
     {
-      "priority": 2,
       "request": {
         "method": "POST",
         "urlPath": "/persondata",
@@ -40,14 +38,13 @@
       },
       "response": {
         "status": 200,
-        "body": "{\"data\": {\"hentPerson\": {\"adressebeskyttelse\": [{\"gradering\": \"UGRADERT\"}]}}}≤",
+        "body": "{\"data\": {\"hentPerson\": {\"adressebeskyttelse\": [{\"gradering\": \"UGRADERT\"}]}}}",
         "headers": {
           "Content-Type": "application/json"
         }
       }
     },
     {
-      "priority": 3,
       "request": {
         "method": "POST",
         "urlPath": "/persondata",
@@ -63,14 +60,13 @@
       },
       "response": {
         "status": 200,
-        "body": "{\"data\": {\"hentPerson\": {\"adressebeskyttelse\": [{\"gradering\": \"FORTROLIG\"}]}}}≤",
+        "body": "{\"data\": {\"hentPerson\": {\"adressebeskyttelse\": [{\"gradering\": \"FORTROLIG\"}]}}}",
         "headers": {
           "Content-Type": "application/json"
         }
       }
     },
     {
-      "priority": 4,
       "request": {
         "method": "POST",
         "urlPath": "/persondata",
@@ -86,14 +82,13 @@
       },
       "response": {
         "status": 200,
-        "body": "{\"data\": {\"hentPerson\": {\"adressebeskyttelse\": [{\"gradering\": \"\"}]}}}≤",
+        "body": "{\"data\": {\"hentPerson\": {\"adressebeskyttelse\": [{\"gradering\": \"\"}]}}}",
         "headers": {
           "Content-Type": "application/json"
         }
       }
     },
     {
-      "priority": 5,
       "request": {
         "method": "POST",
         "urlPath": "/persondata",
@@ -116,7 +111,6 @@
       }
     },
     {
-      "priority": 6,
       "request": {
         "method": "POST",
         "urlPath": "/persondata"
@@ -130,7 +124,6 @@
       }
     },
     {
-      "priority": 7,
       "request": {
         "method": "POST",
         "urlPath": "/persondata",
@@ -141,12 +134,12 @@
           }
         },
         "bodyPatterns" : [ {
-          "equalToJson" : "{\"query\" : \"query{ hentPerson( ident: \\\"27030960020\\\") {adressebeskyttelse {gradering} } }\" }"
+          "equalToJson" : "{\"query\" : \"query{ hentPerson( ident: \\\"00000000000\\\") {adressebeskyttelse {gradering} } }\" }"
         } ]
       },
       "response": {
         "status": 200,
-        "body": "{\"data\": {\"hentPerson\": {\"adressebeskyttelse\": []}}}≤",
+        "body": "{\"data\": {\"hentPerson\": {\"adressebeskyttelse\": [{\"gradering\": \"UGRADERT\"}]}}}",
         "headers": {
           "Content-Type": "application/json"
         }


### PR DESCRIPTION
Etter samtale med PDL-teamet, viser det seg at responsen er litt annerledes enn først antatt. Vi tar derfor nå høyde for at responsen ser slik ut når man ikke har noen gradering:
```
{
    "data": {
        "hentPerson": {
            "adressebeskyttelse": []
        }
    }
}
```
Har en pending task på å refaktorere PersondataService ytterligere, som bla. innebærer å skrive om til å bruke variables i GraphQL-spørringen.