### PR TITLE
TAG-57 Preutfyll deltakernavn når avtale opprettes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,6 +108,11 @@
             <version>2.4</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-text</artifactId>
+            <version>1.8</version>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.kafka</groupId>
             <artifactId>spring-kafka</artifactId>
         </dependency>

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/Avtale.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/Avtale.java
@@ -9,7 +9,9 @@ import lombok.experimental.FieldNameConstants;
 import no.nav.tag.tiltaksgjennomforing.avtale.events.*;
 import no.nav.tag.tiltaksgjennomforing.exceptions.TilgangskontrollException;
 import no.nav.tag.tiltaksgjennomforing.exceptions.TiltaksgjennomforingException;
+import no.nav.tag.tiltaksgjennomforing.persondata.Navn;
 import org.springframework.data.domain.AbstractAggregateRoot;
+import org.springframework.util.StringUtils;
 
 import javax.persistence.*;
 import java.time.Instant;
@@ -214,6 +216,15 @@ public class Avtale extends AbstractAggregateRoot<Avtale> {
 
     public void leggTilBedriftNavn(String bedriftNavn) {
         this.setBedriftNavn(bedriftNavn);
+    }
+
+    public void leggTilDeltakerNavn(Navn navn) {
+        if (StringUtils.hasLength(navn.getMellomnavn())) {
+            this.setDeltakerFornavn(navn.getFornavn() + " " + navn.getMellomnavn());
+        } else {
+            this.setDeltakerFornavn(navn.getFornavn());
+        }
+        this.setDeltakerEtternavn(navn.getEtternavn());
     }
 
     @JsonProperty

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/Avtale.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/Avtale.java
@@ -10,8 +10,8 @@ import no.nav.tag.tiltaksgjennomforing.avtale.events.*;
 import no.nav.tag.tiltaksgjennomforing.exceptions.TilgangskontrollException;
 import no.nav.tag.tiltaksgjennomforing.exceptions.TiltaksgjennomforingException;
 import no.nav.tag.tiltaksgjennomforing.persondata.Navn;
+import no.nav.tag.tiltaksgjennomforing.persondata.NavnFormaterer;
 import org.springframework.data.domain.AbstractAggregateRoot;
-import org.springframework.util.StringUtils;
 
 import javax.persistence.*;
 import java.time.Instant;
@@ -219,12 +219,9 @@ public class Avtale extends AbstractAggregateRoot<Avtale> {
     }
 
     public void leggTilDeltakerNavn(Navn navn) {
-        if (StringUtils.hasLength(navn.getMellomnavn())) {
-            this.setDeltakerFornavn(navn.getFornavn() + " " + navn.getMellomnavn());
-        } else {
-            this.setDeltakerFornavn(navn.getFornavn());
-        }
-        this.setDeltakerEtternavn(navn.getEtternavn());
+        NavnFormaterer formaterer = new NavnFormaterer(navn);
+        this.setDeltakerFornavn(formaterer.getFornavn());
+        this.setDeltakerEtternavn(formaterer.getEtternavn());
     }
 
     @JsonProperty

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleController.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleController.java
@@ -66,6 +66,7 @@ public class AvtaleController {
         persondataService.sjekkGradering(opprettAvtale.getDeltakerFnr());
         Avtale avtale = innloggetNavAnsatt.opprettAvtale(opprettAvtale);
         avtale.leggTilBedriftNavn(eregService.hentVirksomhet(avtale.getBedriftNr()).getBedriftNavn());
+        avtale.leggTilDeltakerNavn(persondataService.hentNavn(avtale.getDeltakerFnr()));
         Avtale opprettetAvtale = avtaleRepository.save(avtale);
         URI uri = lagUri("/avtaler/" + opprettetAvtale.getId());
         return ResponseEntity.created(uri).build();

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/featuretoggles/FeatureToggleService.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/featuretoggles/FeatureToggleService.java
@@ -4,7 +4,6 @@ import no.finn.unleash.Unleash;
 import no.finn.unleash.UnleashContext;
 import no.finn.unleash.UnleashContext.Builder;
 import no.nav.tag.tiltaksgjennomforing.autorisasjon.TokenUtils;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -22,7 +21,7 @@ public class FeatureToggleService {
     @Autowired
     public FeatureToggleService(Unleash unleash, TokenUtils tokenUtils) {
         this.unleash = unleash;
-        this.tokenUtils = tokenUtils;        
+        this.tokenUtils = tokenUtils;
     }
 
     public Map<String, Boolean> hentFeatureToggles(List<String> features) {

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/persondata/Adressebeskyttelse.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/persondata/Adressebeskyttelse.java
@@ -4,5 +4,6 @@ import lombok.Value;
 
 @Value
 public class Adressebeskyttelse {
+    public static final Adressebeskyttelse INGEN_BESKYTTELSE = new Adressebeskyttelse("");
     private final String gradering;
 }

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/persondata/HentPerson.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/persondata/HentPerson.java
@@ -5,4 +5,5 @@ import lombok.Value;
 @Value
 public class HentPerson {
     private final Adressebeskyttelse[] adressebeskyttelse;
+    private final Navn[] navn;
 }

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/persondata/Navn.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/persondata/Navn.java
@@ -1,0 +1,11 @@
+package no.nav.tag.tiltaksgjennomforing.persondata;
+
+import lombok.Value;
+
+@Value
+public class Navn {
+    public static final Navn TOMT_NAVN = new Navn("", "", "");
+    private final String fornavn;
+    private final String mellomnavn;
+    private final String etternavn;
+}

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/persondata/NavnFormaterer.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/persondata/NavnFormaterer.java
@@ -1,0 +1,29 @@
+package no.nav.tag.tiltaksgjennomforing.persondata;
+
+import org.apache.commons.text.WordUtils;
+import org.springframework.util.StringUtils;
+
+public class NavnFormaterer {
+    private final Navn navn;
+
+    public NavnFormaterer(Navn navn) {
+        this.navn = navn;
+    }
+
+    public String getEtternavn() {
+        return storeBokstaver(navn.getEtternavn());
+    }
+
+
+    public String getFornavn() {
+        var fornavnOgMellomnavn = navn.getFornavn();
+        if (StringUtils.hasLength(navn.getMellomnavn())) {
+            fornavnOgMellomnavn += " " + navn.getMellomnavn();
+        }
+        return storeBokstaver(fornavnOgMellomnavn);
+    }
+
+    private static String storeBokstaver(String navn) {
+        return WordUtils.capitalizeFully(navn, '-', ' ');
+    }
+}

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/persondata/NavnFormaterer.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/persondata/NavnFormaterer.java
@@ -11,19 +11,18 @@ public class NavnFormaterer {
     }
 
     public String getEtternavn() {
-        return storeBokstaver(navn.getEtternavn());
+        return storeForbokstaver(navn.getEtternavn());
     }
 
-
     public String getFornavn() {
-        var fornavnOgMellomnavn = navn.getFornavn();
+        String fornavnOgMellomnavn = navn.getFornavn();
         if (StringUtils.hasLength(navn.getMellomnavn())) {
             fornavnOgMellomnavn += " " + navn.getMellomnavn();
         }
-        return storeBokstaver(fornavnOgMellomnavn);
+        return storeForbokstaver(fornavnOgMellomnavn);
     }
 
-    private static String storeBokstaver(String navn) {
+    private static String storeForbokstaver(String navn) {
         return WordUtils.capitalizeFully(navn, '-', ' ');
     }
 }

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/persondata/PdlRequest.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/persondata/PdlRequest.java
@@ -1,0 +1,9 @@
+package no.nav.tag.tiltaksgjennomforing.persondata;
+
+import lombok.Value;
+
+@Value
+public class PdlRequest {
+    private final String query;
+    private final Variables variables;
+}

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/persondata/PdlRespons.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/persondata/PdlRespons.java
@@ -3,6 +3,6 @@ package no.nav.tag.tiltaksgjennomforing.persondata;
 import lombok.Value;
 
 @Value
-public class PdlPerson {
+public class PdlRespons {
     private final Data data;
 }

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/persondata/PersondataService.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/persondata/PersondataService.java
@@ -1,12 +1,19 @@
 package no.nav.tag.tiltaksgjennomforing.persondata;
 
 import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import no.nav.tag.tiltaksgjennomforing.avtale.Fnr;
 import no.nav.tag.tiltaksgjennomforing.exceptions.TilgangskontrollException;
 import no.nav.tag.tiltaksgjennomforing.infrastruktur.sts.STSClient;
-import org.springframework.http.*;
+import org.apache.commons.io.Charsets;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.Resource;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
+import org.springframework.util.StreamUtils;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 
@@ -18,48 +25,68 @@ public class PersondataService {
     private final STSClient stsClient;
     private final PersondataProperties persondataProperties;
 
-    private static String createQuery(Fnr fnr) {
-        return String.format("{\"query\" : \"query{ hentPerson( ident: \\\"%s\\\") {adressebeskyttelse {gradering} } }\"}", fnr.asString());
+    @Value("classpath:pdl/hentPerson.adressebeskyttelse.graphql")
+    private Resource adressebeskyttelseQueryResource;
+
+    @Value("classpath:pdl/hentPerson.navn.graphql")
+    private Resource navnQueryResource;
+
+    @SneakyThrows
+    private static String resourceAsString(Resource adressebeskyttelseQuery) {
+        String filinnhold = StreamUtils.copyToString(adressebeskyttelseQuery.getInputStream(), Charsets.UTF_8);
+        return filinnhold.replaceAll("\\s+", " ");
     }
 
-    public void sjekkGradering(Fnr fnr) {
-        String gradering = hentGradering(fnr).getGradering();
-        if ("FORTROLIG".equals(gradering) || "STRENGT_FORTROLIG".equals(gradering)) {
-            throw new TilgangskontrollException("Du har ikke tilgang til deltaker");
-        }
+    public Adressebeskyttelse hentAdressebeskyttelse(Fnr fnr) {
+        PdlRequest pdlRequest = new PdlRequest(resourceAsString(adressebeskyttelseQueryResource), new Variables(fnr.asString()));
+        return hentAdressebeskyttelseFraPdlRespons(utførKallTilPdl(pdlRequest));
     }
 
-    private HttpEntity<String> createRequestEntity(Fnr fnr) {
+    private HttpEntity<String> createRequestEntity(PdlRequest pdlRequest) {
         String stsToken = stsClient.hentSTSToken().getAccessToken();
         HttpHeaders headers = new HttpHeaders();
         headers.setBearerAuth(stsToken);
         headers.setContentType(MediaType.APPLICATION_JSON);
         headers.set("Tema", "GEN");
         headers.set("Nav-Consumer-Token", "Bearer " + stsToken);
-        return new HttpEntity<>(createQuery(fnr), headers);
+        return new HttpEntity(pdlRequest, headers);
     }
 
-    private Adressebeskyttelse hentGraderingFraPdlRespons(PdlPerson pdlPerson) {
-        if (pdlPerson.getData().getHentPerson() == null) {
-            // Person finnes ikke
-            return new Adressebeskyttelse("");
-        } else if (pdlPerson.getData().getHentPerson().getAdressebeskyttelse().length == 0) {
-            // Ugradert
-            return new Adressebeskyttelse("");
-        }
-        else {
-            return pdlPerson.getData().getHentPerson().getAdressebeskyttelse()[0];
-        }
-    }
-
-    Adressebeskyttelse hentGradering(Fnr fnr) {
+    private static Adressebeskyttelse hentAdressebeskyttelseFraPdlRespons(PdlRespons pdlRespons) {
         try {
-            PdlPerson pdlPerson = restTemplate.postForObject(persondataProperties.getUri(), createRequestEntity(fnr), PdlPerson.class);
-            return hentGraderingFraPdlRespons(pdlPerson);
+            return pdlRespons.getData().getHentPerson().getAdressebeskyttelse()[0];
+        } catch (NullPointerException | ArrayIndexOutOfBoundsException e) {
+            return Adressebeskyttelse.INGEN_BESKYTTELSE;
+        }
+    }
+
+    private static Navn hentNavnFraPdlRespons(PdlRespons pdlRespons) {
+        try {
+            return pdlRespons.getData().getHentPerson().getNavn()[0];
+        } catch (NullPointerException | ArrayIndexOutOfBoundsException e) {
+            return Navn.TOMT_NAVN;
+        }
+    }
+
+    private PdlRespons utførKallTilPdl(PdlRequest pdlRequest) {
+        try {
+            return restTemplate.postForObject(persondataProperties.getUri(), createRequestEntity(pdlRequest), PdlRespons.class);
         } catch (RestClientException exception) {
             stsClient.evictToken();
             log.error("Feil fra PDL med request-url: " + persondataProperties.getUri(), exception);
             throw exception;
+        }
+    }
+
+    public Navn hentNavn(Fnr fnr) {
+        PdlRequest pdlRequest = new PdlRequest(resourceAsString(navnQueryResource), new Variables(fnr.asString()));
+        return hentNavnFraPdlRespons(utførKallTilPdl(pdlRequest));
+    }
+
+    public void sjekkGradering(Fnr fnr) {
+        String gradering = hentAdressebeskyttelse(fnr).getGradering();
+        if ("FORTROLIG".equals(gradering) || "STRENGT_FORTROLIG".equals(gradering)) {
+            throw new TilgangskontrollException("Du har ikke tilgang til deltaker");
         }
     }
 }

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/persondata/Variables.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/persondata/Variables.java
@@ -1,0 +1,8 @@
+package no.nav.tag.tiltaksgjennomforing.persondata;
+
+import lombok.Value;
+
+@Value
+public class Variables {
+    private final String ident;
+}

--- a/src/main/resources/pdl/hentPerson.adressebeskyttelse.graphql
+++ b/src/main/resources/pdl/hentPerson.adressebeskyttelse.graphql
@@ -1,0 +1,7 @@
+query($ident: ID!) {
+    hentPerson(ident: $ident) {
+        adressebeskyttelse {
+			gradering
+		}
+    }
+}

--- a/src/main/resources/pdl/hentPerson.navn.graphql
+++ b/src/main/resources/pdl/hentPerson.navn.graphql
@@ -1,0 +1,9 @@
+query($ident: ID!) {
+  hentPerson(ident: $ident) {
+	  navn {
+		  fornavn
+		  mellomnavn
+		  etternavn
+	  }
+  }
+}

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleControllerTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleControllerTest.java
@@ -11,6 +11,7 @@ import no.nav.tag.tiltaksgjennomforing.exceptions.RessursFinnesIkkeException;
 import no.nav.tag.tiltaksgjennomforing.exceptions.TilgangskontrollException;
 import no.nav.tag.tiltaksgjennomforing.orgenhet.EregService;
 import no.nav.tag.tiltaksgjennomforing.orgenhet.Organisasjon;
+import no.nav.tag.tiltaksgjennomforing.persondata.Navn;
 import no.nav.tag.tiltaksgjennomforing.persondata.PersondataService;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -156,6 +157,7 @@ public class AvtaleControllerTest {
         vaerInnloggetSom(innloggetNavAnsatt(TestData.enVeileder(avtale), tilgangskontrollService));
         when(avtaleRepository.save(any(Avtale.class))).thenReturn(avtale);
         when(eregService.hentVirksomhet(avtale.getBedriftNr())).thenReturn(new Organisasjon(avtale.getBedriftNr(), avtale.getBedriftNavn()));
+        when(persondataService.hentNavn(any())).thenReturn(Navn.TOMT_NAVN);
         ResponseEntity svar = avtaleController.opprettAvtale(new OpprettAvtale(avtale.getDeltakerFnr(), avtale.getBedriftNr(), Tiltakstype.ARBEIDSTRENING));
         assertThat(svar.getStatusCode()).isEqualTo(HttpStatus.CREATED);
         assertThat(svar.getHeaders().getLocation().getPath()).isEqualTo("/avtaler/" + avtale.getId());

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/persondata/NavnFormatererTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/persondata/NavnFormatererTest.java
@@ -1,0 +1,28 @@
+package no.nav.tag.tiltaksgjennomforing.persondata;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class NavnFormatererTest {
+    @Test
+    void bare_fornavn_og_etternavn() {
+        NavnFormaterer navnFormaterer = new NavnFormaterer(new Navn("FOO", null, "BAR"));
+        assertThat(navnFormaterer.getFornavn()).isEqualTo("Foo");
+        assertThat(navnFormaterer.getEtternavn()).isEqualTo("Bar");
+    }
+
+    @Test
+    void fornavn_mellomnavn_og_etternavn() {
+        NavnFormaterer navnFormaterer = new NavnFormaterer(new Navn("FOO", "BAR", "BAZ"));
+        assertThat(navnFormaterer.getFornavn()).isEqualTo("Foo Bar");
+        assertThat(navnFormaterer.getEtternavn()).isEqualTo("Baz");
+    }
+
+    @Test
+    void navn_med_bindestrek() {
+        NavnFormaterer navnFormaterer = new NavnFormaterer(new Navn("FOO-BAR", "BARNEY BOO", "BAZZ-Y BAG"));
+        assertThat(navnFormaterer.getFornavn()).isEqualTo("Foo-Bar Barney Boo");
+        assertThat(navnFormaterer.getEtternavn()).isEqualTo("Bazz-Y Bag");
+    }
+}

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/persondata/PersondataServiceTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/persondata/PersondataServiceTest.java
@@ -20,77 +20,97 @@ public class PersondataServiceTest {
     @Autowired
     private PersondataService persondataService;
 
-    private Fnr strengtFortroligPerson = new Fnr("16053900422");
-    private Fnr fortroligPerson = new Fnr("26067114433");
-    private Fnr ugradertPerson = new Fnr("00000000000");
-    private Fnr getUgradertPersonTomResponse = new Fnr("27030960020");
-    private Fnr uspesifisertGradertPerson = new Fnr("18076641842");
-    private Fnr personFinnesIkke = new Fnr("24080687881");
-    private Fnr personForResponsUtenData = new Fnr("23097010706");
+    private static final Fnr STRENGT_FORTROLIG_PERSON = new Fnr("16053900422");
+    private static final Fnr FORTROLIG_PERSON = new Fnr("26067114433");
+    private static final Fnr UGRADERT_PERSON = new Fnr("00000000000");
+    private static final Fnr UGRADERT_PERSON_TOM_RESPONSE = new Fnr("27030960020");
+    private static final Fnr USPESIFISERT_GRADERT_PERSON = new Fnr("18076641842");
+    private static final Fnr PERSON_FINNES_IKKE = new Fnr("24080687881");
+    private static final Fnr PERSON_FOR_RESPONS_UTEN_DATA = new Fnr("23097010706");
+    private static final Fnr DONALD_DUCK = new Fnr("00000000000");
 
     @Test
     public void hentGradering__returnerer_strengt_fortrolig_person() {
-        Adressebeskyttelse adressebeskyttelse = persondataService.hentGradering(strengtFortroligPerson);
+        Adressebeskyttelse adressebeskyttelse = persondataService.hentAdressebeskyttelse(STRENGT_FORTROLIG_PERSON);
         assertThat(adressebeskyttelse.getGradering()).isEqualTo("STRENGT_FORTROLIG");
     }
 
     @Test
     public void hentGradering__returnerer_fortrolig_person() {
-        Adressebeskyttelse adressebeskyttelse = persondataService.hentGradering(fortroligPerson);
+        Adressebeskyttelse adressebeskyttelse = persondataService.hentAdressebeskyttelse(FORTROLIG_PERSON);
         assertThat(adressebeskyttelse.getGradering()).isEqualTo("FORTROLIG");
     }
 
     @Test
     public void hentGradering__returnerer_ugradert_person() {
-        Adressebeskyttelse adressebeskyttelse = persondataService.hentGradering(new Fnr("00000000000"));
+        Adressebeskyttelse adressebeskyttelse = persondataService.hentAdressebeskyttelse(UGRADERT_PERSON);
         assertThat(adressebeskyttelse.getGradering()).isEqualTo("UGRADERT");
     }
 
     @Test
     public void hentGradering__returnerer_tom_gradering() {
-        Adressebeskyttelse adressebeskyttelse = persondataService.hentGradering(new Fnr("18076641842"));
-        assertThat(adressebeskyttelse.getGradering()).isBlank();
+        Adressebeskyttelse adressebeskyttelse = persondataService.hentAdressebeskyttelse(USPESIFISERT_GRADERT_PERSON);
+        assertThat(adressebeskyttelse).isEqualTo(Adressebeskyttelse.INGEN_BESKYTTELSE);
     }
 
     @Test
     public void hentGradering__person_finnes_ikke_er_ok() {
-        Adressebeskyttelse adressebeskyttelse = persondataService.hentGradering(personFinnesIkke);
-        assertThat(adressebeskyttelse.getGradering().equals("null"));
+        Adressebeskyttelse adressebeskyttelse = persondataService.hentAdressebeskyttelse(PERSON_FINNES_IKKE);
+        assertThat(adressebeskyttelse).isEqualTo(Adressebeskyttelse.INGEN_BESKYTTELSE);
     }
 
     @Test
     public void hentGradering__returnerer_ugradert_tom_gradering() {
-        Adressebeskyttelse adressebeskyttelse = persondataService.hentGradering(getUgradertPersonTomResponse);
-        assertThat(adressebeskyttelse.getGradering().equals(""));
+        Adressebeskyttelse adressebeskyttelse = persondataService.hentAdressebeskyttelse(UGRADERT_PERSON_TOM_RESPONSE);
+        assertThat(adressebeskyttelse).isEqualTo(Adressebeskyttelse.INGEN_BESKYTTELSE);
     }
 
-    @Test(expected = NullPointerException.class)
-    public void hentGradering_person_far_respons_uten_Data() {
-        Adressebeskyttelse adressebeskyttelse = persondataService.hentGradering(personForResponsUtenData);
+    @Test
+    public void hentGradering__person_får_respons_uten_data() {
+        Adressebeskyttelse adressebeskyttelse = persondataService.hentAdressebeskyttelse(PERSON_FOR_RESPONS_UTEN_DATA);
+        assertThat(adressebeskyttelse).isEqualTo(Adressebeskyttelse.INGEN_BESKYTTELSE);
+    }
+
+    @Test
+    public void hentNavn__tomt_navn_hvis_person_ikke_finens() {
+        Navn navn = persondataService.hentNavn(PERSON_FINNES_IKKE);
+        assertThat(navn).isEqualTo(Navn.TOMT_NAVN);
+    }
+
+    @Test
+    public void hentNavn__navn_hvis_person_finnes() {
+        Navn navn = persondataService.hentNavn(DONALD_DUCK);
+        assertThat(navn).isEqualTo(new Navn("Donald", null, "Duck"));
     }
 
     @Test(expected = TilgangskontrollException.class)
-    public void sjekkGradering__skal_kaste_feile__strengt_fortrolig() { persondataService.sjekkGradering(strengtFortroligPerson); }
+    public void sjekkGradering__skal_kaste_feile__strengt_fortrolig() {
+        persondataService.sjekkGradering(STRENGT_FORTROLIG_PERSON);
+    }
 
     @Test(expected = TilgangskontrollException.class)
     public void sjekkGradering__skal_kaste_feile__fortrolig() {
-        persondataService.sjekkGradering(fortroligPerson);
+        persondataService.sjekkGradering(FORTROLIG_PERSON);
     }
 
     @Test
     public void sjekkGradering__skal_ikke_kaste_feil_ugradert() {
-        persondataService.sjekkGradering(ugradertPerson);
+        persondataService.sjekkGradering(UGRADERT_PERSON);
     }
 
     @Test
-    public void sjekkGradering_skal_ikke_kaste_feil_ugradertTom() { persondataService.sjekkGradering(getUgradertPersonTomResponse); }
+    public void sjekkGradering_skal_ikke_kaste_feil_ugradertTom() {
+        persondataService.sjekkGradering(UGRADERT_PERSON_TOM_RESPONSE);
+    }
 
     @Test
-    public void sjekkGradering__skal_ikke_kaste_feil_uspesifisert_gradering() { persondataService.sjekkGradering(uspesifisertGradertPerson); }
+    public void sjekkGradering__skal_ikke_kaste_feil_uspesifisert_gradering() {
+        persondataService.sjekkGradering(USPESIFISERT_GRADERT_PERSON);
+    }
 
     @Test
     public void sjekkGradering_person_finnes_ikke_er_ok() {
-        persondataService.sjekkGradering(personFinnesIkke);
+        persondataService.sjekkGradering(PERSON_FINNES_IKKE);
     }
 
 }

--- a/src/test/resources/mappings/pdl_gradering.json
+++ b/src/test/resources/mappings/pdl_gradering.json
@@ -24,7 +24,7 @@
           }
         },
         "bodyPatterns" : [ {
-          "equalToJson" : "{\"query\" : \"query{ hentPerson( ident: \\\"16053900422\\\") {adressebeskyttelse {gradering} } }\"}"
+          "equalToJson" : {"query" : "query($ident: ID!) { hentPerson(ident: $ident) { adressebeskyttelse { gradering } } }", "variables":  {"ident": "16053900422"}}
         } ]
       },
       "response": {
@@ -46,7 +46,7 @@
           }
         },
         "bodyPatterns" : [ {
-          "equalToJson" : "{\"query\" : \"query{ hentPerson( ident: \\\"00000000000\\\") {adressebeskyttelse {gradering} } }\" }"
+          "equalToJson" : {"query" : "query($ident: ID!) { hentPerson(ident: $ident) { adressebeskyttelse { gradering } } }", "variables":  {"ident": "00000000000"}}
         } ]
       },
       "response": {
@@ -68,7 +68,7 @@
           }
         },
         "bodyPatterns" : [ {
-          "equalToJson" : "{\"query\" : \"query{ hentPerson( ident: \\\"26067114433\\\") {adressebeskyttelse {gradering} } }\" }"
+          "equalToJson" : {"query" : "query($ident: ID!) { hentPerson(ident: $ident) { adressebeskyttelse { gradering } } }", "variables":  {"ident": "26067114433"}}
         } ]
       },
       "response": {
@@ -90,7 +90,7 @@
           }
         },
         "bodyPatterns" : [ {
-          "equalToJson" : "{\"query\" : \"query{ hentPerson( ident: \\\"18076641842\\\") {adressebeskyttelse {gradering} } }\" }"
+          "equalToJson" : {"query" : "query($ident: ID!) { hentPerson(ident: $ident) { adressebeskyttelse { gradering } } }", "variables":  {"ident": "18076641842"}}
         } ]
       },
       "response": {
@@ -112,7 +112,7 @@
           }
         },
         "bodyPatterns" : [ {
-          "equalToJson" : "{\"query\" : \"query{ hentPerson( ident: \\\"23097010706\\\") {adressebeskyttelse {gradering} } }\" }"
+          "equalToJson" : {"query" : "query($ident: ID!) { hentPerson(ident: $ident) { adressebeskyttelse { gradering } } }", "variables":  {"ident": "23097010706"}}
         } ]
       },
       "response": {
@@ -134,12 +134,12 @@
           }
         },
         "bodyPatterns" : [ {
-          "equalToJson" : "{\"query\" : \"query{ hentPerson( ident: \\\"00000000000\\\") {adressebeskyttelse {gradering} } }\" }"
+          "equalToJson" : {"query" : "query($ident: ID!) { hentPerson(ident: $ident) { navn { fornavn mellomnavn etternavn } } }", "variables":  {"ident": "00000000000"}}
         } ]
       },
       "response": {
         "status": 200,
-        "body": "{\"data\": {\"hentPerson\": {\"adressebeskyttelse\": [{\"gradering\": \"UGRADERT\"}]}}}",
+        "body": "{\"data\": {\"hentPerson\": {\"navn\": [{\"fornavn\": \"Donald\", \"etternavn\": \"Duck\"}]}}}",
         "headers": {
           "Content-Type": "application/json"
         }


### PR DESCRIPTION
Henter navn fra PDL og setter `deltakerFornavn` og `deltakerEtternavn` når avtalen opprettes.

Fra PDL kommer alt i store bokstaver. Jeg formaterer navnet med `WordUtils` fra Apache Commons, som legger på stor bokstav etter mellomrom eller bindestrek.