### PR TITLE
TAG-1046 Handtere Altinn-feil

### DIFF
--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/altinntilgangsstyring/AltinnTilgangsstyringService.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/altinntilgangsstyring/AltinnTilgangsstyringService.java
@@ -2,6 +2,7 @@ package no.nav.tag.tiltaksgjennomforing.autorisasjon.altinntilgangsstyring;
 
 import lombok.extern.slf4j.Slf4j;
 import no.nav.tag.tiltaksgjennomforing.avtale.Identifikator;
+import no.nav.tag.tiltaksgjennomforing.exceptions.TiltaksgjennomforingException;
 import no.nav.tag.tiltaksgjennomforing.orgenhet.Organisasjon;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClientException;
@@ -49,8 +50,8 @@ public class AltinnTilgangsstyringService {
             AltinnOrganisasjon[] altinnOrganisasjoner = restTemplate.getForObject(uri, AltinnOrganisasjon[].class);
             return konverterTilDomeneObjekter(altinnOrganisasjoner);
         } catch (RestClientException exception) {
-            log.warn("Feil ved kall mot Altinn. Bedrifter som innlogget bruker kan representere settes til tom liste.", exception);
-            return Collections.emptyList();
+            log.warn("Feil ved kall mot Altinn.", exception);
+            throw new TiltaksgjennomforingException("Feil ved oppslag mot Altinn. Forsøk å laste siden på nytt");
         }
     }
 }

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/altinntilgangsstyring/AltinnTilgangsstyringService.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/altinntilgangsstyring/AltinnTilgangsstyringService.java
@@ -51,7 +51,7 @@ public class AltinnTilgangsstyringService {
             return konverterTilDomeneObjekter(altinnOrganisasjoner);
         } catch (RestClientException exception) {
             log.warn("Feil ved kall mot Altinn.", exception);
-            throw new TiltaksgjennomforingException("Feil ved oppslag mot Altinn. Forsøk å laste siden på nytt");
+            throw new TiltaksgjennomforingException("Det har skjedd e n feil ved oppslag mot Altinn. Forsøk å laste siden på nytt");
         }
     }
 }

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/altinntilgangsstyring/AltinnTilgangsstyringService.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/altinntilgangsstyring/AltinnTilgangsstyringService.java
@@ -51,7 +51,7 @@ public class AltinnTilgangsstyringService {
             return konverterTilDomeneObjekter(altinnOrganisasjoner);
         } catch (RestClientException exception) {
             log.warn("Feil ved kall mot Altinn.", exception);
-            throw new TiltaksgjennomforingException("Det har skjedd e n feil ved oppslag mot Altinn. Forsøk å laste siden på nytt");
+            throw new TiltaksgjennomforingException("Det har skjedd en feil ved oppslag mot Altinn. Forsøk å laste siden på nytt");
         }
     }
 }

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleController.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleController.java
@@ -18,6 +18,7 @@ import org.springframework.web.bind.annotation.*;
 import java.net.URI;
 import java.time.Instant;
 import java.util.Comparator;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
@@ -46,8 +47,8 @@ public class AvtaleController {
     }
 
     @GetMapping
-    public Iterable<Avtale> hentAlleAvtalerInnloggetBrukerHarTilgangTil(AvtalePredicate queryParametre) {
-        InnloggetBruker<?> bruker = innloggingService.hentInnloggetBruker();
+    public Iterable<Avtale> hentAlleAvtalerInnloggetBrukerHarTilgangTil(AvtalePredicate queryParametre, @CookieValue("innlogget-part") Optional<Avtalerolle> innloggetPart) {
+        InnloggetBruker<?> bruker = innloggingService.hentInnloggetBruker(innloggetPart);
         return avtaleRepository.findAll().stream()
                 .filter(queryParametre)
                 .filter(bruker::harLeseTilgang)
@@ -70,8 +71,8 @@ public class AvtaleController {
     }
 
     @GetMapping("/{avtaleId}/status-detaljer")
-    public AvtaleStatusDetaljer hentAvtaleStatusDetaljer(@PathVariable("avtaleId") UUID avtaleId) {
-        InnloggetBruker innloggetBruker = innloggingService.hentInnloggetBruker();
+    public AvtaleStatusDetaljer hentAvtaleStatusDetaljer(@PathVariable("avtaleId") UUID avtaleId, @CookieValue("innlogget-part") Optional<Avtalerolle> innloggetPart) {
+        InnloggetBruker innloggetBruker = innloggingService.hentInnloggetBruker(innloggetPart);
         Avtale avtale = avtaleRepository.findById(avtaleId).orElseThrow(RessursFinnesIkkeException::new);
         Avtalepart avtalepart = innloggetBruker.avtalepart(avtale);
         return avtalepart.statusDetaljerForAvtale();
@@ -81,8 +82,8 @@ public class AvtaleController {
     @Transactional
     public ResponseEntity<?> endreAvtale(@PathVariable("avtaleId") UUID avtaleId,
                                          @RequestHeader(HttpHeaders.IF_UNMODIFIED_SINCE) Instant sistEndret,
-                                         @RequestBody EndreAvtale endreAvtale) {
-        InnloggetBruker<?> innloggetBruker = innloggingService.hentInnloggetBruker();
+                                         @RequestBody EndreAvtale endreAvtale, Optional<Avtalerolle> innloggetPart) {
+        InnloggetBruker<?> innloggetBruker = innloggingService.hentInnloggetBruker(innloggetPart);
         Avtale avtale = avtaleRepository.findById(avtaleId)
                 .orElseThrow(RessursFinnesIkkeException::new);
         innloggetBruker.sjekkSkriveTilgang(avtale);
@@ -93,8 +94,8 @@ public class AvtaleController {
     }
 
     @GetMapping("/{avtaleId}/rolle")
-    public Avtalerolle hentRolle(@PathVariable("avtaleId") UUID avtaleId) {
-        InnloggetBruker<?> innloggetBruker = innloggingService.hentInnloggetBruker();
+    public Avtalerolle hentRolle(@PathVariable("avtaleId") UUID avtaleId, Optional<Avtalerolle> innloggetPart) {
+        InnloggetBruker<?> innloggetBruker = innloggingService.hentInnloggetBruker(innloggetPart);
         Avtale avtale = avtaleRepository.findById(avtaleId).orElseThrow(RessursFinnesIkkeException::new);
         innloggetBruker.sjekkLeseTilgang(avtale);
         Avtalepart<?> avtalepart = innloggetBruker.avtalepart(avtale);
@@ -103,8 +104,8 @@ public class AvtaleController {
 
     @PostMapping("/{avtaleId}/opphev-godkjenninger")
     @Transactional
-    public void opphevGodkjenninger(@PathVariable("avtaleId") UUID avtaleId) {
-        InnloggetBruker<?> innloggetBruker = innloggingService.hentInnloggetBruker();
+    public void opphevGodkjenninger(@PathVariable("avtaleId") UUID avtaleId, Optional<Avtalerolle> innloggetPart) {
+        InnloggetBruker<?> innloggetBruker = innloggingService.hentInnloggetBruker(innloggetPart);
         Avtale avtale = avtaleRepository.findById(avtaleId).orElseThrow(RessursFinnesIkkeException::new);
         innloggetBruker.sjekkSkriveTilgang(avtale);
         Avtalepart<?> avtalepart = innloggetBruker.avtalepart(avtale);
@@ -114,8 +115,8 @@ public class AvtaleController {
 
     @PostMapping("/{avtaleId}/godkjenn")
     @Transactional
-    public void godkjenn(@PathVariable("avtaleId") UUID avtaleId, @RequestHeader(HttpHeaders.IF_UNMODIFIED_SINCE) Instant sistEndret) {
-        InnloggetBruker<?> innloggetBruker = innloggingService.hentInnloggetBruker();
+    public void godkjenn(@PathVariable("avtaleId") UUID avtaleId, @RequestHeader(HttpHeaders.IF_UNMODIFIED_SINCE) Instant sistEndret, Optional<Avtalerolle> innloggetPart) {
+        InnloggetBruker<?> innloggetBruker = innloggingService.hentInnloggetBruker(innloggetPart);
         Avtale avtale = avtaleRepository.findById(avtaleId).orElseThrow(RessursFinnesIkkeException::new);
         innloggetBruker.sjekkSkriveTilgang(avtale);
         Avtalepart<?> avtalepart = innloggetBruker.avtalepart(avtale);
@@ -125,8 +126,8 @@ public class AvtaleController {
 
     @PostMapping("/{avtaleId}/godkjenn-paa-vegne-av")
     @Transactional
-    public void godkjennPaVegneAv(@PathVariable("avtaleId") UUID avtaleId, @RequestBody GodkjentPaVegneGrunn paVegneAvGrunn) {
-        InnloggetBruker<?> innloggetBruker = innloggingService.hentInnloggetBruker();
+    public void godkjennPaVegneAv(@PathVariable("avtaleId") UUID avtaleId, @RequestBody GodkjentPaVegneGrunn paVegneAvGrunn, Optional<Avtalerolle> innloggetPart) {
+        InnloggetBruker<?> innloggetBruker = innloggingService.hentInnloggetBruker(innloggetPart);
         Avtale avtale = avtaleRepository.findById(avtaleId).orElseThrow(RessursFinnesIkkeException::new);
         innloggetBruker.sjekkSkriveTilgang(avtale);
         Avtalepart<?> avtalepart = innloggetBruker.avtalepart(avtale);
@@ -146,8 +147,8 @@ public class AvtaleController {
 
     @PostMapping("/{avtaleId}/laas-opp")
     @Transactional
-    public void laasOpp(@PathVariable("avtaleId") UUID avtaleId) {
-        InnloggetBruker<?> innloggetBruker = innloggingService.hentInnloggetBruker();
+    public void laasOpp(@PathVariable("avtaleId") UUID avtaleId, Optional<Avtalerolle> innloggetPart) {
+        InnloggetBruker<?> innloggetBruker = innloggingService.hentInnloggetBruker(innloggetPart);
         Avtale avtale = avtaleRepository.findById(avtaleId).orElseThrow(RessursFinnesIkkeException::new);
         innloggetBruker.sjekkSkriveTilgang(avtale);
         Avtalepart<?> avtalepart = innloggetBruker.avtalepart(avtale);

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/AltinnTilgangsstyringServiceTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/AltinnTilgangsstyringServiceTest.java
@@ -47,16 +47,14 @@ public class AltinnTilgangsstyringServiceTest {
     }
 
     @Test (expected = TiltaksgjennomforingException.class)
-    public void hentOrganisasjoner__ugyldig_fnr_tom_liste() {
+    public void hentOrganisasjoner__ugyldig_fnr_skal_kaste_feil() {
         List<Organisasjon> organisasjoner = altinnTilgangsstyringService.hentOrganisasjoner(TestData.enIdentifikator());
-        assertThat(organisasjoner).hasSize(0);
     }
 
     @Test (expected = TiltaksgjennomforingException.class)
-    public void hentOrganisasjoner__feilkonfigurasjon_tom_liste() {
+    public void hentOrganisasjoner__feilkonfigurasjon_skal_kaste_feil() {
         AltinnTilgangsstyringProperties altinnTilgangsstyringProperties = new AltinnTilgangsstyringProperties();
         altinnTilgangsstyringProperties.setUri(URI.create("http://foobar"));
         List<Organisasjon> organisasjoner = new AltinnTilgangsstyringService(altinnTilgangsstyringProperties).hentOrganisasjoner(TestData.enIdentifikator());
-        assertThat(organisasjoner).hasSize(0);
     }
 }

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/AltinnTilgangsstyringServiceTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/AltinnTilgangsstyringServiceTest.java
@@ -3,6 +3,7 @@ package no.nav.tag.tiltaksgjennomforing.autorisasjon;
 import no.nav.tag.tiltaksgjennomforing.TestData;
 import no.nav.tag.tiltaksgjennomforing.avtale.BedriftNr;
 import no.nav.tag.tiltaksgjennomforing.avtale.Fnr;
+import no.nav.tag.tiltaksgjennomforing.exceptions.TiltaksgjennomforingException;
 import no.nav.tag.tiltaksgjennomforing.orgenhet.Organisasjon;
 import no.nav.tag.tiltaksgjennomforing.autorisasjon.altinntilgangsstyring.AltinnTilgangsstyringService;
 import no.nav.tag.tiltaksgjennomforing.autorisasjon.altinntilgangsstyring.AltinnTilgangsstyringProperties;
@@ -45,13 +46,13 @@ public class AltinnTilgangsstyringServiceTest {
         assertThat(organisasjoner).hasSize(0);
     }
 
-    @Test
+    @Test (expected = TiltaksgjennomforingException.class)
     public void hentOrganisasjoner__ugyldig_fnr_tom_liste() {
         List<Organisasjon> organisasjoner = altinnTilgangsstyringService.hentOrganisasjoner(TestData.enIdentifikator());
         assertThat(organisasjoner).hasSize(0);
     }
 
-    @Test
+    @Test (expected = TiltaksgjennomforingException.class)
     public void hentOrganisasjoner__feilkonfigurasjon_tom_liste() {
         AltinnTilgangsstyringProperties altinnTilgangsstyringProperties = new AltinnTilgangsstyringProperties();
         altinnTilgangsstyringProperties.setUri(URI.create("http://foobar"));

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/InnloggingServiceTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/InnloggingServiceTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.*;
 import java.util.List;
 import java.util.Optional;
 
+import no.nav.tag.tiltaksgjennomforing.avtale.Avtalerolle;
 import no.nav.tag.tiltaksgjennomforing.avtale.BedriftNr;
 import no.nav.tag.tiltaksgjennomforing.avtale.Fnr;
 import no.nav.tag.tiltaksgjennomforing.TestData;
@@ -44,13 +45,13 @@ public class InnloggingServiceTest {
     }
     
     @Test
-    public void hentInnloggetBruker__selvbetjeningbruker_skal_hente_organisasjoner() {
+    public void hentInnloggetBruker__selvbetjeningbruker_type_arbeidsgiver_skal_hente_organisasjoner() {
         List<Organisasjon> organisasjoner = asList(new Organisasjon(new BedriftNr("111111111"), "Navn"));
         InnloggetSelvbetjeningBruker selvbetjeningBruker = new InnloggetSelvbetjeningBruker(new Fnr("11111111111"), organisasjoner);
         when(altinnTilgangsstyringService.hentOrganisasjoner(selvbetjeningBruker.getIdentifikator())).thenReturn(organisasjoner);
         vaerInnloggetSelvbetjening(selvbetjeningBruker);
         
-        assertThat(innloggingService.hentInnloggetBruker()).isEqualTo(selvbetjeningBruker);
+        assertThat(innloggingService.hentInnloggetBruker(Optional.of(Avtalerolle.ARBEIDSGIVER))).isEqualTo(selvbetjeningBruker);
         verify(altinnTilgangsstyringService).hentOrganisasjoner(selvbetjeningBruker.getIdentifikator());
     }
     

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleControllerTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleControllerTest.java
@@ -106,7 +106,7 @@ public class AvtaleControllerTest {
         vaerInnloggetSom(innloggetBruker);
         when(avtaleRepository.findAll()).thenReturn(asList(avtaleForVeilederSomSøkesEtter, avtaleForAnnenVeilder));
         when(tilgangskontrollService.harLesetilgangTilKandidat(eq(innloggetBruker), any(Fnr.class))).thenReturn(true);
-        Iterable<Avtale> avtaler = avtaleController.hentAlleAvtalerInnloggetBrukerHarTilgangTil(new AvtalePredicate().setVeilederNavIdent(veilederNavIdent));
+        Iterable<Avtale> avtaler = avtaleController.hentAlleAvtalerInnloggetBrukerHarTilgangTil(new AvtalePredicate().setVeilederNavIdent(veilederNavIdent), Optional.empty());
         assertThat(avtaler)
                 .contains(avtaleForVeilederSomSøkesEtter)
                 .doesNotContain(avtaleForAnnenVeilder);
@@ -120,7 +120,7 @@ public class AvtaleControllerTest {
         vaerInnloggetSom(innloggetBruker);
         when(avtaleRepository.findAll()).thenReturn(asList(avtaleForVeilederSomSøkesEtter));
         when(tilgangskontrollService.harLesetilgangTilKandidat(eq(innloggetBruker), any(Fnr.class))).thenReturn(false);
-        Iterable<Avtale> avtaler = avtaleController.hentAlleAvtalerInnloggetBrukerHarTilgangTil(new AvtalePredicate().setVeilederNavIdent(veilederNavIdent));
+        Iterable<Avtale> avtaler = avtaleController.hentAlleAvtalerInnloggetBrukerHarTilgangTil(new AvtalePredicate().setVeilederNavIdent(veilederNavIdent), Optional.empty());
         assertThat(avtaler).doesNotContain(avtaleForVeilederSomSøkesEtter);
     }
 
@@ -133,7 +133,7 @@ public class AvtaleControllerTest {
         vaerInnloggetSom(innloggetBruker);
         when(avtaleRepository.findAll()).thenReturn(asList(avtaleForInnloggetVeileder, avtaleForAnnenVeilder));
         when(tilgangskontrollService.harLesetilgangTilKandidat(eq(innloggetBruker), any(Fnr.class))).thenReturn(true);
-        Iterable<Avtale> avtaler = avtaleController.hentAlleAvtalerInnloggetBrukerHarTilgangTil(new AvtalePredicate().setVeilederNavIdent(innloggetVeileder));
+        Iterable<Avtale> avtaler = avtaleController.hentAlleAvtalerInnloggetBrukerHarTilgangTil(new AvtalePredicate().setVeilederNavIdent(innloggetVeileder), Optional.empty());
         assertThat(avtaler)
                 .contains(avtaleForInnloggetVeileder)
                 .doesNotContain(avtaleForAnnenVeilder);
@@ -164,7 +164,7 @@ public class AvtaleControllerTest {
         Avtale avtale = TestData.enAvtale();
         vaerInnloggetSom(innloggetNavAnsatt(TestData.enVeileder(avtale), tilgangskontrollService));
         when(avtaleRepository.findById(avtale.getId())).thenReturn(Optional.empty());
-        avtaleController.endreAvtale(avtale.getId(), avtale.getSistEndret(), TestData.ingenEndring());
+        avtaleController.endreAvtale(avtale.getId(), avtale.getSistEndret(), TestData.ingenEndring(), Optional.empty());
     }
 
     @Test
@@ -174,7 +174,7 @@ public class AvtaleControllerTest {
         when(tilgangskontrollService.harSkrivetilgangTilKandidat(any(InnloggetNavAnsatt.class), any(Fnr.class))).thenReturn(true);
         when(avtaleRepository.findById(avtale.getId())).thenReturn(Optional.of(avtale));
         when(avtaleRepository.save(avtale)).thenReturn(avtale);
-        ResponseEntity svar = avtaleController.endreAvtale(avtale.getId(), avtale.getSistEndret(), TestData.ingenEndring());
+        ResponseEntity svar = avtaleController.endreAvtale(avtale.getId(), avtale.getSistEndret(), TestData.ingenEndring(), Optional.empty());
         assertThat(svar.getStatusCode()).isEqualTo(HttpStatus.OK);
     }
 
@@ -183,7 +183,7 @@ public class AvtaleControllerTest {
         Avtale avtale = TestData.enAvtale();
         vaerInnloggetSom(TestData.enSelvbetjeningBruker());
         when(avtaleRepository.findById(avtale.getId())).thenReturn(Optional.of(avtale));
-        avtaleController.endreAvtale(avtale.getId(), avtale.getSistEndret(), TestData.ingenEndring());
+        avtaleController.endreAvtale(avtale.getId(), avtale.getSistEndret(), TestData.ingenEndring(), Optional.empty());
     }
 
     @Test
@@ -198,7 +198,7 @@ public class AvtaleControllerTest {
         alleAvtaler.addAll(lagListeMedAvtaler(avtaleUtenTilgang, 4));
         when(avtaleRepository.findAll()).thenReturn(alleAvtaler);
         List<Avtale> hentedeAvtaler = new ArrayList<>();
-        for (Avtale avtale : avtaleController.hentAlleAvtalerInnloggetBrukerHarTilgangTil(new AvtalePredicate())) {
+        for (Avtale avtale : avtaleController.hentAlleAvtalerInnloggetBrukerHarTilgangTil(new AvtalePredicate(), Optional.empty())) {
             hentedeAvtaler.add(avtale);
         }
         hentedeAvtaler.forEach(avtale -> assertThat(selvbetjeningBruker.harLeseTilgang(avtale)).isTrue());
@@ -209,7 +209,7 @@ public class AvtaleControllerTest {
     public void hentRolleSkalKasteResourceNotFoundExceptionHvisAvtaleIkkeFins() {
         Avtale avtale = TestData.enAvtale();
         when(avtaleRepository.findById(avtale.getId())).thenReturn(Optional.empty());
-        avtaleController.hentRolle(avtale.getId());
+        avtaleController.hentRolle(avtale.getId(), Optional.empty());
     }
 
     @Test(expected = TilgangskontrollException.class)
@@ -217,7 +217,7 @@ public class AvtaleControllerTest {
         Avtale avtale = TestData.enAvtale();
         vaerInnloggetSom(TestData.enNavAnsatt());
         when(avtaleRepository.findById(avtale.getId())).thenReturn(Optional.of(avtale));
-        avtaleController.hentRolle(avtale.getId());
+        avtaleController.hentRolle(avtale.getId(), Optional.empty());
     }
 
     @Test
@@ -226,7 +226,7 @@ public class AvtaleControllerTest {
         InnloggetSelvbetjeningBruker selvbetjeningBruker = TestData.innloggetSelvbetjeningBrukerUtenOrganisasjon(TestData.enDeltaker(avtale));
         vaerInnloggetSom(selvbetjeningBruker);
         when(avtaleRepository.findById(avtale.getId())).thenReturn(Optional.of(avtale));
-        Avtalerolle svar = avtaleController.hentRolle(avtale.getId());
+        Avtalerolle svar = avtaleController.hentRolle(avtale.getId(), Optional.empty());
         assertThat(svar).isEqualTo(Avtalerolle.DELTAKER);
     }
 
@@ -253,7 +253,7 @@ public class AvtaleControllerTest {
         InnloggetBruker enNavAnsatt = TestData.enNavAnsatt();
         vaerInnloggetSom(enNavAnsatt);
         when(avtaleRepository.findById(avtale.getId())).thenReturn(Optional.of(avtale));
-        AvtaleStatusDetaljer avtaleStatusDetaljer = avtaleController.hentAvtaleStatusDetaljer(avtale.getId());
+        AvtaleStatusDetaljer avtaleStatusDetaljer = avtaleController.hentAvtaleStatusDetaljer(avtale.getId(), Optional.empty());
         assertThat(avtaleStatusDetaljer.header).isEqualTo(Avtalepart.tekstHeaderAvtalePaabegynt);
         assertThat(avtaleStatusDetaljer.infoDel1).isEqualTo("");
         assertThat(avtaleStatusDetaljer.infoDel2).isEqualTo("");
@@ -265,7 +265,7 @@ public class AvtaleControllerTest {
         InnloggetBruker innloggetArbeidsgiver = TestData.innloggetSelvbetjeningBrukerMedOrganisasjon(TestData.enArbeidsgiver(avtale));
         vaerInnloggetSom(innloggetArbeidsgiver);
         when(avtaleRepository.findById(avtale.getId())).thenReturn(Optional.of(avtale));
-        AvtaleStatusDetaljer avtaleStatusDetaljer = avtaleController.hentAvtaleStatusDetaljer(avtale.getId());
+        AvtaleStatusDetaljer avtaleStatusDetaljer = avtaleController.hentAvtaleStatusDetaljer(avtale.getId(), Optional.empty());
         assertThat(avtaleStatusDetaljer.header).isEqualTo(Avtalepart.tekstHeaderAvtalePaabegynt);
         assertThat(avtaleStatusDetaljer.infoDel1).isEqualTo("");
         assertThat(avtaleStatusDetaljer.infoDel2).isEqualTo("");
@@ -279,7 +279,7 @@ public class AvtaleControllerTest {
         InnloggetBruker innloggetDeltaker = TestData.innloggetSelvbetjeningBrukerUtenOrganisasjon(TestData.enDeltaker(avtale));
         vaerInnloggetSom(innloggetDeltaker);
         when(avtaleRepository.findById(avtale.getId())).thenReturn(Optional.of(avtale));
-        AvtaleStatusDetaljer avtaleStatusDetaljer = avtaleController.hentAvtaleStatusDetaljer(avtale.getId());
+        AvtaleStatusDetaljer avtaleStatusDetaljer = avtaleController.hentAvtaleStatusDetaljer(avtale.getId(), Optional.empty());
         assertThat(avtaleStatusDetaljer.header).isEqualTo(Deltaker.tekstHeaderAvtalePaabegynt);
         assertThat(avtaleStatusDetaljer.infoDel1).isEqualTo(Deltaker.tekstAvtalePaabegynt);
         assertThat(avtaleStatusDetaljer.infoDel2).isEqualTo("");
@@ -292,7 +292,7 @@ public class AvtaleControllerTest {
         InnloggetBruker innloggetDeltaker = TestData.innloggetSelvbetjeningBrukerUtenOrganisasjon(TestData.enDeltaker(avtale));
         vaerInnloggetSom(innloggetDeltaker);
         when(avtaleRepository.findById(avtale.getId())).thenReturn(Optional.of(avtale));
-        AvtaleStatusDetaljer avtaleStatusDetaljer = avtaleController.hentAvtaleStatusDetaljer(avtale.getId());
+        AvtaleStatusDetaljer avtaleStatusDetaljer = avtaleController.hentAvtaleStatusDetaljer(avtale.getId(), Optional.empty());
         assertThat(avtaleStatusDetaljer.header).isEqualTo(Avtalepart.tekstHeaderAvtaleVenterPaaDinGodkjenning);
         assertThat(avtaleStatusDetaljer.infoDel1).isEqualTo(Deltaker.tekstAvtaleVenterPaaDinGodkjenning);
         assertThat(avtaleStatusDetaljer.infoDel2).isEqualTo(Deltaker.ekstraTekstAvtaleVenterPaaDinGodkjenning);
@@ -305,7 +305,7 @@ public class AvtaleControllerTest {
         InnloggetBruker innloggetArbeidsgiver = TestData.innloggetSelvbetjeningBrukerMedOrganisasjon(TestData.enArbeidsgiver(avtale));
         vaerInnloggetSom(innloggetArbeidsgiver);
         when(avtaleRepository.findById(avtale.getId())).thenReturn(Optional.of(avtale));
-        AvtaleStatusDetaljer avtaleStatusDetaljer = avtaleController.hentAvtaleStatusDetaljer(avtale.getId());
+        AvtaleStatusDetaljer avtaleStatusDetaljer = avtaleController.hentAvtaleStatusDetaljer(avtale.getId(), Optional.empty());
         assertThat(avtaleStatusDetaljer.header).isEqualTo(Avtalepart.tekstHeaderAvtaleVenterPaaDinGodkjenning);
         assertThat(avtaleStatusDetaljer.infoDel1).isEqualTo(Arbeidsgiver.tekstAvtaleVenterPaaDinGodkjenning);
         assertThat(avtaleStatusDetaljer.infoDel2).isEqualTo(Arbeidsgiver.ekstraTekstAvtaleVenterPaaDinGodkjenning);
@@ -316,7 +316,7 @@ public class AvtaleControllerTest {
         Avtale avtale = TestData.enAvtaleMedAltUtfylt();
         vaerInnloggetSom(innloggetNavAnsatt(TestData.enVeileder(avtale), tilgangskontrollService));
         when(avtaleRepository.findById(avtale.getId())).thenReturn(Optional.of(avtale));
-        AvtaleStatusDetaljer avtaleStatusDetaljer = avtaleController.hentAvtaleStatusDetaljer(avtale.getId());
+        AvtaleStatusDetaljer avtaleStatusDetaljer = avtaleController.hentAvtaleStatusDetaljer(avtale.getId(), Optional.empty());
         assertThat(avtaleStatusDetaljer.header).isEqualTo(Avtalepart.tekstHeaderVentAndreGodkjenning);
         assertThat(avtaleStatusDetaljer.infoDel1).isEqualTo("");
         assertThat(avtaleStatusDetaljer.infoDel2).isEqualTo("");
@@ -328,7 +328,7 @@ public class AvtaleControllerTest {
         avtale.godkjennForDeltaker(TestData.enDeltaker(avtale).getIdentifikator());
         vaerInnloggetSom(innloggetNavAnsatt(TestData.enVeileder(avtale), tilgangskontrollService));
         when(avtaleRepository.findById(avtale.getId())).thenReturn(Optional.of(avtale));
-        AvtaleStatusDetaljer avtaleStatusDetaljer = avtaleController.hentAvtaleStatusDetaljer(avtale.getId());
+        AvtaleStatusDetaljer avtaleStatusDetaljer = avtaleController.hentAvtaleStatusDetaljer(avtale.getId(), Optional.empty());
         assertThat(avtaleStatusDetaljer.header).isEqualTo(Avtalepart.tekstHeaderVentAndreGodkjenning);
         assertThat(avtaleStatusDetaljer.infoDel1).isEqualTo("");
         assertThat(avtaleStatusDetaljer.infoDel2).isEqualTo("");
@@ -342,7 +342,7 @@ public class AvtaleControllerTest {
         InnloggetBruker innloggetDeltaker = TestData.innloggetSelvbetjeningBrukerUtenOrganisasjon(TestData.enDeltaker(avtale));
         vaerInnloggetSom(innloggetDeltaker);
         when(avtaleRepository.findById(avtale.getId())).thenReturn(Optional.of(avtale));
-        AvtaleStatusDetaljer avtaleStatusDetaljer = avtaleController.hentAvtaleStatusDetaljer(avtale.getId());
+        AvtaleStatusDetaljer avtaleStatusDetaljer = avtaleController.hentAvtaleStatusDetaljer(avtale.getId(), Optional.empty());
         assertThat(avtaleStatusDetaljer.header).isEqualTo(Avtalepart.tekstHeaderVentAndreGodkjenning);
         assertThat(avtaleStatusDetaljer.infoDel1).isEqualTo("");
         assertThat(avtaleStatusDetaljer.infoDel2).isEqualTo("");
@@ -359,7 +359,7 @@ public class AvtaleControllerTest {
         avtale.setStartDato(LocalDate.now().plusWeeks(1));
         vaerInnloggetSom(TestData.enNavAnsatt());
         when(avtaleRepository.findById(avtale.getId())).thenReturn(Optional.of(avtale));
-        AvtaleStatusDetaljer avtaleStatusDetaljer = avtaleController.hentAvtaleStatusDetaljer(avtale.getId());
+        AvtaleStatusDetaljer avtaleStatusDetaljer = avtaleController.hentAvtaleStatusDetaljer(avtale.getId(), Optional.empty());
         assertThat(avtaleStatusDetaljer.header).isEqualTo(Avtalepart.tekstHeaderAvtaleErGodkjentAvAllePartner);
         assertThat(avtaleStatusDetaljer.infoDel1).isEqualTo(Avtalepart.tekstAvtaleErGodkjentAvAllePartner + avtale.getStartDato().format(Avtalepart.formatter));
         assertThat(avtaleStatusDetaljer.infoDel2).isEqualTo(Veileder.ekstraTekstAvtleErGodkjentAvAllePartner);

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleControllerTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleControllerTest.java
@@ -241,6 +241,7 @@ public class AvtaleControllerTest {
 
     private void vaerInnloggetSom(InnloggetBruker innloggetBruker) {
         when(innloggingService.hentInnloggetBruker()).thenReturn(innloggetBruker);
+        when(innloggingService.hentInnloggetBruker(any())).thenReturn(innloggetBruker);
         if (innloggetBruker instanceof InnloggetNavAnsatt) {
             when(innloggingService.hentInnloggetNavAnsatt()).thenReturn((InnloggetNavAnsatt) innloggetBruker);
         }

--- a/src/test/resources/mappings/altinn_tilgangsstyring.json
+++ b/src/test/resources/mappings/altinn_tilgangsstyring.json
@@ -49,6 +49,31 @@
           "Content-Type": "application/json"
         }
       }
+    },
+    {
+      "priority": 1,
+      "request": {
+        "method": "GET",
+        "urlPath": "/altinn-tilgangsstyring",
+        "queryParameters" : {
+          "subject" : {
+            "matches" : "^3\\d{10}$"
+          },
+          "serviceCode": {
+            "equalTo": "42"
+          },
+          "serviceEdition": {
+            "equalTo": "1"
+          }
+        }
+      },
+      "response": {
+        "status": 500,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "statusMessage": "Internal Server Error: 500 UserID"
+      }
     },{
       "priority": 2,
       "request": {


### PR DESCRIPTION
Kaster exception når altinn-kall feiler, istedenfor å bare returnere en tom liste med organisasjoner.
Tar imot innlogget-part cookien som settes i frontend når man logger inn og bruker denne til å kun kalle altinn når en arbeidsgiver er logget inn.

Kan sees i delvis sammenheng med https://github.com/navikt/tiltaksgjennomforing/pull/239 og bør deployes etter denne