### PR TITLE
Endre EREG til a ga mot Q0 i preprod

### DIFF
--- a/src/main/resources/config/application-preprod.yaml
+++ b/src/main/resources/config/application-preprod.yaml
@@ -39,7 +39,7 @@ tiltaksgjennomforing:
   altinn-varsel:
     uri: https://pep-gw-q1.oera-q.local:9443/ekstern/altinn/notificationagencyexternalbasic/v1
   ereg:
-    uri: https://modapp-q1.adeo.no/ereg/api/v1/organisasjon
+    uri: https://modapp-q0.adeo.no/ereg/api/v1/organisasjon
   sts:
     username: ${tiltaksgjennomforing.serviceuser.username}
     password: ${tiltaksgjennomforing.serviceuser.password}


### PR DESCRIPTION
Endrer midlertidig EREG til å gå mot Q0, da det her finnes noen Altinn bedrifter her, mens vi venter på at datasettet vårt skal bli lastet inn i EREG Q1 igjen.