### PR TITLE
Alerterator mot ny slack kanal

### DIFF
--- a/alerterator-prod.yaml
+++ b/alerterator-prod.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   receivers:
     slack:
-      channel: 'tag-notifications'
+      channel: 'arbeidsgiver-notifications'
       prependText: '<!here> | '
   alerts:
     - alert: applikasjon nede


### PR DESCRIPTION
Peker alerterator bort fra tag-notifications over mot arbeidsgiver-notifications.