### PR TITLE
Endret navn pa databasefeltet stillingtype til stillingstittel

### DIFF
--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleInnhold.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleInnhold.java
@@ -66,7 +66,7 @@ public class AvtaleInnhold {
 
     // Lønnstilskudd
     private String arbeidsgiverKontonummer;
-    private String stillingtype;
+    private String stillingstittel;
     private Integer lonnstilskuddProsent;
     private Integer manedslonn;
     private BigDecimal feriepengesats;

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/EndreAvtale.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/EndreAvtale.java
@@ -39,7 +39,7 @@ public class EndreAvtale {
 
     // Lønnstilskuddsfelter
     private String arbeidsgiverKontonummer;
-    private String stillingtype;
+    private String stillingstittel;
     private Integer lonnstilskuddProsent;
     private Integer manedslonn;
     private BigDecimal feriepengesats;

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/LonnstilskuddStrategy.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/LonnstilskuddStrategy.java
@@ -10,7 +10,7 @@ public class LonnstilskuddStrategy extends BaseAvtaleInnholdStrategy {
     @Override
     public void endre(EndreAvtale nyAvtale) {
         avtaleInnhold.setArbeidsgiverKontonummer(nyAvtale.getArbeidsgiverKontonummer());
-        avtaleInnhold.setStillingtype(nyAvtale.getStillingtype());
+        avtaleInnhold.setStillingstittel(nyAvtale.getStillingstittel());
         avtaleInnhold.setLonnstilskuddProsent(nyAvtale.getLonnstilskuddProsent());
         avtaleInnhold.setManedslonn(nyAvtale.getManedslonn());
         avtaleInnhold.setFeriepengesats(nyAvtale.getFeriepengesats());
@@ -22,7 +22,7 @@ public class LonnstilskuddStrategy extends BaseAvtaleInnholdStrategy {
     public boolean erAltUtfylt() {
         return super.erAltUtfylt() && erIkkeTomme(
                 avtaleInnhold.getArbeidsgiverKontonummer(),
-                avtaleInnhold.getStillingtype(),
+                avtaleInnhold.getStillingstittel(),
                 avtaleInnhold.getArbeidsoppgaver(),
                 avtaleInnhold.getLonnstilskuddProsent(),
                 avtaleInnhold.getManedslonn(),

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/journalfoering/AvtaleTilJournalfoering.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/journalfoering/AvtaleTilJournalfoering.java
@@ -42,7 +42,7 @@ public class AvtaleTilJournalfoering {
     private LocalDate startDato;
     private LocalDate sluttDato;
     private Integer stillingprosent;
-    private String stillingstype;
+    private String stillingstittel;
     private String arbeidsoppgaver;
 
     // Lønnstilskudd

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/journalfoering/AvtaleTilJournalfoeringMapper.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/journalfoering/AvtaleTilJournalfoeringMapper.java
@@ -13,7 +13,7 @@ public class AvtaleTilJournalfoeringMapper {
         AvtaleTilJournalfoering avtaleTilJournalfoering = new AvtaleTilJournalfoering();
         avtaleTilJournalfoering.setTiltakstype(avtale.getTiltakstype());
         avtaleTilJournalfoering.setArbeidsgiverKontonummer(avtale.getArbeidsgiverKontonummer());
-        avtaleTilJournalfoering.setStillingstype(avtale.getStillingtype());
+        avtaleTilJournalfoering.setStillingstittel(avtale.getStillingstittel());
         avtaleTilJournalfoering.setArbeidsoppgaver(avtale.getArbeidsoppgaver());
         avtaleTilJournalfoering.setLonnstilskuddProsent(avtale.getLonnstilskuddProsent());
         avtaleTilJournalfoering.setManedslonn(avtale.getManedslonn());

--- a/src/main/resources/db/migration/V22__endre_stillingstype_til_stillingstittel.sql
+++ b/src/main/resources/db/migration/V22__endre_stillingstype_til_stillingstittel.sql
@@ -1,0 +1,1 @@
+alter table avtale_innhold rename column stillingtype to stillingstittel;

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/TestData.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/TestData.java
@@ -5,7 +5,6 @@ import no.nav.tag.tiltaksgjennomforing.autorisasjon.InnloggetSelvbetjeningBruker
 import no.nav.tag.tiltaksgjennomforing.autorisasjon.veilarbabac.TilgangskontrollService;
 import no.nav.tag.tiltaksgjennomforing.avtale.*;
 import no.nav.tag.tiltaksgjennomforing.orgenhet.ArbeidsgiverOrganisasjon;
-import no.nav.tag.tiltaksgjennomforing.orgenhet.Organisasjon;
 import no.nav.tag.tiltaksgjennomforing.varsel.BjelleVarsel;
 import no.nav.tag.tiltaksgjennomforing.varsel.SmsVarsel;
 import no.nav.tag.tiltaksgjennomforing.varsel.VarslbarHendelse;
@@ -146,7 +145,7 @@ public class TestData {
         endreAvtale.setOppgaver(List.of(TestData.enOppgave(), TestData.enOppgave(), TestData.enOppgave()));
         endreAvtale.setArbeidsoppgaver("Butikkarbeid");
         endreAvtale.setArbeidsgiverKontonummer("000111222");
-        endreAvtale.setStillingtype("Stilling");
+        endreAvtale.setStillingstittel("Stilling");
         endreAvtale.setLonnstilskuddProsent(60);
         endreAvtale.setManedslonn(10000);
         endreAvtale.setFeriepengesats(BigDecimal.ONE);

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/journalfoering/AvtaleTilJournalfoeringMapperTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/journalfoering/AvtaleTilJournalfoeringMapperTest.java
@@ -70,7 +70,7 @@ public class AvtaleTilJournalfoeringMapperTest {
         assertEquals(avtale.getVersjon(), tilJournalfoering.getVersjon());
         assertEquals(avtale.getTiltakstype(), tilJournalfoering.getTiltakstype());
         assertEquals(avtale.getArbeidsgiverKontonummer(), tilJournalfoering.getArbeidsgiverKontonummer());
-        assertEquals(avtale.getStillingtype(), tilJournalfoering.getStillingstype());
+        assertEquals(avtale.getStillingstittel(), tilJournalfoering.getStillingstittel());
         assertEquals(avtale.getArbeidsoppgaver(), tilJournalfoering.getArbeidsoppgaver());
         assertEquals(avtale.getLonnstilskuddProsent(), tilJournalfoering.getLonnstilskuddProsent());
         assertEquals(avtale.getManedslonn(), tilJournalfoering.getManedslonn());


### PR DESCRIPTION
Endret navn på databasefeltet `stillingtype` til `stillingstittel`. Den PR-en har direkte knytning til PR på frontend med samme navn. (https://github.com/navikt/tiltaksgjennomforing/pull/369)