### PR TITLE
TAG-1004 Arbeidsoppgaver til stilling arbeidstrening

### DIFF
--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/ArbeidstreningStrategy.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/ArbeidstreningStrategy.java
@@ -10,13 +10,14 @@ public class ArbeidstreningStrategy extends BaseAvtaleInnholdStrategy {
     @Override
     public void endre(EndreAvtale nyAvtale) {
         nyAvtale.getMaal().forEach(Maal::sjekkMaalLengde);
-        nyAvtale.getOppgaver().forEach(Oppgave::sjekkOppgaveLengde);tMaal().clear();
+        nyAvtale.getOppgaver().forEach(Oppgave::sjekkOppgaveLengde);
+        avtaleInnhold.getMaal().clear();
         avtaleInnhold.getMaal().addAll(nyAvtale.getMaal());
         avtaleInnhold.getMaal().forEach(m -> m.setAvtaleInnhold(avtaleInnhold));
         avtaleInnhold.getOppgaver().clear();
         avtaleInnhold.getOppgaver().addAll(nyAvtale.getOppgaver());
         avtaleInnhold.getOppgaver().forEach(o -> o.setAvtaleInnhold(avtaleInnhold));
-        avtaleInnhold.setStillingtype(nyAvtale.getStillingtype());
+        avtaleInnhold.setStillingstittel(nyAvtale.getStillingstittel());
         super.endre(nyAvtale);
     }
 
@@ -27,6 +28,7 @@ public class ArbeidstreningStrategy extends BaseAvtaleInnholdStrategy {
 
         return super.erAltUtfylt()
                 && !avtaleInnhold.getMaal().isEmpty()
-                && arbeidsoppgaverErUtfylt;
+                && arbeidsoppgaverErUtfylt
+                && erIkkeTomme(avtaleInnhold.getStillingstittel());
     }
 }

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/ArbeidstreningStrategy.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/ArbeidstreningStrategy.java
@@ -10,13 +10,13 @@ public class ArbeidstreningStrategy extends BaseAvtaleInnholdStrategy {
     @Override
     public void endre(EndreAvtale nyAvtale) {
         nyAvtale.getMaal().forEach(Maal::sjekkMaalLengde);
-        nyAvtale.getOppgaver().forEach(Oppgave::sjekkOppgaveLengde);
-        avtaleInnhold.getMaal().clear();
+        nyAvtale.getOppgaver().forEach(Oppgave::sjekkOppgaveLengde);tMaal().clear();
         avtaleInnhold.getMaal().addAll(nyAvtale.getMaal());
         avtaleInnhold.getMaal().forEach(m -> m.setAvtaleInnhold(avtaleInnhold));
         avtaleInnhold.getOppgaver().clear();
         avtaleInnhold.getOppgaver().addAll(nyAvtale.getOppgaver());
         avtaleInnhold.getOppgaver().forEach(o -> o.setAvtaleInnhold(avtaleInnhold));
+        avtaleInnhold.setStillingtype(nyAvtale.getStillingtype());
         super.endre(nyAvtale);
     }
 

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleInnhold.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleInnhold.java
@@ -56,6 +56,7 @@ public class AvtaleInnhold {
     private Integer stillingprosent;
     private String journalpostId;
     private String arbeidsoppgaver;
+    private String stillingstittel;
 
     // Mentor
     private String mentorFornavn;
@@ -66,7 +67,6 @@ public class AvtaleInnhold {
 
     // Lønnstilskudd
     private String arbeidsgiverKontonummer;
-    private String stillingstittel;
     private Integer lonnstilskuddProsent;
     private Integer manedslonn;
     private BigDecimal feriepengesats;

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/TestData.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/TestData.java
@@ -117,6 +117,7 @@ public class TestData {
         endreAvtale.setSluttDato(endreAvtale.getStartDato().plusWeeks(2));
         endreAvtale.setStillingprosent(50);
         endreAvtale.setMaal(List.of(TestData.etMaal()));
+        endreAvtale.setStillingstittel("Butikksjef");
 
         // Gjør endring begge steder i en overgangsfase
         endreAvtale.setOppgaver(List.of(TestData.enOppgave(), TestData.enOppgave(), TestData.enOppgave()));

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/ArbeidstreningStrategyTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/ArbeidstreningStrategyTest.java
@@ -39,6 +39,7 @@ class ArbeidstreningStrategyTest {
                 startDato,
                 sluttDato,
                 stillingprosent,
+                stillingstittel,
                 arbeidsoppgaver
         ).filteredOn(Objects::isNull).isEmpty();
     }

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleTest.java
@@ -44,6 +44,7 @@ public class AvtaleTest {
             softly.assertThat(avtale.getStartDato()).isNull();
             softly.assertThat(avtale.getSluttDato()).isNull();
             softly.assertThat(avtale.getStillingprosent()).isNull();
+            softly.assertThat(avtale.getStillingstittel()).isNull();
             softly.assertThat(avtale.erGodkjentAvDeltaker()).isFalse();
             softly.assertThat(avtale.erGodkjentAvArbeidsgiver()).isFalse();
             softly.assertThat(avtale.erGodkjentAvVeileder()).isFalse();
@@ -107,6 +108,7 @@ public class AvtaleTest {
             softly.assertThat(avtale.getStillingprosent()).isEqualTo(endreAvtale.getStillingprosent());
             softly.assertThat(avtale.getMaal()).isEqualTo(endreAvtale.getMaal());
             softly.assertThat(avtale.getOppgaver()).isEqualTo(endreAvtale.getOppgaver());
+            softly.assertThat(avtale.getStillingstittel()).isEqualTo(endreAvtale.getStillingstittel());
         });
     }
 


### PR DESCRIPTION
Lagt til `stillingstittel` som påkrevd felt i arbeidstrening. Henger sammen med frontend PR som gjør om steget Arbeidsoppgaver til Stilling og inkluderer Stillingstittel på lik linje med lønnstilskudd. (https://github.com/navikt/tiltaksgjennomforing/pull/373)