### PR TITLE
Ytelseforbedring: hent alle avtaler

### DIFF
--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/InnloggetArbeidsgiver.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/InnloggetArbeidsgiver.java
@@ -71,6 +71,11 @@ public class InnloggetArbeidsgiver extends InnloggetBruker<Fnr> {
     }
 
     @Override
+    public Avtalerolle rolle() {
+        return Avtalerolle.ARBEIDSGIVER;
+    }
+
+    @Override
     List<Avtale> hentAlleAvtalerMedMuligTilgang(AvtaleRepository avtaleRepository, AvtalePredicate queryParametre) {
         return avtaleRepository.findAllByBedriftNrIn(arbeidsgiverIdentifikatorer());
     }

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/InnloggetArbeidsgiver.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/InnloggetArbeidsgiver.java
@@ -1,7 +1,5 @@
 package no.nav.tag.tiltaksgjennomforing.autorisasjon;
 
-import lombok.Data;
-import lombok.EqualsAndHashCode;
 import no.nav.tag.tiltaksgjennomforing.avtale.*;
 import no.nav.tag.tiltaksgjennomforing.orgenhet.ArbeidsgiverOrganisasjon;
 
@@ -12,22 +10,26 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
-@Data
-@EqualsAndHashCode(callSuper = true)
-public class InnloggetSelvbetjeningBruker extends InnloggetBruker<Fnr> {
+public class InnloggetArbeidsgiver extends InnloggetBruker<Fnr> {
 
     private final List<ArbeidsgiverOrganisasjon> organisasjoner;
 
-    public InnloggetSelvbetjeningBruker(Fnr identifikator, List<ArbeidsgiverOrganisasjon> organisasjoner) {
+    public InnloggetArbeidsgiver(Fnr identifikator, List<ArbeidsgiverOrganisasjon> organisasjoner) {
         super(identifikator);
-        this.organisasjoner = organisasjoner != null ? organisasjoner : new ArrayList<ArbeidsgiverOrganisasjon>();
+        this.organisasjoner = organisasjoner;
+    }
+
+    private static boolean avbruttForMerEnn12UkerSiden(Avtale avtale) {
+        return avtale.isAvbrutt() && avtale.getSistEndret().plus(84, ChronoUnit.DAYS).isBefore(Instant.now());
+    }
+
+    private static boolean sluttdatoPassertMedMerEnn12Uker(Avtale avtale) {
+        return avtale.erGodkjentAvVeileder() && avtale.getSluttDato().plusWeeks(12).isBefore(LocalDate.now());
     }
 
     @Override
     public Avtalepart<Fnr> avtalepart(Avtale avtale) {
-        if (avtale.getDeltakerFnr().equals(getIdentifikator())) {
-            return new Deltaker(getIdentifikator(), avtale);
-        } else if (sjekkOmArbeidsgiverHarTilgang(avtale)) {
+        if (sjekkOmArbeidsgiverHarTilgang(avtale)) {
             return new Arbeidsgiver(getIdentifikator(), avtale);
         } else {
             return null;
@@ -43,14 +45,6 @@ public class InnloggetSelvbetjeningBruker extends InnloggetBruker<Fnr> {
         }
         // Sjekk om du har en ArbeidsgiverOrganisasjon som matcher både bedriftNr og tilgangstype på avtale
         return organisasjoner.stream().anyMatch(o -> o.getTilgangstyper().contains(avtale.getTiltakstype()) && o.getBedriftNr().equals(avtale.getBedriftNr()));
-    }
-
-    private static boolean avbruttForMerEnn12UkerSiden(Avtale avtale) {
-        return avtale.isAvbrutt() && avtale.getSistEndret().plus(84, ChronoUnit.DAYS).isBefore(Instant.now());
-    }
-
-    private static boolean sluttdatoPassertMedMerEnn12Uker(Avtale avtale) {
-        return avtale.erGodkjentAvVeileder() && avtale.getSluttDato().plusWeeks(12).isBefore(LocalDate.now());
     }
 
     @Override
@@ -76,9 +70,12 @@ public class InnloggetSelvbetjeningBruker extends InnloggetBruker<Fnr> {
         return false;
     }
 
+    @Override
+    List<Avtale> hentAlleAvtalerMedMuligTilgang(AvtaleRepository avtaleRepository, AvtalePredicate queryParametre) {
+        return avtaleRepository.findAllByBedriftNrIn(arbeidsgiverIdentifikatorer());
+    }
+
     private List<BedriftNr> arbeidsgiverIdentifikatorer() {
         return organisasjoner.stream().map(ArbeidsgiverOrganisasjon::getBedriftNr).collect(Collectors.toList());
     }
-
-
 }

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/InnloggetBruker.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/InnloggetBruker.java
@@ -2,12 +2,12 @@ package no.nav.tag.tiltaksgjennomforing.autorisasjon;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
-import no.nav.tag.tiltaksgjennomforing.avtale.Avtale;
-import no.nav.tag.tiltaksgjennomforing.avtale.Avtalepart;
-import no.nav.tag.tiltaksgjennomforing.avtale.Identifikator;
+import no.nav.tag.tiltaksgjennomforing.avtale.*;
 import no.nav.tag.tiltaksgjennomforing.exceptions.TilgangskontrollException;
 
+import java.util.Comparator;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Data
 public abstract class InnloggetBruker<T extends Identifikator> {
@@ -37,4 +37,14 @@ public abstract class InnloggetBruker<T extends Identifikator> {
 
     @JsonProperty("erNavAnsatt")
     public abstract boolean erNavAnsatt();
+
+    public List<Avtale> hentAlleAvtalerMedLesetilgang(AvtaleRepository avtaleRepository, AvtalePredicate queryParametre) {
+        return hentAlleAvtalerMedMuligTilgang(avtaleRepository, queryParametre).stream()
+                .filter(queryParametre)
+                .filter(this::harLeseTilgang)
+                .sorted(Comparator.nullsLast(Comparator.comparing(Avtale::getSistEndret).reversed()))
+                .collect(Collectors.toList());
+    }
+
+    abstract List<Avtale> hentAlleAvtalerMedMuligTilgang(AvtaleRepository avtaleRepository, AvtalePredicate queryParametre);
 }

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/InnloggetBruker.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/InnloggetBruker.java
@@ -35,8 +35,11 @@ public abstract class InnloggetBruker<T extends Identifikator> {
         return List.of(identifikator);
     }
 
-    @JsonProperty("erNavAnsatt")
+    @JsonProperty
     public abstract boolean erNavAnsatt();
+
+    @JsonProperty
+    public abstract Avtalerolle rolle();
 
     public List<Avtale> hentAlleAvtalerMedLesetilgang(AvtaleRepository avtaleRepository, AvtalePredicate queryParametre) {
         return hentAlleAvtalerMedMuligTilgang(avtaleRepository, queryParametre).stream()

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/InnloggetBrukerController.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/InnloggetBrukerController.java
@@ -24,7 +24,7 @@ public class InnloggetBrukerController {
     }
 
     @GetMapping
-    public ResponseEntity<InnloggetBruker<?>> hentInnloggetBruker(@CookieValue("innlogget-part") Optional<Avtalerolle> innloggetPart) {
+    public ResponseEntity<InnloggetBruker<?>> hentInnloggetBruker(@CookieValue("innlogget-part") Avtalerolle innloggetPart) {
         return ResponseEntity.ok(innloggingService.hentInnloggetBruker(innloggetPart));
     }
 }

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/InnloggetDeltaker.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/InnloggetDeltaker.java
@@ -1,0 +1,54 @@
+package no.nav.tag.tiltaksgjennomforing.autorisasjon;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import no.nav.tag.tiltaksgjennomforing.avtale.*;
+import no.nav.tag.tiltaksgjennomforing.orgenhet.ArbeidsgiverOrganisasjon;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class InnloggetDeltaker extends InnloggetBruker<Fnr> {
+
+    public InnloggetDeltaker(Fnr identifikator) {
+        super(identifikator);
+    }
+
+    @Override
+    public Deltaker avtalepart(Avtale avtale) {
+        if (avtale.getDeltakerFnr().equals(getIdentifikator())) {
+            return new Deltaker(getIdentifikator(), avtale);
+        } else {
+            return null;
+        }
+    }
+
+    @Override
+    public boolean harLeseTilgang(Avtale avtale) {
+        return avtalepart(avtale) != null;
+    }
+
+    @Override
+    public boolean harSkriveTilgang(Avtale avtale) {
+        return avtalepart(avtale) != null;
+    }
+
+    @Override
+    public List<Identifikator> identifikatorer() {
+        return List.of(getIdentifikator());
+    }
+
+    @Override
+    public boolean erNavAnsatt() {
+        return false;
+    }
+
+    @Override
+    List<Avtale> hentAlleAvtalerMedMuligTilgang(AvtaleRepository avtaleRepository, AvtalePredicate queryParametre) {
+        return avtaleRepository.findAllByDeltakerFnr(getIdentifikator());
+    }
+}

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/InnloggetDeltaker.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/InnloggetDeltaker.java
@@ -48,6 +48,11 @@ public class InnloggetDeltaker extends InnloggetBruker<Fnr> {
     }
 
     @Override
+    public Avtalerolle rolle() {
+        return Avtalerolle.DELTAKER;
+    }
+
+    @Override
     List<Avtale> hentAlleAvtalerMedMuligTilgang(AvtaleRepository avtaleRepository, AvtalePredicate queryParametre) {
         return avtaleRepository.findAllByDeltakerFnr(getIdentifikator());
     }

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/InnloggetVeileder.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/InnloggetVeileder.java
@@ -41,6 +41,11 @@ public class InnloggetVeileder extends InnloggetBruker<NavIdent> {
     }
 
     @Override
+    public Avtalerolle rolle() {
+        return Avtalerolle.VEILEDER;
+    }
+
+    @Override
     List<Avtale> hentAlleAvtalerMedMuligTilgang(AvtaleRepository avtaleRepository, AvtalePredicate queryParametre) {
         if (queryParametre.getVeilederNavIdent() != null) {
             return avtaleRepository.findAllByVeilederNavIdent(queryParametre.getVeilederNavIdent());

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/InnloggetVeileder.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/InnloggetVeileder.java
@@ -3,11 +3,15 @@ package no.nav.tag.tiltaksgjennomforing.autorisasjon;
 import no.nav.tag.tiltaksgjennomforing.autorisasjon.veilarbabac.TilgangskontrollService;
 import no.nav.tag.tiltaksgjennomforing.avtale.*;
 
-public class InnloggetNavAnsatt extends InnloggetBruker<NavIdent> {
+import java.util.List;
+
+import static java.util.Collections.emptyList;
+
+public class InnloggetVeileder extends InnloggetBruker<NavIdent> {
 
     private final TilgangskontrollService tilgangskontrollService;
 
-    public InnloggetNavAnsatt(NavIdent identifikator, TilgangskontrollService tilgangskontrollService) {
+    public InnloggetVeileder(NavIdent identifikator, TilgangskontrollService tilgangskontrollService) {
         super(identifikator);
         this.tilgangskontrollService = tilgangskontrollService;
     }
@@ -34,5 +38,18 @@ public class InnloggetNavAnsatt extends InnloggetBruker<NavIdent> {
     @Override
     public boolean erNavAnsatt() {
         return true;
+    }
+
+    @Override
+    List<Avtale> hentAlleAvtalerMedMuligTilgang(AvtaleRepository avtaleRepository, AvtalePredicate queryParametre) {
+        if (queryParametre.getVeilederNavIdent() != null) {
+            return avtaleRepository.findAllByVeilederNavIdent(queryParametre.getVeilederNavIdent());
+        } else if (queryParametre.getDeltakerFnr() != null) {
+            return avtaleRepository.findAllByDeltakerFnr(queryParametre.getDeltakerFnr());
+        } else if (queryParametre.getBedriftNr() != null) {
+            return avtaleRepository.findAllByBedriftNrIn(List.of(queryParametre.getBedriftNr()));
+        } else {
+            return emptyList();
+        }
     }
 }

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/veilarbabac/TilgangskontrollService.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/veilarbabac/TilgangskontrollService.java
@@ -4,7 +4,7 @@ import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
 import no.nav.tag.tiltaksgjennomforing.avtale.Fnr;
-import no.nav.tag.tiltaksgjennomforing.autorisasjon.InnloggetNavAnsatt;
+import no.nav.tag.tiltaksgjennomforing.autorisasjon.InnloggetVeileder;
 import no.nav.tag.tiltaksgjennomforing.exceptions.TilgangskontrollException;
 
 @Service
@@ -13,31 +13,31 @@ public class TilgangskontrollService {
 
     private final VeilarbabacClient veilarbabacClient;
 
-    public boolean harLesetilgangTilKandidat(InnloggetNavAnsatt innloggetNavAnsatt, Fnr fnr) {
-        return hentTilgang(innloggetNavAnsatt, fnr, TilgangskontrollAction.read);
+    public boolean harLesetilgangTilKandidat(InnloggetVeileder innloggetVeileder, Fnr fnr) {
+        return hentTilgang(innloggetVeileder, fnr, TilgangskontrollAction.read);
     }
 
-    public boolean harSkrivetilgangTilKandidat(InnloggetNavAnsatt innloggetNavAnsatt, Fnr fnr) {
-        return hentTilgang(innloggetNavAnsatt, fnr, TilgangskontrollAction.update);
+    public boolean harSkrivetilgangTilKandidat(InnloggetVeileder innloggetVeileder, Fnr fnr) {
+        return hentTilgang(innloggetVeileder, fnr, TilgangskontrollAction.update);
     }
 
-    public void sjekkLesetilgangTilKandidat(InnloggetNavAnsatt innloggetNavAnsatt, Fnr fnr) {
-        sjekkTilgang(innloggetNavAnsatt, fnr, TilgangskontrollAction.read);
+    public void sjekkLesetilgangTilKandidat(InnloggetVeileder innloggetVeileder, Fnr fnr) {
+        sjekkTilgang(innloggetVeileder, fnr, TilgangskontrollAction.read);
     }
         
-    public void sjekkSkrivetilgangTilKandidat(InnloggetNavAnsatt innloggetNavAnsatt, Fnr fnr) {
-        sjekkTilgang(innloggetNavAnsatt, fnr, TilgangskontrollAction.update);
+    public void sjekkSkrivetilgangTilKandidat(InnloggetVeileder innloggetVeileder, Fnr fnr) {
+        sjekkTilgang(innloggetVeileder, fnr, TilgangskontrollAction.update);
     }
 
-    private void sjekkTilgang(InnloggetNavAnsatt innloggetNavAnsatt, Fnr fnr, TilgangskontrollAction action) {
-        if (!hentTilgang(innloggetNavAnsatt, fnr, action)) {
+    private void sjekkTilgang(InnloggetVeileder innloggetVeileder, Fnr fnr, TilgangskontrollAction action) {
+        if (!hentTilgang(innloggetVeileder, fnr, action)) {
             throw new TilgangskontrollException("Du har ikke tilgang til deltaker");
         }
     }
 
-    private boolean hentTilgang(InnloggetNavAnsatt innloggetNavAnsatt, Fnr fnr, TilgangskontrollAction action) {
+    private boolean hentTilgang(InnloggetVeileder innloggetVeileder, Fnr fnr, TilgangskontrollAction action) {
         return veilarbabacClient.sjekkTilgang(
-                innloggetNavAnsatt,
+                innloggetVeileder,
                 fnr.asString(),
                 action
         );

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/veilarbabac/VeilarbabacClient.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/veilarbabac/VeilarbabacClient.java
@@ -1,6 +1,6 @@
 package no.nav.tag.tiltaksgjennomforing.autorisasjon.veilarbabac;
 
-import no.nav.tag.tiltaksgjennomforing.autorisasjon.InnloggetNavAnsatt;
+import no.nav.tag.tiltaksgjennomforing.autorisasjon.InnloggetVeileder;
 import no.nav.tag.tiltaksgjennomforing.exceptions.TilgangskontrollException;
 import no.nav.tag.tiltaksgjennomforing.infrastruktur.restservicecache.CacheConfiguration;
 import no.nav.tag.tiltaksgjennomforing.infrastruktur.sts.STSClient;
@@ -35,7 +35,7 @@ public class VeilarbabacClient {
     }
 
     @Cacheable(CacheConfiguration.ABAC_CACHE)
-    public boolean sjekkTilgang(InnloggetNavAnsatt veileder, String fnr, TilgangskontrollAction action) {
+    public boolean sjekkTilgang(InnloggetVeileder veileder, String fnr, TilgangskontrollAction action) {
         String response;
         try {
             response = hentTilgang(veileder, fnr, action);
@@ -53,7 +53,7 @@ public class VeilarbabacClient {
         throw new TilgangskontrollException("Ukjent respons fra veilarbabac: " + response);
     }
 
-    private String hentTilgang(InnloggetNavAnsatt veileder, String fnr, TilgangskontrollAction action) {
+    private String hentTilgang(InnloggetVeileder veileder, String fnr, TilgangskontrollAction action) {
         String uriString = UriComponentsBuilder.fromHttpUrl(veilarbabacUrl)
                 .path("/person")
                 .queryParam("fnr", fnr)

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleRepository.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleRepository.java
@@ -2,12 +2,13 @@ package no.nav.tag.tiltaksgjennomforing.avtale;
 
 import io.micrometer.core.annotation.Timed;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
-public interface AvtaleRepository extends JpaRepository<Avtale, UUID> {
+public interface AvtaleRepository extends JpaRepository<Avtale, UUID>, JpaSpecificationExecutor {
     @Timed(percentiles = { 0.5d, 0.75d, 0.9d, 0.99d, 0.999d })
     @Override
     Optional<Avtale> findById(UUID id);
@@ -15,6 +16,15 @@ public interface AvtaleRepository extends JpaRepository<Avtale, UUID> {
     @Timed(percentiles = { 0.5d, 0.75d, 0.9d, 0.99d, 0.999d })
     @Override
     List<Avtale> findAllById(Iterable<UUID> ids);
+
+    @Timed(percentiles = { 0.5d, 0.75d, 0.9d, 0.99d, 0.999d })
+    List<Avtale> findAllByBedriftNrIn(List<BedriftNr> bedriftNrList);
+
+    @Timed(percentiles = { 0.5d, 0.75d, 0.9d, 0.99d, 0.999d })
+    List<Avtale> findAllByDeltakerFnr(Fnr deltakerFnr);
+
+    @Timed(percentiles = { 0.5d, 0.75d, 0.9d, 0.99d, 0.999d })
+    List<Avtale> findAllByVeilederNavIdent(NavIdent veilederNavIdent);
 
     @Timed(percentiles = { 0.5d, 0.75d, 0.9d, 0.99d, 0.999d })
     @Override

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/Avtalerolle.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/Avtalerolle.java
@@ -1,5 +1,5 @@
 package no.nav.tag.tiltaksgjennomforing.avtale;
 
 public enum Avtalerolle {
-    DELTAKER, ARBEIDSGIVER, VEILEDER, INGEN_ROLLE
+    DELTAKER, ARBEIDSGIVER, VEILEDER
 }

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/varsel/BjelleVarselController.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/varsel/BjelleVarselController.java
@@ -26,14 +26,14 @@ public class BjelleVarselController {
     public Iterable<BjelleVarsel> hentVarsler(
             @RequestParam(value = "avtaleId", required = false) UUID avtaleId,
             @RequestParam(value = "lest", required = false) Boolean lest, @CookieValue("innlogget-part") Optional<Avtalerolle> innloggetPart) {
-        InnloggetBruker<?> bruker = innloggingService.hentInnloggetBruker(innloggetPart);
+        InnloggetBruker<?> bruker = innloggingService.hentInnloggetBruker(innloggetPart.get());
         return bjelleVarselService.varslerForInnloggetBruker(bruker, avtaleId, lest);
     }
 
     @PostMapping("{varselId}/sett-til-lest")
     @Transactional
     public ResponseEntity<?> settTilLest(@PathVariable("varselId") UUID varselId, Optional<Avtalerolle> innloggetPart) {
-        InnloggetBruker<?> bruker = innloggingService.hentInnloggetBruker(innloggetPart);
+        InnloggetBruker<?> bruker = innloggingService.hentInnloggetBruker(innloggetPart.get());
         bjelleVarselService.settTilLest(bruker, varselId);
         return ResponseEntity.ok().build();
     }

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/TestData.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/TestData.java
@@ -1,7 +1,8 @@
 package no.nav.tag.tiltaksgjennomforing;
 
-import no.nav.tag.tiltaksgjennomforing.autorisasjon.InnloggetNavAnsatt;
-import no.nav.tag.tiltaksgjennomforing.autorisasjon.InnloggetSelvbetjeningBruker;
+import no.nav.tag.tiltaksgjennomforing.autorisasjon.InnloggetDeltaker;
+import no.nav.tag.tiltaksgjennomforing.autorisasjon.InnloggetVeileder;
+import no.nav.tag.tiltaksgjennomforing.autorisasjon.InnloggetArbeidsgiver;
 import no.nav.tag.tiltaksgjennomforing.autorisasjon.veilarbabac.TilgangskontrollService;
 import no.nav.tag.tiltaksgjennomforing.avtale.*;
 import no.nav.tag.tiltaksgjennomforing.orgenhet.ArbeidsgiverOrganisasjon;
@@ -90,7 +91,7 @@ public class TestData {
     }
 
     private static OpprettAvtale lagOpprettAvtale() {
-        Fnr deltakerFnr = new Fnr("88888899999");
+        Fnr deltakerFnr = new Fnr("00000000000");
         BedriftNr bedriftNr = new BedriftNr("999999999");
         return new OpprettAvtale(deltakerFnr, bedriftNr, Tiltakstype.ARBEIDSTRENING);
     }
@@ -169,12 +170,16 @@ public class TestData {
         return new Deltaker(avtale.getDeltakerFnr(), avtale);
     }
 
-    public static InnloggetSelvbetjeningBruker enSelvbetjeningBruker() {
-        return new InnloggetSelvbetjeningBruker(new Fnr("99999999999"), emptyList());
+    public static InnloggetDeltaker enInnloggetDeltaker() {
+        return new InnloggetDeltaker(new Fnr("99999999999"));
     }
 
-    public static InnloggetNavAnsatt enNavAnsatt() {
-        return new InnloggetNavAnsatt(new NavIdent("F888888"), mock(TilgangskontrollService.class));
+    public static InnloggetArbeidsgiver enInnloggetArbeidsgiver() {
+        return new InnloggetArbeidsgiver(new Fnr("99999999999"), emptyList());
+    }
+
+    public static InnloggetVeileder enInnloggetVeileder() {
+        return new InnloggetVeileder(new NavIdent("F888888"), mock(TilgangskontrollService.class));
     }
 
     public static Arbeidsgiver enArbeidsgiver() {
@@ -218,14 +223,14 @@ public class TestData {
         return paVegneGrunn;
     }
 
-    public static InnloggetSelvbetjeningBruker innloggetSelvbetjeningBrukerMedOrganisasjon(Avtalepart<Fnr> avtalepartMedFnr) {
+    public static InnloggetArbeidsgiver innloggetArbeidsgiver(Avtalepart<Fnr> avtalepartMedFnr) {
         ArbeidsgiverOrganisasjon organisasjon = new ArbeidsgiverOrganisasjon(avtalepartMedFnr.getAvtale().getBedriftNr(), avtalepartMedFnr.getAvtale().getBedriftNavn());
         organisasjon.getTilgangstyper().addAll(List.of(Tiltakstype.values()));
-        return new InnloggetSelvbetjeningBruker(avtalepartMedFnr.getIdentifikator(), List.of(organisasjon));
+        return new InnloggetArbeidsgiver(avtalepartMedFnr.getIdentifikator(), List.of(organisasjon));
     }
 
-    public static InnloggetSelvbetjeningBruker innloggetSelvbetjeningBrukerUtenOrganisasjon(Avtalepart<Fnr> avtalepartMedFnr) {
-        return new InnloggetSelvbetjeningBruker(avtalepartMedFnr.getIdentifikator(), emptyList());
+    public static InnloggetDeltaker innloggetDeltaker(Avtalepart<Fnr> avtalepartMedFnr) {
+        return new InnloggetDeltaker(avtalepartMedFnr.getIdentifikator());
     }
 
     public static Identifikator enIdentifikator() {

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/InnloggetBrukerTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/InnloggetBrukerTest.java
@@ -3,7 +3,6 @@ package no.nav.tag.tiltaksgjennomforing.autorisasjon;
 import no.nav.tag.tiltaksgjennomforing.*;
 import no.nav.tag.tiltaksgjennomforing.avtale.*;
 import no.nav.tag.tiltaksgjennomforing.orgenhet.ArbeidsgiverOrganisasjon;
-import no.nav.tag.tiltaksgjennomforing.orgenhet.Organisasjon;
 import no.nav.tag.tiltaksgjennomforing.autorisasjon.veilarbabac.TilgangskontrollService;
 
 import org.junit.Before;
@@ -16,7 +15,6 @@ import static org.mockito.Mockito.*;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
-import java.time.temporal.TemporalUnit;
 import java.util.Arrays;
 import java.util.List;
 
@@ -40,99 +38,99 @@ public class InnloggetBrukerTest {
     @Test
     public void deltakerKnyttetTilAvtaleSkalHaDeltakerRolle() {
         Avtale avtale = TestData.enAvtale();
-        InnloggetSelvbetjeningBruker selvbetjeningBruker = TestData.innloggetSelvbetjeningBrukerUtenOrganisasjon(TestData.enDeltaker(avtale));
+        InnloggetDeltaker selvbetjeningBruker = TestData.innloggetDeltaker(TestData.enDeltaker(avtale));
         assertThat(selvbetjeningBruker.avtalepart(avtale)).isInstanceOf(Deltaker.class);
     }
 
     @Test
     public void arbeidsgiverKnyttetTilAvtaleSkalHaArbeidsgiverRolle() {
         Avtale avtale = TestData.enAvtale();
-        InnloggetSelvbetjeningBruker selvbetjeningBruker = TestData.innloggetSelvbetjeningBrukerMedOrganisasjon(TestData.enArbeidsgiver(avtale));
+        InnloggetArbeidsgiver selvbetjeningBruker = TestData.innloggetArbeidsgiver(TestData.enArbeidsgiver(avtale));
         assertThat(selvbetjeningBruker.avtalepart(avtale)).isInstanceOf(Arbeidsgiver.class);
     }
 
     @Test
     public void veilederKnyttetTilAvtaleSkalHaVeilederRolle() {
         Avtale avtale = TestData.enAvtale();
-        InnloggetNavAnsatt navAnsatt = new InnloggetNavAnsatt(avtale.getVeilederNavIdent(), tilgangskontrollService);
+        InnloggetVeileder navAnsatt = new InnloggetVeileder(avtale.getVeilederNavIdent(), tilgangskontrollService);
         assertThat(navAnsatt.avtalepart(avtale)).isInstanceOf(Veileder.class);
     }
 
     @Test
     public void harTilgang__deltaker_skal_ha_tilgang_til_avtale() {
-        assertThat(new InnloggetSelvbetjeningBruker(deltaker, emptyList()).harLeseTilgang(avtale)).isTrue();
+        assertThat(new InnloggetDeltaker(deltaker).harLeseTilgang(avtale)).isTrue();
     }
 
     @Test
     public void harTilgang__veileder_skal_ha_lesetilgang_til_avtale_hvis_toggle_er_på_og_tilgangskontroll_er_ok() {
-        InnloggetNavAnsatt innloggetNavAnsatt = new InnloggetNavAnsatt(navIdent, tilgangskontrollService);
-        when(tilgangskontrollService.harLesetilgangTilKandidat(innloggetNavAnsatt, avtale.getDeltakerFnr())).thenReturn(true);
+        InnloggetVeileder innloggetVeileder = new InnloggetVeileder(navIdent, tilgangskontrollService);
+        when(tilgangskontrollService.harLesetilgangTilKandidat(innloggetVeileder, avtale.getDeltakerFnr())).thenReturn(true);
 
-        assertThat(innloggetNavAnsatt.harLeseTilgang(avtale)).isTrue();
-        verify(tilgangskontrollService).harLesetilgangTilKandidat(innloggetNavAnsatt, avtale.getDeltakerFnr());
+        assertThat(innloggetVeileder.harLeseTilgang(avtale)).isTrue();
+        verify(tilgangskontrollService).harLesetilgangTilKandidat(innloggetVeileder, avtale.getDeltakerFnr());
     }
     
     @Test
     public void harTilgang__veileder_skal_ikke_ha_lesetilgang_til_avtale_hvis_toggle_er_på_og_tilgangskontroll_feiler() {
-        InnloggetNavAnsatt innloggetNavAnsatt = new InnloggetNavAnsatt(navIdent, tilgangskontrollService);
-        when(tilgangskontrollService.harLesetilgangTilKandidat(innloggetNavAnsatt, avtale.getDeltakerFnr())).thenReturn(false);
+        InnloggetVeileder innloggetVeileder = new InnloggetVeileder(navIdent, tilgangskontrollService);
+        when(tilgangskontrollService.harLesetilgangTilKandidat(innloggetVeileder, avtale.getDeltakerFnr())).thenReturn(false);
 
-        assertThat(innloggetNavAnsatt.harLeseTilgang(avtale)).isFalse();
+        assertThat(innloggetVeileder.harLeseTilgang(avtale)).isFalse();
     }
     
     @Test
     public void harTilgang__veileder_skal_ha_skrivetilgang_til_avtale_hvis_toggle_er_på_og_tilgangskontroll_er_ok() {
-        InnloggetNavAnsatt innloggetNavAnsatt = new InnloggetNavAnsatt(navIdent, tilgangskontrollService);
-        when(tilgangskontrollService.harSkrivetilgangTilKandidat(innloggetNavAnsatt, avtale.getDeltakerFnr())).thenReturn(true);
+        InnloggetVeileder innloggetVeileder = new InnloggetVeileder(navIdent, tilgangskontrollService);
+        when(tilgangskontrollService.harSkrivetilgangTilKandidat(innloggetVeileder, avtale.getDeltakerFnr())).thenReturn(true);
 
-        assertThat(innloggetNavAnsatt.harSkriveTilgang(avtale)).isTrue();
-        verify(tilgangskontrollService).harSkrivetilgangTilKandidat(innloggetNavAnsatt, avtale.getDeltakerFnr());
+        assertThat(innloggetVeileder.harSkriveTilgang(avtale)).isTrue();
+        verify(tilgangskontrollService).harSkrivetilgangTilKandidat(innloggetVeileder, avtale.getDeltakerFnr());
     }
     
     @Test
     public void harTilgang__veileder_skal_ikke_ha_skrivetilgang_til_avtale_hvis_toggle_er_på_og_tilgangskontroll_feiler() {
-        InnloggetNavAnsatt innloggetNavAnsatt = new InnloggetNavAnsatt(navIdent, tilgangskontrollService);
-        when(tilgangskontrollService.harSkrivetilgangTilKandidat(innloggetNavAnsatt, avtale.getDeltakerFnr())).thenReturn(false);
+        InnloggetVeileder innloggetVeileder = new InnloggetVeileder(navIdent, tilgangskontrollService);
+        when(tilgangskontrollService.harSkrivetilgangTilKandidat(innloggetVeileder, avtale.getDeltakerFnr())).thenReturn(false);
         
-        assertThat(innloggetNavAnsatt.harSkriveTilgang(avtale)).isFalse();
+        assertThat(innloggetVeileder.harSkriveTilgang(avtale)).isFalse();
     }
     
     @Test
     public void harTilgang__arbeidsgiver_skal_ikke_ha_tilgang_til_avtale() {
-        assertThat(new InnloggetSelvbetjeningBruker(TestData.etFodselsnummer(), emptyList()).harLeseTilgang(avtale)).isFalse();
+        assertThat(new InnloggetArbeidsgiver(TestData.etFodselsnummer(), emptyList()).harLeseTilgang(avtale)).isFalse();
     }
 
     @Test
     public void harTilgang__ikkepart_veileder_skal_ikke_ha_lesetilgang_hvis_toggle_er_av() {
-        assertThat(new InnloggetNavAnsatt(new NavIdent("X123456"), tilgangskontrollService).harLeseTilgang(avtale)).isFalse();
+        assertThat(new InnloggetVeileder(new NavIdent("X123456"), tilgangskontrollService).harLeseTilgang(avtale)).isFalse();
     }
 
     @Test
     public void harTilgang__ikkepart_veileder_skal_ikke_ha_skrivetilgang_hvis_toggle_er_av() {
-        assertThat(new InnloggetNavAnsatt(new NavIdent("X123456"), tilgangskontrollService).harSkriveTilgang(avtale)).isFalse();
+        assertThat(new InnloggetVeileder(new NavIdent("X123456"), tilgangskontrollService).harSkriveTilgang(avtale)).isFalse();
     }
     
     @Test
     public void harTilgang__ikkepart_selvbetjeningsbruker_skal_ikke_ha_tilgang() {
-        assertThat(new InnloggetSelvbetjeningBruker(new Fnr("00000000001"), emptyList()).harLeseTilgang(avtale)).isFalse();
+        assertThat(new InnloggetArbeidsgiver(new Fnr("00000000001"), emptyList()).harLeseTilgang(avtale)).isFalse();
     }
 
     @Test
     public void harTilgang__arbeidsgiver_skal_kunne_representere_bedrift_uten_Fnr() {
         ArbeidsgiverOrganisasjon organisasjon = new ArbeidsgiverOrganisasjon(bedriftNr, "Testbutikken");
         organisasjon.getTilgangstyper().addAll(List.of(Tiltakstype.values()));
-        InnloggetSelvbetjeningBruker innloggetSelvbetjeningBruker = new InnloggetSelvbetjeningBruker(new Fnr("00000000009"), Arrays.asList(organisasjon));
-        assertThat(innloggetSelvbetjeningBruker.harLeseTilgang(avtale)).isTrue();
+        InnloggetArbeidsgiver innloggetArbeidsgiver = new InnloggetArbeidsgiver(new Fnr("00000000009"), Arrays.asList(organisasjon));
+        assertThat(innloggetArbeidsgiver.harLeseTilgang(avtale)).isTrue();
     }
 
     @Test
     public void harTilgang__arbeidsgiver_skal_ikke_ha_tilgang_til_avbrutt_avtale_eldre_enn_12_uker() {
         ArbeidsgiverOrganisasjon organisasjon = new ArbeidsgiverOrganisasjon(bedriftNr, "Testbutikken");
         organisasjon.getTilgangstyper().addAll(List.of(Tiltakstype.values()));
-        InnloggetSelvbetjeningBruker innloggetSelvbetjeningBruker = new InnloggetSelvbetjeningBruker(new Fnr("00000000009"), Arrays.asList(organisasjon));
+        InnloggetArbeidsgiver innloggetArbeidsgiver = new InnloggetArbeidsgiver(new Fnr("00000000009"), Arrays.asList(organisasjon));
         avtale.setAvbrutt(true);
         avtale.setSistEndret(Instant.now().minus(84, ChronoUnit.DAYS));
-        assertThat(innloggetSelvbetjeningBruker.harLeseTilgang(avtale)).isFalse();
+        assertThat(innloggetArbeidsgiver.harLeseTilgang(avtale)).isFalse();
     }
 
     @Test
@@ -141,8 +139,8 @@ public class InnloggetBrukerTest {
         avtale.setSluttDato(LocalDate.now().minusDays(85));
         ArbeidsgiverOrganisasjon organisasjon = new ArbeidsgiverOrganisasjon(avtale.getBedriftNr(), "Testbutikken");
         organisasjon.getTilgangstyper().addAll(List.of(Tiltakstype.values()));
-        InnloggetSelvbetjeningBruker innloggetSelvbetjeningBruker = new InnloggetSelvbetjeningBruker(new Fnr("00000000009"), Arrays.asList(organisasjon));
-        assertThat(innloggetSelvbetjeningBruker.harLeseTilgang(avtale)).isFalse();
+        InnloggetArbeidsgiver innloggetArbeidsgiver = new InnloggetArbeidsgiver(new Fnr("00000000009"), Arrays.asList(organisasjon));
+        assertThat(innloggetArbeidsgiver.harLeseTilgang(avtale)).isFalse();
     }
 
     @Test
@@ -151,8 +149,8 @@ public class InnloggetBrukerTest {
         avtale.setSluttDato(LocalDate.now().minusDays(85));
         ArbeidsgiverOrganisasjon organisasjon = new ArbeidsgiverOrganisasjon(avtale.getBedriftNr(), "Testbutikken");
         organisasjon.getTilgangstyper().addAll(List.of(Tiltakstype.values()));
-        InnloggetSelvbetjeningBruker innloggetSelvbetjeningBruker = new InnloggetSelvbetjeningBruker(new Fnr("00000000009"), Arrays.asList(organisasjon));
-        assertThat(innloggetSelvbetjeningBruker.harLeseTilgang(avtale)).isTrue();
+        InnloggetArbeidsgiver innloggetArbeidsgiver = new InnloggetArbeidsgiver(new Fnr("00000000009"), Arrays.asList(organisasjon));
+        assertThat(innloggetArbeidsgiver.harLeseTilgang(avtale)).isTrue();
     }
 
     @Test
@@ -160,7 +158,7 @@ public class InnloggetBrukerTest {
         Avtale avtale = TestData.enLonnstilskuddAvtaleMedAltUtfylt();
         ArbeidsgiverOrganisasjon organisasjon = new ArbeidsgiverOrganisasjon(avtale.getBedriftNr(), "Testbutikken");
         organisasjon.getTilgangstyper().add(Tiltakstype.ARBEIDSTRENING);
-        InnloggetSelvbetjeningBruker innloggetSelvbetjeningBruker = new InnloggetSelvbetjeningBruker(new Fnr("00000000009"), Arrays.asList(organisasjon));
-        assertThat(innloggetSelvbetjeningBruker.harLeseTilgang(avtale)).isFalse();
+        InnloggetArbeidsgiver innloggetArbeidsgiver = new InnloggetArbeidsgiver(new Fnr("00000000009"), Arrays.asList(organisasjon));
+        assertThat(innloggetArbeidsgiver.harLeseTilgang(avtale)).isFalse();
     }
 }

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/InnloggingServiceTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/InnloggingServiceTest.java
@@ -11,9 +11,7 @@ import no.nav.tag.tiltaksgjennomforing.avtale.Avtalerolle;
 import no.nav.tag.tiltaksgjennomforing.avtale.BedriftNr;
 import no.nav.tag.tiltaksgjennomforing.avtale.Fnr;
 import no.nav.tag.tiltaksgjennomforing.TestData;
-import no.nav.tag.tiltaksgjennomforing.avtale.Tiltakstype;
 import no.nav.tag.tiltaksgjennomforing.orgenhet.ArbeidsgiverOrganisasjon;
-import no.nav.tag.tiltaksgjennomforing.orgenhet.Organisasjon;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
@@ -41,50 +39,50 @@ public class InnloggingServiceTest {
 
     @Test
     public void hentInnloggetBruker__er_selvbetjeningbruker() {
-        InnloggetSelvbetjeningBruker selvbetjeningBruker = TestData.enSelvbetjeningBruker();
-        vaerInnloggetSelvbetjening(selvbetjeningBruker);
-        assertThat(innloggingService.hentInnloggetBruker()).isEqualTo(selvbetjeningBruker);
+        InnloggetDeltaker selvbetjeningBruker = TestData.enInnloggetDeltaker();
+        værInnloggetDeltaker(selvbetjeningBruker);
+        assertThat(innloggingService.hentInnloggetBruker(Avtalerolle.DELTAKER)).isEqualTo(selvbetjeningBruker);
     }
     
     @Test
     public void hentInnloggetBruker__selvbetjeningbruker_type_arbeidsgiver_skal_hente_organisasjoner() {
         List<ArbeidsgiverOrganisasjon> organisasjoner = asList(new ArbeidsgiverOrganisasjon(new BedriftNr("111111111"), "Navn"));
-        InnloggetSelvbetjeningBruker selvbetjeningBruker = new InnloggetSelvbetjeningBruker(new Fnr("11111111111"), organisasjoner);
+        InnloggetArbeidsgiver selvbetjeningBruker = new InnloggetArbeidsgiver(new Fnr("11111111111"), organisasjoner);
         when(altinnTilgangsstyringService.hentOrganisasjoner(selvbetjeningBruker.getIdentifikator())).thenReturn(organisasjoner);
-        vaerInnloggetSelvbetjening(selvbetjeningBruker);
-        
-        assertThat(innloggingService.hentInnloggetBruker(Optional.of(Avtalerolle.ARBEIDSGIVER))).isEqualTo(selvbetjeningBruker);
+        værInnloggetArbeidsgiver(selvbetjeningBruker);
+
+        assertThat(innloggingService.hentInnloggetBruker(Optional.of(Avtalerolle.ARBEIDSGIVER).get())).isEqualTo(selvbetjeningBruker);
         verify(altinnTilgangsstyringService).hentOrganisasjoner(selvbetjeningBruker.getIdentifikator());
     }
     
     @Test
     public void hentInnloggetBruker__er_nav_ansatt() {
-        InnloggetNavAnsatt navAnsatt = TestData.enNavAnsatt();
-        vaerInnloggetNavAnsatt(navAnsatt);
-        assertThat(innloggingService.hentInnloggetBruker()).isEqualTo(navAnsatt);
+        InnloggetVeileder navAnsatt = TestData.enInnloggetVeileder();
+        værInnloggetVeileder(navAnsatt);
+        assertThat(innloggingService.hentInnloggetBruker(Avtalerolle.VEILEDER)).isEqualTo(navAnsatt);
     }
 
     @Test(expected = TilgangskontrollException.class)
     public void hentInnloggetNavAnsatt__er_selvbetjeningbruker() {
-        vaerInnloggetSelvbetjening(TestData.enSelvbetjeningBruker());
-        innloggingService.hentInnloggetNavAnsatt();
+        værInnloggetArbeidsgiver(TestData.enInnloggetArbeidsgiver());
+        innloggingService.hentInnloggetVeileder();
     }
 
     @Test(expected = TilgangskontrollException.class)
     public void hentInnloggetBruker__er_uinnlogget() {
         when(tokenUtils.hentBrukerOgIssuer()).thenReturn(Optional.empty());
-        innloggingService.hentInnloggetNavAnsatt();
+        innloggingService.hentInnloggetVeileder();
     }
 
     @Test(expected = TilgangskontrollException.class)
     public void avviser_selvbetjeningBruker_som_systemBruker(){
-        vaerInnloggetSelvbetjening(TestData.enSelvbetjeningBruker());
+        værInnloggetArbeidsgiver(TestData.enInnloggetArbeidsgiver());
         innloggingService.validerSystembruker();
     }
 
     @Test(expected = TilgangskontrollException.class)
     public void avviser_navAnsatt_som_systemBruker(){
-        vaerInnloggetNavAnsatt(TestData.enNavAnsatt());
+        værInnloggetVeileder(TestData.enInnloggetVeileder());
         innloggingService.validerSystembruker();
     }
 
@@ -105,11 +103,15 @@ public class InnloggingServiceTest {
         when(systembrukerProperties.getId()).thenReturn("forventet");
     }
 
-    private void vaerInnloggetSelvbetjening(InnloggetSelvbetjeningBruker bruker) {
+    private void værInnloggetDeltaker(InnloggetDeltaker bruker) {
         when(tokenUtils.hentBrukerOgIssuer()).thenReturn(Optional.of(new TokenUtils.BrukerOgIssuer(Issuer.ISSUER_SELVBETJENING, bruker.getIdentifikator().asString())));
     }
 
-    private void vaerInnloggetNavAnsatt(InnloggetNavAnsatt navAnsatt) {
+    private void værInnloggetArbeidsgiver(InnloggetArbeidsgiver bruker) {
+        when(tokenUtils.hentBrukerOgIssuer()).thenReturn(Optional.of(new TokenUtils.BrukerOgIssuer(Issuer.ISSUER_SELVBETJENING, bruker.getIdentifikator().asString())));
+    }
+
+    private void værInnloggetVeileder(InnloggetVeileder navAnsatt) {
         when(tokenUtils.hentBrukerOgIssuer()).thenReturn(Optional.of(new TokenUtils.BrukerOgIssuer(Issuer.ISSUER_ISSO, navAnsatt.getIdentifikator().asString())));
     }
 

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/TokenUtilsTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/TokenUtilsTest.java
@@ -36,14 +36,14 @@ public class TokenUtilsTest {
 
     @Test
     public void hentInnloggetBruker__er_selvbetjeningbruker() {
-        InnloggetSelvbetjeningBruker selvbetjeningBruker = TestData.enSelvbetjeningBruker();
+        InnloggetArbeidsgiver selvbetjeningBruker = TestData.enInnloggetArbeidsgiver();
         vaerInnloggetSelvbetjening(selvbetjeningBruker);
         assertThat(tokenUtils.hentBrukerOgIssuer().get()).isEqualTo(new BrukerOgIssuer(ISSUER_SELVBETJENING, selvbetjeningBruker.getIdentifikator().asString()));
     }
 
     @Test
     public void hentInnloggetBruker__er_selvbetjeningbruker_må_være_nivå_4() {
-        InnloggetSelvbetjeningBruker selvbetjeningBruker = TestData.enSelvbetjeningBruker();
+        InnloggetArbeidsgiver selvbetjeningBruker = TestData.enInnloggetArbeidsgiver();
         vaerInnloggetSelvbetjening(selvbetjeningBruker);
         assertThat(tokenUtils.hentBrukerOgIssuer().get()).isEqualTo(new BrukerOgIssuer(ISSUER_SELVBETJENING, selvbetjeningBruker.getIdentifikator().asString()));
         vaerInnloggetSelvbetjeningNiva3(selvbetjeningBruker);
@@ -52,7 +52,7 @@ public class TokenUtilsTest {
     
     @Test
     public void hentInnloggetBruker__er_nav_ansatt() {
-        InnloggetNavAnsatt navAnsatt = TestData.enNavAnsatt();
+        InnloggetVeileder navAnsatt = TestData.enInnloggetVeileder();
         vaerInnloggetNavAnsatt(navAnsatt);
         assertThat(tokenUtils.hentBrukerOgIssuer().get()).isEqualTo(new BrukerOgIssuer(ISSUER_ISSO, navAnsatt.getIdentifikator().asString()));
     }
@@ -77,15 +77,15 @@ public class TokenUtilsTest {
         lagOidcContext(ISSUER_SYSTEM, systemId, new HashMap<>(), null);
     }
 
-    private void vaerInnloggetSelvbetjening(InnloggetSelvbetjeningBruker bruker) {
+    private void vaerInnloggetSelvbetjening(InnloggetArbeidsgiver bruker) {
         lagOidcContext(ISSUER_SELVBETJENING, bruker.getIdentifikator().asString(), new HashMap<>(), ACR_LEVEL_4);
     }
 
-    private void vaerInnloggetSelvbetjeningNiva3(InnloggetSelvbetjeningBruker bruker) {
+    private void vaerInnloggetSelvbetjeningNiva3(InnloggetArbeidsgiver bruker) {
         lagOidcContext(ISSUER_SELVBETJENING, bruker.getIdentifikator().asString(), new HashMap<>(), "Level3");
     }
     
-    private void vaerInnloggetNavAnsatt(InnloggetNavAnsatt innloggetBruker) {
+    private void vaerInnloggetNavAnsatt(InnloggetVeileder innloggetBruker) {
         lagOidcContext(ISSUER_ISSO, "blablabla", Map.of("NAVident", innloggetBruker.getIdentifikator().asString()), null);
     }
 

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/veilarbabac/VeilarbabacClientTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/veilarbabac/VeilarbabacClientTest.java
@@ -1,7 +1,7 @@
 package no.nav.tag.tiltaksgjennomforing.autorisasjon.veilarbabac;
 
 import no.nav.tag.tiltaksgjennomforing.avtale.NavIdent;
-import no.nav.tag.tiltaksgjennomforing.autorisasjon.InnloggetNavAnsatt;
+import no.nav.tag.tiltaksgjennomforing.autorisasjon.InnloggetVeileder;
 import no.nav.tag.tiltaksgjennomforing.exceptions.TilgangskontrollException;
 import no.nav.tag.tiltaksgjennomforing.infrastruktur.sts.STSClient;
 import no.nav.tag.tiltaksgjennomforing.infrastruktur.sts.STSToken;
@@ -60,8 +60,8 @@ public class VeilarbabacClientTest {
                 .thenReturn(ResponseEntity.ok().body(response));
     }
 
-    private static InnloggetNavAnsatt enVeileder() {
-        return new InnloggetNavAnsatt(new NavIdent("X123456"), null);
+    private static InnloggetVeileder enVeileder() {
+        return new InnloggetVeileder(new NavIdent("X123456"), null);
     }
 
     @Test
@@ -80,7 +80,7 @@ public class VeilarbabacClientTest {
     public void harSkrivetilgangTilKandidat__skal_gjøre_kall_med_riktige_parametre() {
         STSToken stsToken = etStsToken();
 
-        InnloggetNavAnsatt veileder = enVeileder();
+        InnloggetVeileder veileder = enVeileder();
 
         when(stsClient.hentSTSToken()).thenReturn(stsToken);
 

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleControllerTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleControllerTest.java
@@ -1,10 +1,7 @@
 package no.nav.tag.tiltaksgjennomforing.avtale;
 
 import no.nav.tag.tiltaksgjennomforing.TestData;
-import no.nav.tag.tiltaksgjennomforing.autorisasjon.InnloggetBruker;
-import no.nav.tag.tiltaksgjennomforing.autorisasjon.InnloggetNavAnsatt;
-import no.nav.tag.tiltaksgjennomforing.autorisasjon.InnloggetSelvbetjeningBruker;
-import no.nav.tag.tiltaksgjennomforing.autorisasjon.InnloggingService;
+import no.nav.tag.tiltaksgjennomforing.autorisasjon.*;
 import no.nav.tag.tiltaksgjennomforing.autorisasjon.veilarbabac.TilgangskontrollService;
 import no.nav.tag.tiltaksgjennomforing.exceptions.RessursFinnesIkkeException;
 import no.nav.tag.tiltaksgjennomforing.exceptions.TilgangskontrollException;
@@ -31,6 +28,7 @@ import static no.nav.tag.tiltaksgjennomforing.TestData.enAvtale;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
+@SuppressWarnings("rawtypes")
 @RunWith(MockitoJUnitRunner.class)
 public class AvtaleControllerTest {
 
@@ -69,32 +67,32 @@ public class AvtaleControllerTest {
     @Test
     public void hentSkalReturnereRiktigAvtale() {
         Avtale avtale = enAvtale();
-        InnloggetNavAnsatt innloggetNavAnsatt = innloggetNavAnsatt(TestData.enVeileder(avtale), tilgangskontrollService);
-        vaerInnloggetSom(innloggetNavAnsatt);
-        when(tilgangskontrollService.harLesetilgangTilKandidat(eq(innloggetNavAnsatt), any(Fnr.class))).thenReturn(true);
+        InnloggetVeileder innloggetVeileder = innloggetNavAnsatt(TestData.enVeileder(avtale), tilgangskontrollService);
+        værInnloggetSom(innloggetVeileder);
+        when(tilgangskontrollService.harLesetilgangTilKandidat(eq(innloggetVeileder), any(Fnr.class))).thenReturn(true);
         when(avtaleRepository.findById(avtale.getId())).thenReturn(Optional.of(avtale));
-        Avtale hentetAvtale = avtaleController.hent(avtale.getId(), Optional.empty());
+        Avtale hentetAvtale = avtaleController.hent(avtale.getId(), Avtalerolle.VEILEDER);
         assertThat(hentetAvtale).isEqualTo(avtale);
     }
 
-    private static InnloggetNavAnsatt innloggetNavAnsatt(Avtalepart<NavIdent> avtalepartMedNavIdent, TilgangskontrollService tilgangskontrollService) {
-        return new InnloggetNavAnsatt(avtalepartMedNavIdent.getIdentifikator(), tilgangskontrollService);
+    private static InnloggetVeileder innloggetNavAnsatt(Avtalepart<NavIdent> avtalepartMedNavIdent, TilgangskontrollService tilgangskontrollService) {
+        return new InnloggetVeileder(avtalepartMedNavIdent.getIdentifikator(), tilgangskontrollService);
     }
 
     @Test(expected = RessursFinnesIkkeException.class)
     public void hentSkalKasteResourceNotFoundExceptionHvisAvtaleIkkeFins() {
         Avtale avtale = TestData.enAvtale();
-        vaerInnloggetSom(innloggetNavAnsatt(TestData.enVeileder(avtale), tilgangskontrollService));
+        værInnloggetSom(innloggetNavAnsatt(TestData.enVeileder(avtale), tilgangskontrollService));
         when(avtaleRepository.findById(avtale.getId())).thenReturn(Optional.empty());
-        avtaleController.hent(avtale.getId(), Optional.empty());
+        avtaleController.hent(avtale.getId(), Avtalerolle.VEILEDER);
     }
 
     @Test(expected = TilgangskontrollException.class)
     public void hentSkalKastTilgangskontrollExceptionHvisInnloggetNavAnsattIkkeHarTilgang() {
         Avtale avtale = TestData.enAvtale();
-        vaerInnloggetSom(new InnloggetNavAnsatt(new NavIdent("Z333333"), tilgangskontrollService));
+        værInnloggetSom(new InnloggetVeileder(new NavIdent("Z333333"), tilgangskontrollService));
         when(avtaleRepository.findById(avtale.getId())).thenReturn(Optional.of(avtale));
-        avtaleController.hent(avtale.getId(), Optional.empty());
+        avtaleController.hent(avtale.getId(), Avtalerolle.VEILEDER);
     }
 
     @Test
@@ -102,11 +100,13 @@ public class AvtaleControllerTest {
         NavIdent veilederNavIdent = new NavIdent("Z222222");
         Avtale avtaleForVeilederSomSøkesEtter = AvtaleFactory.nyAvtale(lagOpprettAvtale(), veilederNavIdent);
         Avtale avtaleForAnnenVeilder = AvtaleFactory.nyAvtale(lagOpprettAvtale(), new NavIdent("Z111111"));
-        InnloggetNavAnsatt innloggetBruker = new InnloggetNavAnsatt(new NavIdent("Z333333"), tilgangskontrollService);
-        vaerInnloggetSom(innloggetBruker);
-        when(avtaleRepository.findAll()).thenReturn(asList(avtaleForVeilederSomSøkesEtter, avtaleForAnnenVeilder));
+        InnloggetVeileder innloggetBruker = new InnloggetVeileder(new NavIdent("Z333333"), tilgangskontrollService);
+        værInnloggetSom(innloggetBruker);
+        when(avtaleRepository.findAllByVeilederNavIdent(veilederNavIdent)).thenReturn(asList(avtaleForVeilederSomSøkesEtter, avtaleForAnnenVeilder));
         when(tilgangskontrollService.harLesetilgangTilKandidat(eq(innloggetBruker), any(Fnr.class))).thenReturn(true);
-        Iterable<Avtale> avtaler = avtaleController.hentAlleAvtalerInnloggetBrukerHarTilgangTil(new AvtalePredicate().setVeilederNavIdent(veilederNavIdent), Optional.empty());
+        AvtalePredicate avtalePredicate = new AvtalePredicate();
+        avtalePredicate.setVeilederNavIdent(veilederNavIdent);
+        Iterable<Avtale> avtaler = avtaleController.hentAlleAvtalerInnloggetBrukerHarTilgangTil(avtalePredicate.setVeilederNavIdent(veilederNavIdent), Avtalerolle.VEILEDER);
         assertThat(avtaler)
                 .contains(avtaleForVeilederSomSøkesEtter)
                 .doesNotContain(avtaleForAnnenVeilder);
@@ -116,24 +116,24 @@ public class AvtaleControllerTest {
     public void hentAvtalerOpprettetAvVeileder_skal_returnere_tom_liste_dersom_veileder_ikke_har_tilgang() {
         NavIdent veilederNavIdent = new NavIdent("Z222222");
         Avtale avtaleForVeilederSomSøkesEtter = AvtaleFactory.nyAvtale(lagOpprettAvtale(), veilederNavIdent);
-        InnloggetNavAnsatt innloggetBruker = new InnloggetNavAnsatt(new NavIdent("Z333333"), tilgangskontrollService);
-        vaerInnloggetSom(innloggetBruker);
-        when(avtaleRepository.findAll()).thenReturn(asList(avtaleForVeilederSomSøkesEtter));
+        InnloggetVeileder innloggetBruker = new InnloggetVeileder(new NavIdent("Z333333"), tilgangskontrollService);
+        værInnloggetSom(innloggetBruker);
+        when(avtaleRepository.findAllByVeilederNavIdent(veilederNavIdent)).thenReturn(List.of(avtaleForVeilederSomSøkesEtter));
         when(tilgangskontrollService.harLesetilgangTilKandidat(eq(innloggetBruker), any(Fnr.class))).thenReturn(false);
-        Iterable<Avtale> avtaler = avtaleController.hentAlleAvtalerInnloggetBrukerHarTilgangTil(new AvtalePredicate().setVeilederNavIdent(veilederNavIdent), Optional.empty());
+        Iterable<Avtale> avtaler = avtaleController.hentAlleAvtalerInnloggetBrukerHarTilgangTil(new AvtalePredicate().setVeilederNavIdent(veilederNavIdent), Avtalerolle.VEILEDER);
         assertThat(avtaler).doesNotContain(avtaleForVeilederSomSøkesEtter);
     }
 
     @Test
     public void hentAvtalerOpprettetAvInnloggetVeileder_skal_returnere_avtaler_dersom_veileder_har_tilgang() {
-        NavIdent innloggetVeileder = new NavIdent("Z333333");
-        Avtale avtaleForInnloggetVeileder = AvtaleFactory.nyAvtale(lagOpprettAvtale(), innloggetVeileder);
+        NavIdent navIdent = new NavIdent("Z333333");
+        Avtale avtaleForInnloggetVeileder = AvtaleFactory.nyAvtale(lagOpprettAvtale(), navIdent);
         Avtale avtaleForAnnenVeilder = AvtaleFactory.nyAvtale(lagOpprettAvtale(), new NavIdent("Z111111"));
-        InnloggetNavAnsatt innloggetBruker = new InnloggetNavAnsatt(innloggetVeileder, tilgangskontrollService);
-        vaerInnloggetSom(innloggetBruker);
-        when(avtaleRepository.findAll()).thenReturn(asList(avtaleForInnloggetVeileder, avtaleForAnnenVeilder));
-        when(tilgangskontrollService.harLesetilgangTilKandidat(eq(innloggetBruker), any(Fnr.class))).thenReturn(true);
-        Iterable<Avtale> avtaler = avtaleController.hentAlleAvtalerInnloggetBrukerHarTilgangTil(new AvtalePredicate().setVeilederNavIdent(innloggetVeileder), Optional.empty());
+        InnloggetVeileder innloggetVeileder = new InnloggetVeileder(navIdent, tilgangskontrollService);
+        værInnloggetSom(innloggetVeileder);
+        when(avtaleRepository.findAllByVeilederNavIdent(navIdent)).thenReturn(asList(avtaleForInnloggetVeileder, avtaleForAnnenVeilder));
+        when(tilgangskontrollService.harLesetilgangTilKandidat(eq(innloggetVeileder), any(Fnr.class))).thenReturn(true);
+        Iterable<Avtale> avtaler = avtaleController.hentAlleAvtalerInnloggetBrukerHarTilgangTil(new AvtalePredicate().setVeilederNavIdent(navIdent), Avtalerolle.VEILEDER);
         assertThat(avtaler)
                 .contains(avtaleForInnloggetVeileder)
                 .doesNotContain(avtaleForAnnenVeilder);
@@ -142,15 +142,15 @@ public class AvtaleControllerTest {
     @Test(expected = TilgangskontrollException.class)
     public void hentSkalKastTilgangskontrollExceptionHvisInnloggetSelvbetjeningBrukerIkkeHarTilgang() {
         Avtale avtale = TestData.enAvtale();
-        vaerInnloggetSom(new InnloggetSelvbetjeningBruker(new Fnr("55555566666"), emptyList()));
+        værInnloggetSom(new InnloggetArbeidsgiver(new Fnr("55555566666"), emptyList()));
         when(avtaleRepository.findById(avtale.getId())).thenReturn(Optional.of(avtale));
-        avtaleController.hent(avtale.getId(), Optional.empty());
+        avtaleController.hent(avtale.getId(), Avtalerolle.DELTAKER);
     }
 
     @Test
     public void opprettAvtaleSkalReturnereCreatedOgOpprettetLokasjon() {
         Avtale avtale = TestData.enAvtale();
-        vaerInnloggetSom(innloggetNavAnsatt(TestData.enVeileder(avtale), tilgangskontrollService));
+        værInnloggetSom(innloggetNavAnsatt(TestData.enVeileder(avtale), tilgangskontrollService));
         when(avtaleRepository.save(any(Avtale.class))).thenReturn(avtale);
         when(eregService.hentVirksomhet(avtale.getBedriftNr())).thenReturn(new Organisasjon(avtale.getBedriftNr(), avtale.getBedriftNavn()));
         when(persondataService.hentNavn(any())).thenReturn(Navn.TOMT_NAVN);
@@ -162,88 +162,85 @@ public class AvtaleControllerTest {
     @Test(expected = RessursFinnesIkkeException.class)
     public void endreAvtaleSkalReturnereNotFoundHvisDenIkkeFins() {
         Avtale avtale = TestData.enAvtale();
-        vaerInnloggetSom(innloggetNavAnsatt(TestData.enVeileder(avtale), tilgangskontrollService));
+        værInnloggetSom(innloggetNavAnsatt(TestData.enVeileder(avtale), tilgangskontrollService));
         when(avtaleRepository.findById(avtale.getId())).thenReturn(Optional.empty());
-        avtaleController.endreAvtale(avtale.getId(), avtale.getSistEndret(), TestData.ingenEndring(), Optional.empty());
+        avtaleController.endreAvtale(avtale.getId(), avtale.getSistEndret(), TestData.ingenEndring(), Avtalerolle.VEILEDER);
     }
 
     @Test
     public void endreAvtaleSkalReturnereOkHvisInnloggetPersonErVeileder() {
         Avtale avtale = TestData.enAvtale();
-        vaerInnloggetSom(innloggetNavAnsatt(TestData.enVeileder(avtale), tilgangskontrollService));
-        when(tilgangskontrollService.harSkrivetilgangTilKandidat(any(InnloggetNavAnsatt.class), any(Fnr.class))).thenReturn(true);
+        værInnloggetSom(innloggetNavAnsatt(TestData.enVeileder(avtale), tilgangskontrollService));
+        when(tilgangskontrollService.harSkrivetilgangTilKandidat(any(InnloggetVeileder.class), any(Fnr.class))).thenReturn(true);
         when(avtaleRepository.findById(avtale.getId())).thenReturn(Optional.of(avtale));
         when(avtaleRepository.save(avtale)).thenReturn(avtale);
-        ResponseEntity svar = avtaleController.endreAvtale(avtale.getId(), avtale.getSistEndret(), TestData.ingenEndring(), Optional.empty());
+        ResponseEntity svar = avtaleController.endreAvtale(avtale.getId(), avtale.getSistEndret(), TestData.ingenEndring(), Avtalerolle.VEILEDER);
         assertThat(svar.getStatusCode()).isEqualTo(HttpStatus.OK);
     }
 
     @Test(expected = TilgangskontrollException.class)
     public void endreAvtaleSkalReturnereForbiddenHvisInnloggetPersonIkkeHarTilgang() {
         Avtale avtale = TestData.enAvtale();
-        vaerInnloggetSom(TestData.enSelvbetjeningBruker());
+        værInnloggetSom(TestData.enInnloggetArbeidsgiver());
         when(avtaleRepository.findById(avtale.getId())).thenReturn(Optional.of(avtale));
-        avtaleController.endreAvtale(avtale.getId(), avtale.getSistEndret(), TestData.ingenEndring(), Optional.empty());
+        avtaleController.endreAvtale(avtale.getId(), avtale.getSistEndret(), TestData.ingenEndring(), Avtalerolle.ARBEIDSGIVER);
     }
 
     @Test
     public void hentAlleAvtalerInnloggetBrukerHarTilgangTilSkalIkkeReturnereAvtalerManIkkeHarTilgangTil() {
         Avtale avtaleMedTilgang = TestData.enAvtale();
         Avtale avtaleUtenTilgang = AvtaleFactory.nyAvtale(new OpprettAvtale(new Fnr("89898989898"), new BedriftNr("111222333"), Tiltakstype.ARBEIDSTRENING), new NavIdent("X643564"));
-        InnloggetSelvbetjeningBruker selvbetjeningBruker = TestData.innloggetSelvbetjeningBrukerUtenOrganisasjon(TestData.enDeltaker(avtaleMedTilgang));
-        vaerInnloggetSom(selvbetjeningBruker);
+        InnloggetDeltaker innloggetDeltaker = TestData.innloggetDeltaker(TestData.enDeltaker(avtaleMedTilgang));
+        værInnloggetSom(innloggetDeltaker);
         List<Avtale> avtalerBrukerHarTilgangTil = lagListeMedAvtaler(avtaleMedTilgang, 5);
         List<Avtale> alleAvtaler = new ArrayList<>();
         alleAvtaler.addAll(avtalerBrukerHarTilgangTil);
         alleAvtaler.addAll(lagListeMedAvtaler(avtaleUtenTilgang, 4));
-        when(avtaleRepository.findAll()).thenReturn(alleAvtaler);
-        List<Avtale> hentedeAvtaler = new ArrayList<>();
-        for (Avtale avtale : avtaleController.hentAlleAvtalerInnloggetBrukerHarTilgangTil(new AvtalePredicate(), Optional.empty())) {
-            hentedeAvtaler.add(avtale);
-        }
-        hentedeAvtaler.forEach(avtale -> assertThat(selvbetjeningBruker.harLeseTilgang(avtale)).isTrue());
-        assertThat(hentedeAvtaler.size()).isEqualTo(avtalerBrukerHarTilgangTil.size());
+        when(avtaleRepository.findAllByDeltakerFnr(innloggetDeltaker.getIdentifikator())).thenReturn(alleAvtaler);
+        var hentedeAvtaler = avtaleController.hentAlleAvtalerInnloggetBrukerHarTilgangTil(new AvtalePredicate(), Avtalerolle.DELTAKER);
+        assertThat(hentedeAvtaler)
+                .hasSize(avtalerBrukerHarTilgangTil.size())
+                .allMatch(innloggetDeltaker::harLeseTilgang);
     }
 
     @Test(expected = RessursFinnesIkkeException.class)
     public void hentRolleSkalKasteResourceNotFoundExceptionHvisAvtaleIkkeFins() {
         Avtale avtale = TestData.enAvtale();
         when(avtaleRepository.findById(avtale.getId())).thenReturn(Optional.empty());
-        avtaleController.hentRolle(avtale.getId(), Optional.empty());
+        avtaleController.hentRolle(avtale.getId(), Avtalerolle.ARBEIDSGIVER);
     }
 
     @Test(expected = TilgangskontrollException.class)
     public void hentRolleSkalReturnereForbiddenHvisIkkeTilknyttetAvtale() {
         Avtale avtale = TestData.enAvtale();
-        vaerInnloggetSom(TestData.enNavAnsatt());
+        værInnloggetSom(TestData.enInnloggetVeileder());
         when(avtaleRepository.findById(avtale.getId())).thenReturn(Optional.of(avtale));
-        avtaleController.hentRolle(avtale.getId(), Optional.empty());
+        avtaleController.hentRolle(avtale.getId(), Avtalerolle.VEILEDER);
     }
 
     @Test
     public void hentRolleSkalReturnereOkMedEnRolleHvisInnloggetBrukerErTilknyttetAvtale() {
         Avtale avtale = TestData.enAvtale();
-        InnloggetSelvbetjeningBruker selvbetjeningBruker = TestData.innloggetSelvbetjeningBrukerUtenOrganisasjon(TestData.enDeltaker(avtale));
-        vaerInnloggetSom(selvbetjeningBruker);
+        InnloggetDeltaker selvbetjeningBruker = TestData.innloggetDeltaker(TestData.enDeltaker(avtale));
+        værInnloggetSom(selvbetjeningBruker);
         when(avtaleRepository.findById(avtale.getId())).thenReturn(Optional.of(avtale));
-        Avtalerolle svar = avtaleController.hentRolle(avtale.getId(), Optional.empty());
+        Avtalerolle svar = avtaleController.hentRolle(avtale.getId(), Avtalerolle.DELTAKER);
         assertThat(svar).isEqualTo(Avtalerolle.DELTAKER);
     }
 
     @Test(expected = TilgangskontrollException.class)
     public void opprettAvtale__skal_feile_hvis_veileder_ikke_har_tilgang_til_bruker() {
-        InnloggetNavAnsatt enNavAnsatt = TestData.enNavAnsatt();
-        vaerInnloggetSom(enNavAnsatt);
+        InnloggetVeileder enNavAnsatt = TestData.enInnloggetVeileder();
+        værInnloggetSom(enNavAnsatt);
         Fnr deltakerFnr = new Fnr("11111100000");
         doThrow(TilgangskontrollException.class).when(tilgangskontrollService).sjekkSkrivetilgangTilKandidat(enNavAnsatt, deltakerFnr);
         avtaleController.opprettAvtale(new OpprettAvtale(deltakerFnr, new BedriftNr("111222333"), Tiltakstype.ARBEIDSTRENING));
     }
 
-    private void vaerInnloggetSom(InnloggetBruker innloggetBruker) {
-        when(innloggingService.hentInnloggetBruker()).thenReturn(innloggetBruker);
+    private void værInnloggetSom(InnloggetBruker innloggetBruker) {
         when(innloggingService.hentInnloggetBruker(any())).thenReturn(innloggetBruker);
-        if (innloggetBruker instanceof InnloggetNavAnsatt) {
-            when(innloggingService.hentInnloggetNavAnsatt()).thenReturn((InnloggetNavAnsatt) innloggetBruker);
+        if (innloggetBruker instanceof InnloggetVeileder) {
+            when(innloggingService.hentInnloggetVeileder()).thenReturn((InnloggetVeileder) innloggetBruker);
         }
     }
 
@@ -251,10 +248,10 @@ public class AvtaleControllerTest {
     @Test
     public void avtaleStatus__veileder_maa_fylleut_avtale_foer_godkjenning() {
         Avtale avtale = TestData.enAvtale();
-        InnloggetBruker enNavAnsatt = TestData.enNavAnsatt();
-        vaerInnloggetSom(enNavAnsatt);
+        InnloggetBruker enNavAnsatt = TestData.enInnloggetVeileder();
+        værInnloggetSom(enNavAnsatt);
         when(avtaleRepository.findById(avtale.getId())).thenReturn(Optional.of(avtale));
-        AvtaleStatusDetaljer avtaleStatusDetaljer = avtaleController.hentAvtaleStatusDetaljer(avtale.getId(), Optional.empty());
+        AvtaleStatusDetaljer avtaleStatusDetaljer = avtaleController.hentAvtaleStatusDetaljer(avtale.getId(), Avtalerolle.VEILEDER);
         assertThat(avtaleStatusDetaljer.header).isEqualTo(Avtalepart.tekstHeaderAvtalePaabegynt);
         assertThat(avtaleStatusDetaljer.infoDel1).isEqualTo("");
         assertThat(avtaleStatusDetaljer.infoDel2).isEqualTo("");
@@ -263,10 +260,10 @@ public class AvtaleControllerTest {
     @Test
     public void avtaleStatus__arbeidsgiver_maa_fylleut_avtale_foer_godkjenning() {
         Avtale avtale = TestData.enAvtale();
-        InnloggetBruker innloggetArbeidsgiver = TestData.innloggetSelvbetjeningBrukerMedOrganisasjon(TestData.enArbeidsgiver(avtale));
-        vaerInnloggetSom(innloggetArbeidsgiver);
+        InnloggetBruker innloggetArbeidsgiver = TestData.innloggetArbeidsgiver(TestData.enArbeidsgiver(avtale));
+        værInnloggetSom(innloggetArbeidsgiver);
         when(avtaleRepository.findById(avtale.getId())).thenReturn(Optional.of(avtale));
-        AvtaleStatusDetaljer avtaleStatusDetaljer = avtaleController.hentAvtaleStatusDetaljer(avtale.getId(), Optional.empty());
+        AvtaleStatusDetaljer avtaleStatusDetaljer = avtaleController.hentAvtaleStatusDetaljer(avtale.getId(), Avtalerolle.ARBEIDSGIVER);
         assertThat(avtaleStatusDetaljer.header).isEqualTo(Avtalepart.tekstHeaderAvtalePaabegynt);
         assertThat(avtaleStatusDetaljer.infoDel1).isEqualTo("");
         assertThat(avtaleStatusDetaljer.infoDel2).isEqualTo("");
@@ -277,10 +274,10 @@ public class AvtaleControllerTest {
     @Test
     public void avtaleStatus__deltaker_maa_be_om_utfylling_av_avtale_foer_godkjenning() {
         Avtale avtale = TestData.enAvtale();
-        InnloggetBruker innloggetDeltaker = TestData.innloggetSelvbetjeningBrukerUtenOrganisasjon(TestData.enDeltaker(avtale));
-        vaerInnloggetSom(innloggetDeltaker);
+        InnloggetBruker innloggetDeltaker = TestData.innloggetDeltaker(TestData.enDeltaker(avtale));
+        værInnloggetSom(innloggetDeltaker);
         when(avtaleRepository.findById(avtale.getId())).thenReturn(Optional.of(avtale));
-        AvtaleStatusDetaljer avtaleStatusDetaljer = avtaleController.hentAvtaleStatusDetaljer(avtale.getId(), Optional.empty());
+        AvtaleStatusDetaljer avtaleStatusDetaljer = avtaleController.hentAvtaleStatusDetaljer(avtale.getId(), Avtalerolle.DELTAKER);
         assertThat(avtaleStatusDetaljer.header).isEqualTo(Deltaker.tekstHeaderAvtalePaabegynt);
         assertThat(avtaleStatusDetaljer.infoDel1).isEqualTo(Deltaker.tekstAvtalePaabegynt);
         assertThat(avtaleStatusDetaljer.infoDel2).isEqualTo("");
@@ -290,10 +287,10 @@ public class AvtaleControllerTest {
     @Test
     public void avtaleStatus__deltaker_og_arbeidsgiver_maa_godkjenne_avtale() {
         Avtale avtale = TestData.enAvtaleMedAltUtfylt();
-        InnloggetBruker innloggetDeltaker = TestData.innloggetSelvbetjeningBrukerUtenOrganisasjon(TestData.enDeltaker(avtale));
-        vaerInnloggetSom(innloggetDeltaker);
+        InnloggetBruker innloggetDeltaker = TestData.innloggetDeltaker(TestData.enDeltaker(avtale));
+        værInnloggetSom(innloggetDeltaker);
         when(avtaleRepository.findById(avtale.getId())).thenReturn(Optional.of(avtale));
-        AvtaleStatusDetaljer avtaleStatusDetaljer = avtaleController.hentAvtaleStatusDetaljer(avtale.getId(), Optional.empty());
+        AvtaleStatusDetaljer avtaleStatusDetaljer = avtaleController.hentAvtaleStatusDetaljer(avtale.getId(), Avtalerolle.DELTAKER);
         assertThat(avtaleStatusDetaljer.header).isEqualTo(Avtalepart.tekstHeaderAvtaleVenterPaaDinGodkjenning);
         assertThat(avtaleStatusDetaljer.infoDel1).isEqualTo(Deltaker.tekstAvtaleVenterPaaDinGodkjenning);
         assertThat(avtaleStatusDetaljer.infoDel2).isEqualTo(Deltaker.ekstraTekstAvtaleVenterPaaDinGodkjenning);
@@ -303,10 +300,10 @@ public class AvtaleControllerTest {
     @Test
     public void avtaleStatus__arbeidsgiver__maa_godkjenn__avtale() {
         Avtale avtale = TestData.enAvtaleMedAltUtfylt();
-        InnloggetBruker innloggetArbeidsgiver = TestData.innloggetSelvbetjeningBrukerMedOrganisasjon(TestData.enArbeidsgiver(avtale));
-        vaerInnloggetSom(innloggetArbeidsgiver);
+        InnloggetBruker innloggetArbeidsgiver = TestData.innloggetArbeidsgiver(TestData.enArbeidsgiver(avtale));
+        værInnloggetSom(innloggetArbeidsgiver);
         when(avtaleRepository.findById(avtale.getId())).thenReturn(Optional.of(avtale));
-        AvtaleStatusDetaljer avtaleStatusDetaljer = avtaleController.hentAvtaleStatusDetaljer(avtale.getId(), Optional.empty());
+        AvtaleStatusDetaljer avtaleStatusDetaljer = avtaleController.hentAvtaleStatusDetaljer(avtale.getId(), Avtalerolle.ARBEIDSGIVER);
         assertThat(avtaleStatusDetaljer.header).isEqualTo(Avtalepart.tekstHeaderAvtaleVenterPaaDinGodkjenning);
         assertThat(avtaleStatusDetaljer.infoDel1).isEqualTo(Arbeidsgiver.tekstAvtaleVenterPaaDinGodkjenning);
         assertThat(avtaleStatusDetaljer.infoDel2).isEqualTo(Arbeidsgiver.ekstraTekstAvtaleVenterPaaDinGodkjenning);
@@ -315,9 +312,9 @@ public class AvtaleControllerTest {
     @Test
     public void avtaleStatus__veileder_maa_vente_paa_andre_parter_godkjenning_kan_godkjenne_for_deltaker() {
         Avtale avtale = TestData.enAvtaleMedAltUtfylt();
-        vaerInnloggetSom(innloggetNavAnsatt(TestData.enVeileder(avtale), tilgangskontrollService));
+        værInnloggetSom(innloggetNavAnsatt(TestData.enVeileder(avtale), tilgangskontrollService));
         when(avtaleRepository.findById(avtale.getId())).thenReturn(Optional.of(avtale));
-        AvtaleStatusDetaljer avtaleStatusDetaljer = avtaleController.hentAvtaleStatusDetaljer(avtale.getId(), Optional.empty());
+        AvtaleStatusDetaljer avtaleStatusDetaljer = avtaleController.hentAvtaleStatusDetaljer(avtale.getId(), Avtalerolle.VEILEDER);
         assertThat(avtaleStatusDetaljer.header).isEqualTo(Avtalepart.tekstHeaderVentAndreGodkjenning);
         assertThat(avtaleStatusDetaljer.infoDel1).isEqualTo("");
         assertThat(avtaleStatusDetaljer.infoDel2).isEqualTo("");
@@ -327,9 +324,9 @@ public class AvtaleControllerTest {
     public void avtaleStatus__veileder_maa_vente_paa_andre_parter_godkjenning_deltaker_har_godkjent() {
         Avtale avtale = TestData.enAvtaleMedAltUtfylt();
         avtale.godkjennForDeltaker(TestData.enDeltaker(avtale).getIdentifikator());
-        vaerInnloggetSom(innloggetNavAnsatt(TestData.enVeileder(avtale), tilgangskontrollService));
+        værInnloggetSom(innloggetNavAnsatt(TestData.enVeileder(avtale), tilgangskontrollService));
         when(avtaleRepository.findById(avtale.getId())).thenReturn(Optional.of(avtale));
-        AvtaleStatusDetaljer avtaleStatusDetaljer = avtaleController.hentAvtaleStatusDetaljer(avtale.getId(), Optional.empty());
+        AvtaleStatusDetaljer avtaleStatusDetaljer = avtaleController.hentAvtaleStatusDetaljer(avtale.getId(), Avtalerolle.DELTAKER);
         assertThat(avtaleStatusDetaljer.header).isEqualTo(Avtalepart.tekstHeaderVentAndreGodkjenning);
         assertThat(avtaleStatusDetaljer.infoDel1).isEqualTo("");
         assertThat(avtaleStatusDetaljer.infoDel2).isEqualTo("");
@@ -340,15 +337,15 @@ public class AvtaleControllerTest {
         Avtale avtale = TestData.enAvtaleMedAltUtfylt();
         avtale.godkjennForDeltaker(TestData.enDeltaker(avtale).getIdentifikator());
         avtale.godkjennForArbeidsgiver(TestData.enArbeidsgiver(avtale).getIdentifikator());
-        InnloggetBruker innloggetDeltaker = TestData.innloggetSelvbetjeningBrukerUtenOrganisasjon(TestData.enDeltaker(avtale));
-        vaerInnloggetSom(innloggetDeltaker);
+        InnloggetBruker innloggetDeltaker = TestData.innloggetDeltaker(TestData.enDeltaker(avtale));
+        værInnloggetSom(innloggetDeltaker);
         when(avtaleRepository.findById(avtale.getId())).thenReturn(Optional.of(avtale));
-        AvtaleStatusDetaljer avtaleStatusDetaljer = avtaleController.hentAvtaleStatusDetaljer(avtale.getId(), Optional.empty());
+        AvtaleStatusDetaljer avtaleStatusDetaljer = avtaleController.hentAvtaleStatusDetaljer(avtale.getId(), Avtalerolle.DELTAKER);
         assertThat(avtaleStatusDetaljer.header).isEqualTo(Avtalepart.tekstHeaderVentAndreGodkjenning);
         assertThat(avtaleStatusDetaljer.infoDel1).isEqualTo("");
         assertThat(avtaleStatusDetaljer.infoDel2).isEqualTo("");
-        InnloggetBruker innloggetArbeidsgiver = TestData.innloggetSelvbetjeningBrukerUtenOrganisasjon(TestData.enDeltaker(avtale));
-        vaerInnloggetSom(innloggetArbeidsgiver);
+        InnloggetBruker innloggetArbeidsgiver = TestData.innloggetDeltaker(TestData.enDeltaker(avtale));
+        værInnloggetSom(innloggetArbeidsgiver);
         assertThat(avtaleStatusDetaljer.header).isEqualTo(Avtalepart.tekstHeaderVentAndreGodkjenning);
         assertThat(avtaleStatusDetaljer.infoDel1).isEqualTo("");
         assertThat(avtaleStatusDetaljer.infoDel2).isEqualTo("");
@@ -358,9 +355,9 @@ public class AvtaleControllerTest {
     public void avtaleStatus__godkjent_av_alle_parter() {
         Avtale avtale = TestData.enAvtaleMedAltUtfyltGodkjentAvVeileder();
         avtale.setStartDato(LocalDate.now().plusWeeks(1));
-        vaerInnloggetSom(TestData.enNavAnsatt());
+        værInnloggetSom(TestData.enInnloggetVeileder());
         when(avtaleRepository.findById(avtale.getId())).thenReturn(Optional.of(avtale));
-        AvtaleStatusDetaljer avtaleStatusDetaljer = avtaleController.hentAvtaleStatusDetaljer(avtale.getId(), Optional.empty());
+        AvtaleStatusDetaljer avtaleStatusDetaljer = avtaleController.hentAvtaleStatusDetaljer(avtale.getId(), Avtalerolle.VEILEDER);
         assertThat(avtaleStatusDetaljer.header).isEqualTo(Avtalepart.tekstHeaderAvtaleErGodkjentAvAllePartner);
         assertThat(avtaleStatusDetaljer.infoDel1).isEqualTo(Avtalepart.tekstAvtaleErGodkjentAvAllePartner + avtale.getStartDato().format(Avtalepart.formatter)+".");
         assertThat(avtaleStatusDetaljer.infoDel2).isEqualTo(Veileder.ekstraTekstAvtleErGodkjentAvAllePartner);


### PR DESCRIPTION
Gjør om `InnloggetSelvbetjeningbruker` til `InnloggetDeltaker` og `InnloggetArbeidsgiver`, for å kunne gjøre mer spesifikke spørringer mot databasen og droppe `AvtaleRepository.findAll()`-kallet.