### PR TITLE
Bruk gcp-versjon av altinn-rettigheter-proxy

### DIFF
--- a/src/main/resources/config/application-dev-fss.yaml
+++ b/src/main/resources/config/application-dev-fss.yaml
@@ -36,7 +36,7 @@ tiltaksgjennomforing:
     max-lifetime: 300000
   altinn-tilgangsstyring:
     uri: https://api-gw-q1.adeo.no
-    proxyUri: https://arbeidsgiver.nais.preprod.local/altinn-rettigheter-proxy
+    proxyUri: https://arbeidsgiver.dev.intern.nav.no/altinn-rettigheter-proxy
     beOmRettighetBaseUrl: https://arbeidsgiver-q.nav.no/min-side-arbeidsgiver/?fragment=be-om-tilgang
     ltsMidlertidigServiceCode: 5516
     ltsMidlertidigServiceEdition: 1

--- a/src/main/resources/config/application-prod-fss.yaml
+++ b/src/main/resources/config/application-prod-fss.yaml
@@ -36,7 +36,7 @@ tiltaksgjennomforing:
     max-lifetime: 300000
   altinn-tilgangsstyring:
     uri: https://api-gw.adeo.no/
-    proxyUri: https://arbeidsgiver.nais.adeo.no/altinn-rettigheter-proxy/
+    proxyUri: https://arbeidsgiver.intern.nav.no/altinn-rettigheter-proxy/
     beOmRettighetBaseUrl: https://arbeidsgiver.nav.no/min-side-arbeidsgiver/?fragment=be-om-tilgang
     ltsMidlertidigServiceCode: 5516
     ltsMidlertidigServiceEdition: 1


### PR DESCRIPTION
Altinn-rettigheter-proxy er nå tilgjengelig på gcp.

Vi har allerede byttet to applikasjoner over til gcp-versjonen uten problemer. Siden dere bruker altinn-rettigheter-proxy-klient, er det også mindre risiko, siden dere kaller altinn direkte ved problemer.