### PR TITLE
Now som nav i datotesting

### DIFF
--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/Arbeidsgiver.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/Arbeidsgiver.java
@@ -1,15 +1,5 @@
 package no.nav.tag.tiltaksgjennomforing.avtale;
 
-import java.time.Instant;
-import java.time.LocalDate;
-import java.time.temporal.ChronoUnit;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.UUID;
-import java.util.stream.Collectors;
 import no.nav.arbeidsgiver.altinnrettigheter.proxy.klient.model.AltinnReportee;
 import no.nav.tag.tiltaksgjennomforing.autorisasjon.InnloggetArbeidsgiver;
 import no.nav.tag.tiltaksgjennomforing.autorisasjon.InnloggetBruker;
@@ -18,6 +8,12 @@ import no.nav.tag.tiltaksgjennomforing.exceptions.TilgangskontrollException;
 import no.nav.tag.tiltaksgjennomforing.exceptions.VarighetDatoErTilbakeITidException;
 import no.nav.tag.tiltaksgjennomforing.persondata.PdlRespons;
 import no.nav.tag.tiltaksgjennomforing.persondata.PersondataService;
+import no.nav.tag.tiltaksgjennomforing.utils.Now;
+
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+import java.util.*;
+import java.util.stream.Collectors;
 
 
 public class Arbeidsgiver extends Avtalepart<Fnr> {
@@ -39,11 +35,11 @@ public class Arbeidsgiver extends Avtalepart<Fnr> {
     }
 
     private static boolean avbruttForMerEnn12UkerSiden(Avtale avtale) {
-        return avtale.isAvbrutt() && avtale.getSistEndret().plus(84, ChronoUnit.DAYS).isBefore(Instant.now());
+        return avtale.isAvbrutt() && avtale.getSistEndret().plus(84, ChronoUnit.DAYS).isBefore(Now.instant());
     }
 
     private static boolean sluttdatoPassertMedMerEnn12Uker(Avtale avtale) {
-        return avtale.erGodkjentAvVeileder() && avtale.getSluttDato().plusWeeks(12).isBefore(LocalDate.now());
+        return avtale.erGodkjentAvVeileder() && avtale.getSluttDato().plusWeeks(12).isBefore(Now.localDate());
     }
 
     private static Avtale fjernAvbruttGrunn(Avtale avtale) {
@@ -61,10 +57,10 @@ public class Arbeidsgiver extends Avtalepart<Fnr> {
         if (!avtale.erUfordelt()) {
             return;
         }
-        if (startDato != null && startDato.isBefore(LocalDate.now())) {
+        if (startDato != null && startDato.isBefore(Now.localDate())) {
             throw new VarighetDatoErTilbakeITidException();
         }
-        if (sluttDato != null && sluttDato.isBefore(LocalDate.now())) {
+        if (sluttDato != null && sluttDato.isBefore(Now.localDate())) {
             throw new VarighetDatoErTilbakeITidException();
         }
     }

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleForkortetEntitet.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleForkortetEntitet.java
@@ -1,6 +1,7 @@
 package no.nav.tag.tiltaksgjennomforing.avtale;
 
 import lombok.Data;
+import no.nav.tag.tiltaksgjennomforing.utils.Now;
 
 import javax.persistence.Convert;
 import javax.persistence.Entity;
@@ -32,7 +33,7 @@ public class AvtaleForkortetEntitet {
         this.id = UUID.randomUUID();
         this.avtaleId = avtale.getId();
         this.avtaleInnholdId = avtaleInnhold.getId();
-        this.tidspunkt = Instant.now();
+        this.tidspunkt = Now.instant();
         this.utførtAv = utførtAv;
         this.nySluttDato = nySluttDato;
         this.grunn = grunn;

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/BaseAvtaleInnholdStrategy.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/BaseAvtaleInnholdStrategy.java
@@ -1,7 +1,8 @@
 package no.nav.tag.tiltaksgjennomforing.avtale;
 
+import no.nav.tag.tiltaksgjennomforing.utils.Now;
+
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -59,6 +60,6 @@ public abstract class BaseAvtaleInnholdStrategy implements AvtaleInnholdStrategy
     @Override
     public void endreSluttDato(LocalDate nySluttDato) {
         avtaleInnhold.setSluttDato(nySluttDato);
-        avtaleInnhold.setIkrafttredelsestidspunkt(LocalDateTime.now());
+        avtaleInnhold.setIkrafttredelsestidspunkt(Now.localDateTime());
     }
 }

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/Fnr.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/Fnr.java
@@ -1,6 +1,7 @@
 package no.nav.tag.tiltaksgjennomforing.avtale;
 
 import no.nav.tag.tiltaksgjennomforing.exceptions.TiltaksgjennomforingException;
+import no.nav.tag.tiltaksgjennomforing.utils.Now;
 
 import java.time.LocalDate;
 
@@ -28,19 +29,19 @@ public class Fnr extends Identifikator {
         if (this.asString().equals("00000000000")) {
             return false;
         }
-        return this.fødselsdato().isAfter(LocalDate.now().minusYears(16));
+        return this.fødselsdato().isAfter(Now.localDate().minusYears(16));
     }
 
     public boolean erOver30år() {
         if (this.asString().equals("00000000000")) {
             return false;
         }
-        return this.fødselsdato().isBefore(LocalDate.now().minusYears(30));
+        return this.fødselsdato().isBefore(Now.localDate().minusYears(30));
     }
 
     private static LocalDate førsteJanuarIÅr() {
-        return LocalDate.now()
-                .minusMonths(LocalDate.now().getMonthValue() - 1).minusDays(LocalDate.now().getDayOfMonth() - 1);
+        return Now.localDate()
+                .minusMonths(Now.localDate().getMonthValue() - 1).minusDays(Now.localDate().getDayOfMonth() - 1);
     }
 
     public boolean erOver30årFørsteJanuar() {

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/TilskuddPeriode.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/TilskuddPeriode.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.*;
 import no.nav.tag.tiltaksgjennomforing.exceptions.Feilkode;
 import no.nav.tag.tiltaksgjennomforing.exceptions.FeilkodeException;
+import no.nav.tag.tiltaksgjennomforing.utils.Now;
 import org.apache.commons.lang3.builder.CompareToBuilder;
 import org.jetbrains.annotations.NotNull;
 
@@ -86,7 +87,7 @@ public class TilskuddPeriode implements Comparable<TilskuddPeriode> {
         if (status != TilskuddPeriodeStatus.UBEHANDLET) {
             throw new FeilkodeException(Feilkode.TILSKUDDSPERIODE_ER_ALLEREDE_BEHANDLET);
         }
-        if (LocalDate.now().isBefore(kanBesluttesFom())) {
+        if (Now.localDate().isBefore(kanBesluttesFom())) {
             throw new FeilkodeException(Feilkode.TILSKUDDSPERIODE_BEHANDLE_FOR_TIDLIG);
         }
     }
@@ -102,7 +103,7 @@ public class TilskuddPeriode implements Comparable<TilskuddPeriode> {
     void godkjenn(NavIdent beslutter, String enhet) {
         sjekkOmKanBehandles();
 
-        setGodkjentTidspunkt(LocalDateTime.now());
+        setGodkjentTidspunkt(Now.localDateTime());
         setGodkjentAvNavIdent(beslutter);
         setEnhet(enhet);
         setStatus(TilskuddPeriodeStatus.GODKJENT);
@@ -117,7 +118,7 @@ public class TilskuddPeriode implements Comparable<TilskuddPeriode> {
             throw new FeilkodeException(Feilkode.TILSKUDDSPERIODE_INGEN_AVSLAGSAARSAKER);
         }
 
-        setAvslåttTidspunkt(LocalDateTime.now());
+        setAvslåttTidspunkt(Now.localDateTime());
         setAvslåttAvNavIdent(beslutter);
         this.avslagsårsaker.addAll(avslagsårsaker);
         setAvslagsforklaring(avslagsforklaring);

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/datavarehus/DvhAvtalehendelseLytter.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/datavarehus/DvhAvtalehendelseLytter.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import no.nav.tag.tiltaksgjennomforing.avtale.Avtale;
 import no.nav.tag.tiltaksgjennomforing.avtale.NavIdent;
 import no.nav.tag.tiltaksgjennomforing.avtale.events.*;
+import no.nav.tag.tiltaksgjennomforing.utils.Now;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 
@@ -66,7 +67,7 @@ public class DvhAvtalehendelseLytter {
         if (!dvhMeldingFilter.skalTilDatavarehus(avtale)) {
             return;
         }
-        LocalDateTime tidspunkt = LocalDateTime.now();
+        LocalDateTime tidspunkt = Now.localDateTime();
         UUID meldingId = UUID.randomUUID();
         DvhHendelseType hendelseType = endret;
         var melding = AvroTiltakHendelseFabrikk.konstruer(avtale, tidspunkt, meldingId, hendelseType, utførtAv.asString());

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/datavarehus/DvhStatusendringJobb.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/datavarehus/DvhStatusendringJobb.java
@@ -5,6 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import no.nav.tag.tiltaksgjennomforing.avtale.Avtale;
 import no.nav.tag.tiltaksgjennomforing.avtale.AvtaleRepository;
 import no.nav.tag.tiltaksgjennomforing.leader.LeaderPodCheck;
+import no.nav.tag.tiltaksgjennomforing.utils.Now;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
@@ -42,7 +43,7 @@ public class DvhStatusendringJobb {
                 continue;
             }
             if (avtale.statusSomEnum() != dvhMeldingEntitet.getTiltakStatus()) {
-                LocalDateTime tidspunkt = LocalDateTime.now();
+                LocalDateTime tidspunkt = Now.localDateTime();
                 AvroTiltakHendelse avroTiltakHendelse = AvroTiltakHendelseFabrikk.konstruer(avtale, tidspunkt, UUID.randomUUID(), DvhHendelseType.STATUSENDRING, "system");
                 dvhMeldingRepository.save(new DvhMeldingEntitet(UUID.randomUUID(), avtaleId, tidspunkt, avtale.statusSomEnum(), avroTiltakHendelse));
                 log.info("Avtale med id {} har byttet status til {}, siste melding har status {}, så sender melding med den nye statusen til datavarehus", avtale.getId(), avtale.statusSomEnum(), dvhMeldingEntitet.getTiltakStatus());

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/datavarehus/InternalDvhMeldingProdusentController.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/datavarehus/InternalDvhMeldingProdusentController.java
@@ -7,6 +7,7 @@ import no.nav.security.token.support.core.api.ProtectedWithClaims;
 import no.nav.tag.tiltaksgjennomforing.autorisasjon.TokenUtils;
 import no.nav.tag.tiltaksgjennomforing.avtale.AvtaleRepository;
 import no.nav.tag.tiltaksgjennomforing.avtale.Tiltakstype;
+import no.nav.tag.tiltaksgjennomforing.utils.Now;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -14,7 +15,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.client.HttpClientErrorException;
 
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 
@@ -38,8 +38,8 @@ public class InternalDvhMeldingProdusentController {
         avtaleRepository.findAllById(request.getAvtaleIder()).forEach(avtale -> {
             UUID meldingId = UUID.randomUUID();
             String utførtAv = tokenUtils.hentBrukerOgIssuer().map(TokenUtils.BrukerOgIssuer::getBrukerIdent).orElse("patch");
-            AvroTiltakHendelse avroTiltakHendelse = AvroTiltakHendelseFabrikk.konstruer(avtale, LocalDateTime.now(), meldingId, DvhHendelseType.PATCHING, utførtAv);
-            dvhMeldingRepository.save(new DvhMeldingEntitet(meldingId, avtale.getId(), LocalDateTime.now(), avtale.statusSomEnum(), avroTiltakHendelse));
+            AvroTiltakHendelse avroTiltakHendelse = AvroTiltakHendelseFabrikk.konstruer(avtale, Now.localDateTime(), meldingId, DvhHendelseType.PATCHING, utførtAv);
+            dvhMeldingRepository.save(new DvhMeldingEntitet(meldingId, avtale.getId(), Now.localDateTime(), avtale.statusSomEnum(), avroTiltakHendelse));
             log.info("Patchet avtale {}, sendt melding med id {} til datavarehus", avtale.getId(), meldingId);
         });
     }

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/hendelselogg/Hendelselogg.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/hendelselogg/Hendelselogg.java
@@ -2,6 +2,7 @@ package no.nav.tag.tiltaksgjennomforing.hendelselogg;
 
 import lombok.Data;
 import no.nav.tag.tiltaksgjennomforing.avtale.Avtalerolle;
+import no.nav.tag.tiltaksgjennomforing.utils.Now;
 import no.nav.tag.tiltaksgjennomforing.varsel.VarslbarHendelseType;
 
 import javax.persistence.Entity;
@@ -27,7 +28,7 @@ public class Hendelselogg {
         Hendelselogg hendelselogg = new Hendelselogg();
         hendelselogg.setId(UUID.randomUUID());
         hendelselogg.setAvtaleId(avtaleId);
-        hendelselogg.setTidspunkt(LocalDateTime.now());
+        hendelselogg.setTidspunkt(Now.localDateTime());
         hendelselogg.setUtførtAv(utførtAv);
         hendelselogg.setHendelse(hendelse);
         return hendelselogg;

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/utils/Now.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/utils/Now.java
@@ -1,0 +1,33 @@
+package no.nav.tag.tiltaksgjennomforing.utils;
+
+import java.time.*;
+
+// Inspirasjon fra https://medium.com/agorapulse-stories/how-to-solve-now-problem-in-your-java-tests-7c7f4a6d703c
+public class Now {
+    private static ThreadLocal<Clock> clock = ThreadLocal.withInitial(Clock::systemDefaultZone);
+
+    public static void fixedDate(LocalDate localDate) {
+        Instant instant = ZonedDateTime.of(localDate.atStartOfDay(), ZoneId.systemDefault()).toInstant();
+        clock.set(Clock.fixed(instant, ZoneId.systemDefault()));
+    }
+
+    public static void resetClock() {
+        Now.clock.set(Clock.systemDefaultZone());
+    }
+
+    public static Instant instant() {
+        return Instant.now(clock.get());
+    }
+
+    public static LocalDate localDate() {
+        return LocalDate.now(clock.get());
+    }
+
+    public static LocalDateTime localDateTime() {
+        return LocalDateTime.now(clock.get());
+    }
+
+    public static YearMonth yearMonth() {
+        return YearMonth.now(clock.get());
+    }
+}

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/varsel/BjelleVarsel.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/varsel/BjelleVarsel.java
@@ -8,6 +8,7 @@ import no.nav.tag.tiltaksgjennomforing.avtale.Avtale;
 import no.nav.tag.tiltaksgjennomforing.avtale.Identifikator;
 import no.nav.tag.tiltaksgjennomforing.avtale.IdentifikatorConverter;
 import no.nav.tag.tiltaksgjennomforing.avtale.TilskuddPeriode;
+import no.nav.tag.tiltaksgjennomforing.utils.Now;
 import org.springframework.data.domain.AbstractAggregateRoot;
 
 import javax.persistence.*;
@@ -53,7 +54,7 @@ public class BjelleVarsel extends AbstractAggregateRoot<BjelleVarsel> {
     public static BjelleVarsel nyttVarsel(Identifikator identifikator, VarslbarHendelse varslbarHendelse, Avtale avtale) {
         BjelleVarsel varsel = new BjelleVarsel();
         varsel.id = UUID.randomUUID();
-        varsel.tidspunkt = LocalDateTime.now();
+        varsel.tidspunkt = Now.localDateTime();
         varsel.identifikator = identifikator;
         varsel.varslbarHendelse = varslbarHendelse.getId();
         varsel.varslingstekst = getVarslbarHendelseTekst(varslbarHendelse, avtale);

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/varsel/BjelleVarselService.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/varsel/BjelleVarselService.java
@@ -2,9 +2,9 @@ package no.nav.tag.tiltaksgjennomforing.varsel;
 
 import lombok.RequiredArgsConstructor;
 import no.nav.tag.tiltaksgjennomforing.avtale.Avtalepart;
+import no.nav.tag.tiltaksgjennomforing.utils.Now;
 import org.springframework.stereotype.Service;
 
-import java.time.LocalDateTime;
 import java.util.Comparator;
 import java.util.List;
 import java.util.UUID;
@@ -46,7 +46,7 @@ public class BjelleVarselService {
     }
 
     private Stream<BjelleVarsel> bjelleVarslerForAvtalepart(Avtalepart avtalepart) {
-        return bjelleVarselRepository.findAllByTidspunktAfter(LocalDateTime.now().minusDays(1)).stream()
+        return bjelleVarselRepository.findAllByTidspunktAfter(Now.localDateTime().minusDays(1)).stream()
                 .filter(bjelleVarsel -> avtalepart.identifikatorer().contains(bjelleVarsel.getIdentifikator()))
                 .sorted(Comparator.comparing(BjelleVarsel::getTidspunkt).reversed());
     }

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/varsel/Varsel.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/varsel/Varsel.java
@@ -5,6 +5,7 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.RequiredArgsConstructor;
 import no.nav.tag.tiltaksgjennomforing.avtale.*;
+import no.nav.tag.tiltaksgjennomforing.utils.Now;
 import org.springframework.data.domain.AbstractAggregateRoot;
 
 import javax.persistence.*;
@@ -63,7 +64,7 @@ public class Varsel extends AbstractAggregateRoot<Varsel> {
     public static Varsel nyttVarsel(Identifikator identifikator, boolean bjelle, Avtale avtale, Avtalerolle mottaker, Avtalerolle utførtAv, VarslbarHendelseType varslbarHendelseType, UUID avtaleId) {
         Varsel varsel = new Varsel();
         varsel.id = UUID.randomUUID();
-        varsel.tidspunkt = LocalDateTime.now();
+        varsel.tidspunkt = Now.localDateTime();
         varsel.identifikator = identifikator;
         varsel.tekst = getVarslbarHendelseTekst(avtale, varslbarHendelseType);
         varsel.hendelseType = varslbarHendelseType;

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/varsel/VarslbarHendelse.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/varsel/VarslbarHendelse.java
@@ -4,6 +4,7 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import no.nav.tag.tiltaksgjennomforing.avtale.Avtale;
 import no.nav.tag.tiltaksgjennomforing.avtale.events.GamleVerdier;
+import no.nav.tag.tiltaksgjennomforing.utils.Now;
 import no.nav.tag.tiltaksgjennomforing.varsel.events.VarslbarHendelseOppstaatt;
 import org.springframework.data.domain.AbstractAggregateRoot;
 
@@ -32,7 +33,7 @@ public class VarslbarHendelse extends AbstractAggregateRoot<VarslbarHendelse> {
     public static VarslbarHendelse nyHendelse(Avtale avtale, VarslbarHendelseType varslbarHendelseType, GamleVerdier gamleVerdier) {
         VarslbarHendelse varslbarHendelse = new VarslbarHendelse();
         varslbarHendelse.id = UUID.randomUUID();
-        varslbarHendelse.tidspunkt = LocalDateTime.now();
+        varslbarHendelse.tidspunkt = Now.localDateTime();
         varslbarHendelse.avtaleId = avtale.getId();
         varslbarHendelse.varslbarHendelseType = varslbarHendelseType;
         varslbarHendelse.registerEvent(new VarslbarHendelseOppstaatt(avtale, varslbarHendelse, gamleVerdier));

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/varsel/notifikasjon/ArbeidsgiverNotifikasjon.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/varsel/notifikasjon/ArbeidsgiverNotifikasjon.java
@@ -7,7 +7,9 @@ import lombok.RequiredArgsConstructor;
 import no.nav.tag.tiltaksgjennomforing.avtale.Avtale;
 import no.nav.tag.tiltaksgjennomforing.avtale.BedriftNr;
 import no.nav.tag.tiltaksgjennomforing.avtale.BedriftNrConverter;
+import no.nav.tag.tiltaksgjennomforing.utils.Now;
 import no.nav.tag.tiltaksgjennomforing.varsel.VarslbarHendelseType;
+
 import javax.persistence.*;
 import java.time.LocalDateTime;
 import java.util.UUID;
@@ -50,7 +52,7 @@ public class ArbeidsgiverNotifikasjon {
 
         ArbeidsgiverNotifikasjon notifikasjon = new ArbeidsgiverNotifikasjon();
         notifikasjon.id = UUID.randomUUID();
-        notifikasjon.tidspunkt = LocalDateTime.now();
+        notifikasjon.tidspunkt = Now.localDateTime();
         notifikasjon.avtaleId = avtale.getId();
         notifikasjon.hendelseType = varslbarHendelseType;
         notifikasjon.virksomhetsnummer = avtale.getBedriftNr();

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/varsel/oppgave/OppgaveRequest.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/varsel/oppgave/OppgaveRequest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import no.nav.tag.tiltaksgjennomforing.avtale.Tiltakstype;
+import no.nav.tag.tiltaksgjennomforing.utils.Now;
 
 import java.time.LocalDate;
 
@@ -25,7 +26,7 @@ public class OppgaveRequest {
     private final String behandlingstema;
 
     @JsonFormat(pattern = "yyyy-MM-dd")
-    private final LocalDate aktivDato = LocalDate.now();
+    private final LocalDate aktivDato = Now.localDate();
     private final String aktoerId;
 
     public OppgaveRequest(String aktørId, Tiltakstype tiltakstype) {

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/LastInnTestData.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/LastInnTestData.java
@@ -5,12 +5,11 @@ import lombok.extern.slf4j.Slf4j;
 import no.nav.tag.tiltaksgjennomforing.avtale.Avtale;
 import no.nav.tag.tiltaksgjennomforing.avtale.AvtaleRepository;
 import no.nav.tag.tiltaksgjennomforing.avtale.TestData;
+import no.nav.tag.tiltaksgjennomforing.utils.Now;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.ApplicationListener;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
-
-import java.time.LocalDateTime;
 
 @Component
 @RequiredArgsConstructor
@@ -28,7 +27,7 @@ public class LastInnTestData implements ApplicationListener<ApplicationReadyEven
         avtaleRepository.save(TestData.enAvtaleMedFlereVersjoner());
         avtaleRepository.save(TestData.enAvtaleKlarForOppstart());
         Avtale lilly = TestData.enLonnstilskuddAvtaleMedAltUtfylt();
-        lilly.setGodkjentAvArbeidsgiver(LocalDateTime.now());
+        lilly.setGodkjentAvArbeidsgiver(Now.localDateTime());
         avtaleRepository.save(lilly);
         avtaleRepository.save(TestData.enLonnstilskuddAvtaleGodkjentAvVeileder());
         avtaleRepository.save(TestData.enLonnstilskuddAvtaleGodkjentAvVeilederTilbakeITid());

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/InnloggetBrukerTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/InnloggetBrukerTest.java
@@ -5,11 +5,10 @@ import no.nav.tag.tiltaksgjennomforing.avtale.*;
 import no.nav.tag.tiltaksgjennomforing.enhet.Norg2Client;
 import no.nav.tag.tiltaksgjennomforing.okonomi.KontoregisterService;
 import no.nav.tag.tiltaksgjennomforing.persondata.PersondataService;
+import no.nav.tag.tiltaksgjennomforing.utils.Now;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.time.Instant;
-import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
 import java.util.Collection;
 import java.util.Collections;
@@ -116,14 +115,14 @@ public class InnloggetBrukerTest {
         Map<BedriftNr, Collection<Tiltakstype>> tilganger = Map.of(this.bedriftNr, Set.of(Tiltakstype.values()));
         Arbeidsgiver arbeidsgiver = new Arbeidsgiver(new Fnr("00000000009"), Set.of(), tilganger, null, null);
         avtale.setAvbrutt(true);
-        avtale.setSistEndret(Instant.now().minus(84, ChronoUnit.DAYS).minusMillis(100));
+        avtale.setSistEndret(Now.instant().minus(84, ChronoUnit.DAYS).minusMillis(100));
         assertThat(arbeidsgiver.harTilgang(avtale)).isFalse();
     }
 
     @Test
     public void harTilgang__arbeidsgiver_skal_ikke_ha_tilgang_til_avsluttet_avtale_eldre_enn_12_uker() {
         Avtale avtale = TestData.enAvtaleMedAltUtfyltGodkjentAvVeileder();
-        avtale.setSluttDato(LocalDate.now().minusDays(85));
+        avtale.setSluttDato(Now.localDate().minusDays(85));
         Map<BedriftNr, Collection<Tiltakstype>> tilganger = Map.of(avtale.getBedriftNr(), Set.of(Tiltakstype.values()));
         Arbeidsgiver Arbeidsgiver = new Arbeidsgiver(new Fnr("00000000009"), Set.of(), tilganger, null, null);
         assertThat(Arbeidsgiver.harTilgang(avtale)).isFalse();
@@ -132,7 +131,7 @@ public class InnloggetBrukerTest {
     @Test
     public void harTilgang__arbeidsgiver_skal_ha_tilgang_til_avsluttet_avtale_eldre_enn_12_uker_når_ikke_godkjent_av_veileder() {
         Avtale avtale = TestData.enAvtaleMedAltUtfylt();
-        avtale.setSluttDato(LocalDate.now().minusDays(85));
+        avtale.setSluttDato(Now.localDate().minusDays(85));
         Map<BedriftNr, Collection<Tiltakstype>> tilganger = Map.of(avtale.getBedriftNr(), Set.of(Tiltakstype.values()));
         Arbeidsgiver Arbeidsgiver = new Arbeidsgiver(new Fnr("00000000009"), Set.of(), tilganger, null, null);
         assertThat(Arbeidsgiver.harTilgang(avtale)).isTrue();

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/ArbeidsgiverTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/ArbeidsgiverTest.java
@@ -7,10 +7,9 @@ import no.nav.tag.tiltaksgjennomforing.exceptions.KanIkkeOppheveException;
 import no.nav.tag.tiltaksgjennomforing.exceptions.VarighetDatoErTilbakeITidException;
 import no.nav.tag.tiltaksgjennomforing.persondata.PdlRespons;
 import no.nav.tag.tiltaksgjennomforing.persondata.PersondataService;
+import no.nav.tag.tiltaksgjennomforing.utils.Now;
 import org.junit.jupiter.api.Test;
 
-import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.Map;
 import java.util.Set;
 
@@ -24,7 +23,7 @@ public class ArbeidsgiverTest {
     @Test
     public void opphevGodkjenninger__kan_oppheve_ved_deltakergodkjenning() {
         Avtale avtale = TestData.enAvtaleMedAltUtfylt();
-        avtale.setGodkjentAvDeltaker(LocalDateTime.now());
+        avtale.setGodkjentAvDeltaker(Now.localDateTime());
         Arbeidsgiver arbeidsgiver = TestData.enArbeidsgiver(avtale);
         arbeidsgiver.opphevGodkjenninger(avtale);
         assertThat(avtale.erGodkjentAvDeltaker()).isFalse();
@@ -33,7 +32,7 @@ public class ArbeidsgiverTest {
     @Test
     public void opphevGodkjenninger__kan_ikke_oppheve_veiledergodkjenning() {
         Avtale avtale = TestData.enAvtaleMedAltUtfylt();
-        avtale.setGodkjentAvVeileder(LocalDateTime.now());
+        avtale.setGodkjentAvVeileder(Now.localDateTime());
         Arbeidsgiver arbeidsgiver = TestData.enArbeidsgiver(avtale);
         assertThatThrownBy(() -> arbeidsgiver.opphevGodkjenninger(avtale)).isInstanceOf(KanIkkeOppheveException.class);
     }
@@ -68,13 +67,13 @@ public class ArbeidsgiverTest {
     public void endreAvtale_validererFraDato() {
         Avtale avtale = TestData.enArbeidstreningAvtaleOpprettetAvArbeidsgiverOgErUfordelt();
         Arbeidsgiver arbeidsgiver = new Arbeidsgiver(null, null, null, null, null);
-        assertThatThrownBy(() -> arbeidsgiver.avvisDatoerTilbakeITid(avtale, LocalDate.now().minusDays(1), null)).isInstanceOf(VarighetDatoErTilbakeITidException.class);
+        assertThatThrownBy(() -> arbeidsgiver.avvisDatoerTilbakeITid(avtale, Now.localDate().minusDays(1), null)).isInstanceOf(VarighetDatoErTilbakeITidException.class);
     }
 
     @Test
     public void endreAvtale_validererTilDato() {
         Avtale avtale = TestData.enArbeidstreningAvtaleOpprettetAvArbeidsgiverOgErUfordelt();
         Arbeidsgiver arbeidsgiver = new Arbeidsgiver(null, null, null, null, null);
-        assertThatThrownBy(() -> arbeidsgiver.avvisDatoerTilbakeITid(avtale, LocalDate.now(), LocalDate.now().minusDays(1))).isInstanceOf(VarighetDatoErTilbakeITidException.class);
+        assertThatThrownBy(() -> arbeidsgiver.avvisDatoerTilbakeITid(avtale, Now.localDate(), Now.localDate().minusDays(1))).isInstanceOf(VarighetDatoErTilbakeITidException.class);
     }
 }

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleControllerTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleControllerTest.java
@@ -11,6 +11,7 @@ import no.nav.tag.tiltaksgjennomforing.orgenhet.EregService;
 import no.nav.tag.tiltaksgjennomforing.orgenhet.Organisasjon;
 import no.nav.tag.tiltaksgjennomforing.persondata.PdlRespons;
 import no.nav.tag.tiltaksgjennomforing.persondata.PersondataService;
+import no.nav.tag.tiltaksgjennomforing.utils.Now;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -20,7 +21,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
-import java.time.LocalDate;
 import java.util.*;
 
 import static java.util.Arrays.asList;
@@ -396,7 +396,7 @@ public class AvtaleControllerTest {
     @Test
     public void avtaleStatus__godkjent_av_alle_parter() {
         Avtale avtale = TestData.enAvtaleMedAltUtfyltGodkjentAvVeileder();
-        avtale.setStartDato(LocalDate.now().plusWeeks(1));
+        avtale.setStartDato(Now.localDate().plusWeeks(1));
         værInnloggetSom(TestData.enVeileder(avtale));
         when(avtaleRepository.findById(avtale.getId())).thenReturn(Optional.of(avtale));
         AvtaleStatusDetaljer avtaleStatusDetaljer = avtaleController.hentAvtaleStatusDetaljer(avtale.getId(), Avtalerolle.VEILEDER);

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleRepositoryTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleRepositoryTest.java
@@ -4,6 +4,7 @@ import no.nav.tag.tiltaksgjennomforing.Miljø;
 import no.nav.tag.tiltaksgjennomforing.avtale.events.GodkjenningerOpphevetAvVeileder;
 import no.nav.tag.tiltaksgjennomforing.hendelselogg.HendelseloggRepository;
 import no.nav.tag.tiltaksgjennomforing.metrikker.MetrikkRegistrering;
+import no.nav.tag.tiltaksgjennomforing.utils.Now;
 import no.nav.tag.tiltaksgjennomforing.varsel.VarselRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -14,9 +15,7 @@ import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 
 import java.math.BigDecimal;
-import java.time.Instant;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Optional;
@@ -70,7 +69,7 @@ public class AvtaleRepositoryTest {
         EndreAvtale endreAvtale = new EndreAvtale();
         Maal maal = TestData.etMaal();
         endreAvtale.setMaal(List.of(maal));
-        lagretAvtale.endreAvtale(Instant.now(), endreAvtale, Avtalerolle.VEILEDER, EnumSet.of(lagretAvtale.getTiltakstype()));
+        lagretAvtale.endreAvtale(Now.instant(), endreAvtale, Avtalerolle.VEILEDER, EnumSet.of(lagretAvtale.getTiltakstype()));
         avtaleRepository.save(lagretAvtale);
 
         // Lage ny avtale
@@ -80,7 +79,7 @@ public class AvtaleRepositoryTest {
         EndreAvtale endreAvtale2 = new EndreAvtale();
         Maal maal2 = TestData.etMaal();
         endreAvtale2.setMaal(List.of(maal2));
-        lagretAvtale2.endreAvtale(Instant.now(), endreAvtale2, Avtalerolle.VEILEDER, EnumSet.of(lagretAvtale.getTiltakstype()));
+        lagretAvtale2.endreAvtale(Now.instant(), endreAvtale2, Avtalerolle.VEILEDER, EnumSet.of(lagretAvtale.getTiltakstype()));
         avtaleRepository.save(lagretAvtale2);
     }
 
@@ -91,7 +90,7 @@ public class AvtaleRepositoryTest {
 
         // Lagre maal skal fungere
         EndreAvtale endreAvtale = new EndreAvtale();
-        lagretAvtale.endreAvtale(Instant.now(), endreAvtale, Avtalerolle.VEILEDER, EnumSet.of(lagretAvtale.getTiltakstype()));
+        lagretAvtale.endreAvtale(Now.instant(), endreAvtale, Avtalerolle.VEILEDER, EnumSet.of(lagretAvtale.getTiltakstype()));
         avtaleRepository.save(lagretAvtale);
 
         // Lage ny avtale
@@ -99,7 +98,7 @@ public class AvtaleRepositoryTest {
 
         // Lagre maal skal enda fungere
         EndreAvtale endreAvtale2 = new EndreAvtale();
-        lagretAvtale2.endreAvtale(Instant.now(), endreAvtale2, Avtalerolle.VEILEDER, EnumSet.of(lagretAvtale2.getTiltakstype()));
+        lagretAvtale2.endreAvtale(Now.instant(), endreAvtale2, Avtalerolle.VEILEDER, EnumSet.of(lagretAvtale2.getTiltakstype()));
         avtaleRepository.save(lagretAvtale2);
     }
 
@@ -121,7 +120,7 @@ public class AvtaleRepositoryTest {
         endreAvtale.setArbeidsgiveravgift(BigDecimal.valueOf(0.141));
         endreAvtale.setLonnstilskuddProsent(40);
 
-        lagretAvtale.endreAvtale(Instant.now(), endreAvtale, Avtalerolle.VEILEDER, EnumSet.of(lagretAvtale.getTiltakstype()));
+        lagretAvtale.endreAvtale(Now.instant(), endreAvtale, Avtalerolle.VEILEDER, EnumSet.of(lagretAvtale.getTiltakstype()));
         Avtale nyLagretAvtale = avtaleRepository.save(lagretAvtale);
 
         var perioder = nyLagretAvtale.getTilskuddPeriode();
@@ -132,7 +131,7 @@ public class AvtaleRepositoryTest {
     @Test
     public void avtale_godkjent_pa_vegne_av_skal_lagres_med_pa_vegne_av_grunn() {
         Avtale avtale = TestData.enAvtaleMedAltUtfylt();
-        avtale.setGodkjentAvArbeidsgiver(LocalDateTime.now());
+        avtale.setGodkjentAvArbeidsgiver(Now.localDateTime());
         GodkjentPaVegneGrunn godkjentPaVegneGrunn = TestData.enGodkjentPaVegneGrunn();
         godkjentPaVegneGrunn.setIkkeBankId(true);
         Veileder veileder = TestData.enVeileder(avtale);
@@ -146,7 +145,7 @@ public class AvtaleRepositoryTest {
     @Test
     public void lagre_pa_vegne_skal_publisere_domainevent() {
         Avtale avtale = TestData.enAvtaleMedAltUtfylt();
-        avtale.setGodkjentAvArbeidsgiver(LocalDateTime.now());
+        avtale.setGodkjentAvArbeidsgiver(Now.localDateTime());
         Veileder veileder = TestData.enVeileder(avtale);
         GodkjentPaVegneGrunn godkjentPaVegneGrunn = TestData.enGodkjentPaVegneGrunn();
         veileder.godkjennForVeilederOgDeltaker(godkjentPaVegneGrunn, avtale);
@@ -167,7 +166,7 @@ public class AvtaleRepositoryTest {
         Avtale avtale = TestData.enArbeidstreningAvtale();
         avtaleRepository.save(avtale);
         verify(metrikkRegistrering, never()).avtaleEndret(any());
-        avtale.endreAvtale(Instant.now(), TestData.ingenEndring(), Avtalerolle.VEILEDER, EnumSet.of(avtale.getTiltakstype()));
+        avtale.endreAvtale(Now.instant(), TestData.ingenEndring(), Avtalerolle.VEILEDER, EnumSet.of(avtale.getTiltakstype()));
         avtaleRepository.save(avtale);
         verify(metrikkRegistrering).avtaleEndret(any());
     }
@@ -191,8 +190,8 @@ public class AvtaleRepositoryTest {
     @Test
     public void godkjennForVeileder__skal_publisere_domainevent() {
         Avtale avtale = TestData.enAvtaleMedAltUtfylt();
-        avtale.setGodkjentAvDeltaker(LocalDateTime.now());
-        avtale.setGodkjentAvArbeidsgiver(LocalDateTime.now());
+        avtale.setGodkjentAvDeltaker(Now.localDateTime());
+        avtale.setGodkjentAvArbeidsgiver(Now.localDateTime());
         TestData.enVeileder(avtale).godkjennAvtale(avtale.getSistEndret(), avtale);
         avtaleRepository.save(avtale);
         verify(metrikkRegistrering).godkjentAvVeileder(any());
@@ -210,7 +209,7 @@ public class AvtaleRepositoryTest {
     @Test
     public void finnGodkjenteAvtalerMedTilskuddsperiodestatusOgNavEnheter__skal_ikke_kunne_hente_avtale_med_tiltakstype_arbeidstrening() {
 
-        Avtale lagretAvtale = TestData.enLønnstilskuddsAvtaleMedStartOgSluttGodkjentAvAlleParter(LocalDate.now(), LocalDate.now().plusMonths(2));
+        Avtale lagretAvtale = TestData.enLønnstilskuddsAvtaleMedStartOgSluttGodkjentAvAlleParter(Now.localDate(), Now.localDate().plusMonths(2));
         lagretAvtale.setTiltakstype(Tiltakstype.ARBEIDSTRENING);
         avtaleRepository.save(lagretAvtale);
         Set<String> navEnheter = Set.of(ENHET_OPPFØLGING.getVerdi());
@@ -224,7 +223,7 @@ public class AvtaleRepositoryTest {
     @Test
     public void finnGodkjenteAvtalerMedTilskuddsperiodestatusOgNavEnheter__skal_kunne_hente_avtale_med_ubehandlet_tilskuddsperioder_for_riktig_enhet() {
 
-        Avtale lagretAvtale = avtaleRepository.save(TestData.enLønnstilskuddsAvtaleMedStartOgSluttGodkjentAvAlleParter(LocalDate.now(), LocalDate.now().plusDays(15)));
+        Avtale lagretAvtale = avtaleRepository.save(TestData.enLønnstilskuddsAvtaleMedStartOgSluttGodkjentAvAlleParter(Now.localDate(), Now.localDate().plusDays(15)));
         Set<String> navEnheter = Set.of(ENHET_OPPFØLGING.getVerdi());
 
         List<Avtale> avtalerMedTilskuddsperioder = avtaleRepository
@@ -250,7 +249,7 @@ public class AvtaleRepositoryTest {
     @Test
     public void finnGodkjenteAvtalerMedTilskuddsperiodestatusOgNavEnheter__skal_ikke_kunne_hente_avtale_med_feil_enhet() {
 
-        Avtale lagretAvtale = TestData.enLønnstilskuddsAvtaleMedStartOgSluttGodkjentAvAlleParter(LocalDate.now(), LocalDate.now().plusMonths(2));
+        Avtale lagretAvtale = TestData.enLønnstilskuddsAvtaleMedStartOgSluttGodkjentAvAlleParter(Now.localDate(), Now.localDate().plusMonths(2));
         Set<String> navEnheter = Set.of("0000");
 
         lagretAvtale.godkjennTilskuddsperiode(TestData.enInnloggetBeslutter().getIdentifikator(), lagretAvtale.getEnhetGeografisk());

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleTest.java
@@ -1,6 +1,7 @@
 package no.nav.tag.tiltaksgjennomforing.avtale;
 
 import no.nav.tag.tiltaksgjennomforing.exceptions.*;
+import no.nav.tag.tiltaksgjennomforing.utils.Now;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -8,7 +9,6 @@ import org.springframework.test.util.ReflectionTestUtils;
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.EnumSet;
 import java.util.List;
@@ -93,14 +93,14 @@ public class AvtaleTest {
     @Test
     public void sjekkVersjon__gyldig_versjon() {
         Avtale avtale = TestData.enArbeidstreningAvtale();
-        avtale.sjekkSistEndret(Instant.now());
+        avtale.sjekkSistEndret(Now.instant());
     }
 
     @Test
     public void endreAvtaleSkalOppdatereRiktigeFelt() {
         Avtale avtale = TestData.enArbeidstreningAvtale();
         EndreAvtale endreAvtale = TestData.endringPåAlleArbeidstreningFelter();
-        avtale.endreAvtale(Instant.now(), endreAvtale, Avtalerolle.VEILEDER, EnumSet.of(avtale.getTiltakstype()));
+        avtale.endreAvtale(Now.instant(), endreAvtale, Avtalerolle.VEILEDER, EnumSet.of(avtale.getTiltakstype()));
 
         SoftAssertions.assertSoftly(softly -> {
             softly.assertThat(avtale.getDeltakerFornavn()).isEqualTo(endreAvtale.getDeltakerFornavn());
@@ -130,16 +130,16 @@ public class AvtaleTest {
         etMaal.setBeskrivelse("Dette er en string pa 1024 tegn.Dette er en string pa 1024 tegn.Dette er en string pa 1024 tegn.Dette er en string pa 1024 tegn.Dette er en string pa 1024 tegn.Dette er en string pa 1024 tegn.Dette er en string pa 1024 tegn.Dette er en string pa 1024 tegn.Dette er en string pa 1024 tegn.Dette er en string pa 1024 tegn.Dette er en string pa 1024 tegn.Dette er en string pa 1024 tegn.Dette er en string pa 1024 tegn.Dette er en string pa 1024 tegn.Dette er en string pa 1024 tegn.Dette er en string pa 1024 tegn.Dette er en string pa 1024 tegn.Dette er en string pa 1024 tegn.Dette er en string pa 1024 tegn.Dette er en string pa 1024 tegn.Dette er en string pa 1024 tegn.Dette er en string pa 1024 tegn.Dette er en string pa 1024 tegn.Dette er en string pa 1024 tegn.Dette er en string pa 1024 tegn.Dette er en string pa 1024 tegn.Dette er en string pa 1024 tegn.Dette er en string pa 1024 tegn.Dette er en string pa 1024 tegn.Dette er en string pa 1024 tegn.Dette er en string pa 1024 tegn.Dette er en string pa 1024 tegn.");
         EndreAvtale endreAvtale = new EndreAvtale();
         endreAvtale.setMaal(List.of(etMaal));
-        assertThatThrownBy(() -> avtale.endreAvtale(Instant.now(), endreAvtale, Avtalerolle.VEILEDER, EnumSet.of(avtale.getTiltakstype()))).isInstanceOf(TiltaksgjennomforingException.class);
+        assertThatThrownBy(() -> avtale.endreAvtale(Now.instant(), endreAvtale, Avtalerolle.VEILEDER, EnumSet.of(avtale.getTiltakstype()))).isInstanceOf(TiltaksgjennomforingException.class);
     }
 
     @Test
     public void endreAvtale__startdato_satt_men_ikke_sluttdato() {
         Avtale avtale = TestData.enArbeidstreningAvtale();
         EndreAvtale endreAvtale = new EndreAvtale();
-        LocalDate startDato = LocalDate.now();
+        LocalDate startDato = Now.localDate();
         endreAvtale.setStartDato(startDato);
-        avtale.endreAvtale(Instant.now(), endreAvtale, Avtalerolle.VEILEDER, EnumSet.of(avtale.getTiltakstype()));
+        avtale.endreAvtale(Now.instant(), endreAvtale, Avtalerolle.VEILEDER, EnumSet.of(avtale.getTiltakstype()));
         assertThat(avtale.getStartDato()).isEqualTo(startDato);
     }
 
@@ -147,9 +147,9 @@ public class AvtaleTest {
     public void endreAvtale__sluttdato_satt_men_ikke_startdato() {
         Avtale avtale = TestData.enArbeidstreningAvtale();
         EndreAvtale endreAvtale = new EndreAvtale();
-        LocalDate sluttDato = LocalDate.now();
+        LocalDate sluttDato = Now.localDate();
         endreAvtale.setSluttDato(sluttDato);
-        avtale.endreAvtale(Instant.now(), endreAvtale, Avtalerolle.VEILEDER, EnumSet.of(avtale.getTiltakstype()));
+        avtale.endreAvtale(Now.instant(), endreAvtale, Avtalerolle.VEILEDER, EnumSet.of(avtale.getTiltakstype()));
         assertThat(avtale.getSluttDato()).isEqualTo(sluttDato);
     }
 
@@ -157,11 +157,11 @@ public class AvtaleTest {
     public void endreAvtale__startdato_og_sluttdato_satt_18mnd() {
         Avtale avtale = TestData.enArbeidstreningAvtale();
         EndreAvtale endreAvtale = new EndreAvtale();
-        LocalDate startDato = LocalDate.now();
+        LocalDate startDato = Now.localDate();
         LocalDate sluttDato = startDato.plusMonths(18);
         endreAvtale.setStartDato(startDato);
         endreAvtale.setSluttDato(sluttDato);
-        avtale.endreAvtale(Instant.now(), endreAvtale, Avtalerolle.VEILEDER, EnumSet.of(avtale.getTiltakstype()));
+        avtale.endreAvtale(Now.instant(), endreAvtale, Avtalerolle.VEILEDER, EnumSet.of(avtale.getTiltakstype()));
         assertThat(avtale.getStartDato()).isEqualTo(startDato);
         assertThat(avtale.getSluttDato()).isEqualTo(sluttDato);
     }
@@ -170,22 +170,22 @@ public class AvtaleTest {
     public void endreAvtale__startdato_og_sluttdato_satt_over_18mnd() {
         Avtale avtale = TestData.enArbeidstreningAvtale();
         EndreAvtale endreAvtale = new EndreAvtale();
-        LocalDate startDato = LocalDate.now();
+        LocalDate startDato = Now.localDate();
         LocalDate sluttDato = startDato.plusMonths(18).plusDays(1);
         endreAvtale.setStartDato(startDato);
         endreAvtale.setSluttDato(sluttDato);
-        assertThatThrownBy(() -> avtale.endreAvtale(Instant.now(), endreAvtale, Avtalerolle.VEILEDER, EnumSet.of(avtale.getTiltakstype()))).isInstanceOf(VarighetForLangArbeidstreningException.class);
+        assertThatThrownBy(() -> avtale.endreAvtale(Now.instant(), endreAvtale, Avtalerolle.VEILEDER, EnumSet.of(avtale.getTiltakstype()))).isInstanceOf(VarighetForLangArbeidstreningException.class);
     }
 
     @Test
     public void endreAvtale__startdato_er_etter_sluttdato() {
         Avtale avtale = TestData.enArbeidstreningAvtale();
         EndreAvtale endreAvtale = new EndreAvtale();
-        LocalDate startDato = LocalDate.now();
+        LocalDate startDato = Now.localDate();
         LocalDate sluttDato = startDato.minusDays(1);
         endreAvtale.setStartDato(startDato);
         endreAvtale.setSluttDato(sluttDato);
-        assertFeilkode(Feilkode.START_ETTER_SLUTT, () -> avtale.endreAvtale(Instant.now(), endreAvtale, Avtalerolle.VEILEDER, EnumSet.of(avtale.getTiltakstype())));
+        assertFeilkode(Feilkode.START_ETTER_SLUTT, () -> avtale.endreAvtale(Now.instant(), endreAvtale, Avtalerolle.VEILEDER, EnumSet.of(avtale.getTiltakstype())));
     }
 
     @Test
@@ -195,7 +195,7 @@ public class AvtaleTest {
         boolean arbeidsgiverGodkjenningFoerEndring = avtale.erGodkjentAvArbeidsgiver();
         boolean veilederGodkjenningFoerEndring = avtale.erGodkjentAvVeileder();
 
-        avtale.endreAvtale(Instant.now(), TestData.endringPåAlleArbeidstreningFelter(), Avtalerolle.VEILEDER, EnumSet.of(avtale.getTiltakstype()));
+        avtale.endreAvtale(Now.instant(), TestData.endringPåAlleArbeidstreningFelter(), Avtalerolle.VEILEDER, EnumSet.of(avtale.getTiltakstype()));
 
         SoftAssertions.assertSoftly(softly -> {
             softly.assertThat(deltakerGodkjenningFoerEndring).isEqualTo(avtale.erGodkjentAvDeltaker());
@@ -314,7 +314,7 @@ public class AvtaleTest {
     private static void testAtHvertEnkeltFeltMangler(Avtale avtale, Set<String> felterSomKrevesForTiltakstype) {
         for (String felt : felterSomKrevesForTiltakstype) {
             EndreAvtale endreAvtale = endringPåAltUtenom(felt);
-            avtale.endreAvtale(Instant.now(), endreAvtale, Avtalerolle.VEILEDER, EnumSet.of(avtale.getTiltakstype()));
+            avtale.endreAvtale(Now.instant(), endreAvtale, Avtalerolle.VEILEDER, EnumSet.of(avtale.getTiltakstype()));
             assertThat(avtale.felterSomIkkeErFyltUt()).containsOnly(felt);
             assertFeilkode(Feilkode.ALT_MA_VAERE_FYLT_UT, () -> avtale.godkjennForArbeidsgiver(TestData.enIdentifikator()));
         }
@@ -358,7 +358,7 @@ public class AvtaleTest {
     @Test
     public void status__noe_fylt_ut() {
         Avtale avtale = TestData.enArbeidstreningAvtale();
-        avtale.setStartDato(LocalDate.now().plusDays(5));
+        avtale.setStartDato(Now.localDate().plusDays(5));
         avtale.setSluttDato(avtale.getStartDato().plusMonths(3));
         avtale.setBedriftNavn("testbedriftsnavn");
         assertThat(avtale.status()).isEqualTo(Status.PÅBEGYNT.getBeskrivelse());
@@ -367,48 +367,48 @@ public class AvtaleTest {
     @Test
     public void status__avsluttet_i_gaar() {
         Avtale avtale = TestData.enAvtaleMedAltUtfylt();
-        avtale.setStartDato(LocalDate.now().minusWeeks(4).minusDays(1));
+        avtale.setStartDato(Now.localDate().minusWeeks(4).minusDays(1));
         avtale.setSluttDato(avtale.getStartDato().plusWeeks(4));
-        avtale.setGodkjentAvArbeidsgiver(LocalDateTime.now());
-        avtale.setGodkjentAvDeltaker(LocalDateTime.now());
-        avtale.setGodkjentAvVeileder(LocalDateTime.now());
-        avtale.setAvtaleInngått(LocalDateTime.now());
+        avtale.setGodkjentAvArbeidsgiver(Now.localDateTime());
+        avtale.setGodkjentAvDeltaker(Now.localDateTime());
+        avtale.setGodkjentAvVeileder(Now.localDateTime());
+        avtale.setAvtaleInngått(Now.localDateTime());
         assertThat(avtale.status()).isEqualTo(Status.AVSLUTTET.getBeskrivelse());
     }
 
     @Test
     public void status__avslutter_i_dag() {
         Avtale avtale = TestData.enAvtaleMedAltUtfylt();
-        avtale.setStartDato(LocalDate.now().minusWeeks(4));
+        avtale.setStartDato(Now.localDate().minusWeeks(4));
         avtale.setSluttDato(avtale.getStartDato().plusWeeks(4));
-        avtale.setGodkjentAvArbeidsgiver(LocalDateTime.now());
-        avtale.setGodkjentAvDeltaker(LocalDateTime.now());
-        avtale.setGodkjentAvVeileder(LocalDateTime.now());
-        avtale.setAvtaleInngått(LocalDateTime.now());
+        avtale.setGodkjentAvArbeidsgiver(Now.localDateTime());
+        avtale.setGodkjentAvDeltaker(Now.localDateTime());
+        avtale.setGodkjentAvVeileder(Now.localDateTime());
+        avtale.setAvtaleInngått(Now.localDateTime());
         assertThat(avtale.status()).isEqualTo(Status.GJENNOMFØRES.getBeskrivelse());
     }
 
     @Test
     public void status__startet_i_dag() {
         Avtale avtale = TestData.enAvtaleMedAltUtfylt();
-        avtale.setStartDato(LocalDate.now());
+        avtale.setStartDato(Now.localDate());
         avtale.setSluttDato(avtale.getStartDato().plusWeeks(4));
-        avtale.setGodkjentAvArbeidsgiver(LocalDateTime.now());
-        avtale.setGodkjentAvDeltaker(LocalDateTime.now());
-        avtale.setGodkjentAvVeileder(LocalDateTime.now());
-        avtale.setAvtaleInngått(LocalDateTime.now());
+        avtale.setGodkjentAvArbeidsgiver(Now.localDateTime());
+        avtale.setGodkjentAvDeltaker(Now.localDateTime());
+        avtale.setGodkjentAvVeileder(Now.localDateTime());
+        avtale.setAvtaleInngått(Now.localDateTime());
         assertThat(avtale.status()).isEqualTo(Status.GJENNOMFØRES.getBeskrivelse());
     }
 
     @Test
     public void status__starter_i_morgen() {
         Avtale avtale = TestData.enAvtaleMedAltUtfylt();
-        avtale.setStartDato(LocalDate.now().plusDays(1));
+        avtale.setStartDato(Now.localDate().plusDays(1));
         avtale.setSluttDato(avtale.getStartDato().plusWeeks(4));
-        avtale.setGodkjentAvArbeidsgiver(LocalDateTime.now());
-        avtale.setGodkjentAvDeltaker(LocalDateTime.now());
-        avtale.setGodkjentAvVeileder(LocalDateTime.now());
-        avtale.setAvtaleInngått(LocalDateTime.now());
+        avtale.setGodkjentAvArbeidsgiver(Now.localDateTime());
+        avtale.setGodkjentAvDeltaker(Now.localDateTime());
+        avtale.setGodkjentAvVeileder(Now.localDateTime());
+        avtale.setAvtaleInngått(Now.localDateTime());
         assertThat(avtale.status()).isEqualTo(Status.KLAR_FOR_OPPSTART.getBeskrivelse());
     }
 
@@ -421,12 +421,12 @@ public class AvtaleTest {
     @Test
     public void status__veileder_har_godkjent() {
         Avtale avtale = TestData.enAvtaleMedAltUtfylt();
-        avtale.setStartDato(LocalDate.now().plusDays(1));
-        avtale.setSluttDato(LocalDate.now().plusDays(1).plusMonths(1));
-        avtale.setGodkjentAvArbeidsgiver(LocalDateTime.now());
-        avtale.setGodkjentAvDeltaker(LocalDateTime.now());
-        avtale.setGodkjentAvVeileder(LocalDateTime.now());
-        avtale.setAvtaleInngått(LocalDateTime.now());
+        avtale.setStartDato(Now.localDate().plusDays(1));
+        avtale.setSluttDato(Now.localDate().plusDays(1).plusMonths(1));
+        avtale.setGodkjentAvArbeidsgiver(Now.localDateTime());
+        avtale.setGodkjentAvDeltaker(Now.localDateTime());
+        avtale.setGodkjentAvVeileder(Now.localDateTime());
+        avtale.setAvtaleInngått(Now.localDateTime());
         assertThat(avtale.status()).isEqualTo(Status.KLAR_FOR_OPPSTART.getBeskrivelse());
     }
 
@@ -435,12 +435,12 @@ public class AvtaleTest {
         // Deltaker tlf ble innført etter at avtaler er opprettet. Det kan derfor være
         // avtaler som er inngått som mangler tlf.
         Avtale avtale = TestData.enAvtaleMedAltUtfylt();
-        avtale.setStartDato(LocalDate.now().minusDays(1));
-        avtale.setSluttDato(LocalDate.now().minusDays(1).plusMonths(1));
-        avtale.setGodkjentAvArbeidsgiver(LocalDateTime.now());
-        avtale.setGodkjentAvDeltaker(LocalDateTime.now());
-        avtale.setGodkjentAvVeileder(LocalDateTime.now());
-        avtale.setAvtaleInngått(LocalDateTime.now());
+        avtale.setStartDato(Now.localDate().minusDays(1));
+        avtale.setSluttDato(Now.localDate().minusDays(1).plusMonths(1));
+        avtale.setGodkjentAvArbeidsgiver(Now.localDateTime());
+        avtale.setGodkjentAvDeltaker(Now.localDateTime());
+        avtale.setGodkjentAvVeileder(Now.localDateTime());
+        avtale.setAvtaleInngått(Now.localDateTime());
         avtale.setDeltakerTlf(null);
         assertThat(avtale.status()).isEqualTo(Status.GJENNOMFØRES.getBeskrivelse());
     }
@@ -448,7 +448,7 @@ public class AvtaleTest {
     @Test
     public void status__avbrutt() {
         Avtale avtale = TestData.enArbeidstreningAvtale();
-        avtale.avbryt(TestData.enVeileder(avtale), new AvbruttInfo(LocalDate.now(), "grunnen"));
+        avtale.avbryt(TestData.enVeileder(avtale), new AvbruttInfo(Now.localDate(), "grunnen"));
         assertThat(avtale.status()).isEqualTo(Status.AVBRUTT.getBeskrivelse());
         assertThat(avtale.getAvbruttDato()).isNotNull();
         assertThat(avtale.getAvbruttGrunn()).isEqualTo("grunnen");
@@ -458,7 +458,7 @@ public class AvtaleTest {
     public void avbryt_ufordelt_avtale_skal_bli_fordelt() {
         Avtale avtale = TestData.enArbeidstreningAvtaleOpprettetAvArbeidsgiverOgErUfordelt();
         Veileder veileder = TestData.enVeileder(new NavIdent("Z123456"));
-        avtale.avbryt(veileder, new AvbruttInfo(LocalDate.now(), "grunnen"));
+        avtale.avbryt(veileder, new AvbruttInfo(Now.localDate(), "grunnen"));
 
         assertThat(avtale.status()).isEqualTo(Status.AVBRUTT.getBeskrivelse());
         assertThat(avtale.erUfordelt()).isFalse();
@@ -494,7 +494,7 @@ public class AvtaleTest {
     public void status__gjenopprettet() {
         Avtale avtale = TestData.enArbeidstreningAvtale();
         avtale.setAvbrutt(true);
-        avtale.setAvbruttDato(LocalDate.now());
+        avtale.setAvbruttDato(Now.localDate());
         avtale.setAvbruttGrunn("enGrunn");
 
         avtale.gjenopprett(TestData.enVeileder(avtale));
@@ -580,7 +580,7 @@ public class AvtaleTest {
 
     @Test
     public void sistEndretNå__kalles_ved_endreAvtale() throws InterruptedException {
-        Instant førEndringen = Instant.now();
+        Instant førEndringen = Now.instant();
         Avtale avtale = TestData.enArbeidstreningAvtale();
         Thread.sleep(10);
         avtale.endreAvtale(Instant.MAX, TestData.ingenEndring(), Avtalerolle.VEILEDER, EnumSet.of(avtale.getTiltakstype()));
@@ -589,7 +589,7 @@ public class AvtaleTest {
 
     @Test
     public void sistEndretNå__kalles_ved_godkjennForDeltaker() throws InterruptedException {
-        Instant førEndringen = Instant.now();
+        Instant førEndringen = Now.instant();
         Avtale avtale = TestData.enAvtaleMedAltUtfylt();
         Thread.sleep(10);
         avtale.godkjennForDeltaker(TestData.enIdentifikator());
@@ -598,7 +598,7 @@ public class AvtaleTest {
 
     @Test
     public void sistEndretNå__kalles_ved_godkjennForArbeidsgiver() throws InterruptedException {
-        Instant førEndringen = Instant.now();
+        Instant førEndringen = Now.instant();
         Avtale avtale = TestData.enAvtaleMedAltUtfylt();
         Thread.sleep(10);
         avtale.godkjennForArbeidsgiver(TestData.enIdentifikator());
@@ -607,7 +607,7 @@ public class AvtaleTest {
 
     @Test
     public void sistEndretNå__kalles_ved_godkjennForVeileder() throws InterruptedException {
-        Instant førEndringen = Instant.now();
+        Instant førEndringen = Now.instant();
         Avtale avtale = TestData.enAvtaleMedAltUtfylt();
         Thread.sleep(10);
         avtale.godkjennForArbeidsgiver(TestData.enIdentifikator());
@@ -616,9 +616,9 @@ public class AvtaleTest {
 
     @Test
     public void sistEndretNå__kalles_ved_godkjennForVeilederOgDeltaker() throws InterruptedException {
-        Instant førEndringen = Instant.now();
+        Instant førEndringen = Now.instant();
         Avtale avtale = TestData.enAvtaleMedAltUtfylt();
-        avtale.setGodkjentAvArbeidsgiver(LocalDateTime.now());
+        avtale.setGodkjentAvArbeidsgiver(Now.localDateTime());
         Thread.sleep(10);
         avtale.godkjennForVeilederOgDeltaker(TestData.enNavIdent(), TestData.enGodkjentPaVegneGrunn());
         assertThat(avtale.getSistEndret()).isAfter(førEndringen);
@@ -626,7 +626,7 @@ public class AvtaleTest {
 
     @Test
     public void sistEndretNå__kalles_ved_opphevGodkjenningerSomArbeidsgiver() throws InterruptedException {
-        Instant førEndringen = Instant.now();
+        Instant førEndringen = Now.instant();
         Avtale avtale = TestData.enAvtaleMedAltUtfylt();
         Thread.sleep(10);
         avtale.opphevGodkjenningerSomArbeidsgiver();
@@ -635,7 +635,7 @@ public class AvtaleTest {
 
     @Test
     public void sistEndretNå__kalles_ved_opphevGodkjenningerSomVeileder() throws InterruptedException {
-        Instant førEndringen = Instant.now();
+        Instant førEndringen = Now.instant();
         Avtale avtale = TestData.enAvtaleMedAltUtfylt();
         Thread.sleep(10);
         avtale.opphevGodkjenningerSomVeileder();
@@ -644,7 +644,7 @@ public class AvtaleTest {
 
     @Test
     public void sistEndretNå__kalles_ved_avbryt() throws InterruptedException {
-        Instant førEndringen = Instant.now();
+        Instant førEndringen = Now.instant();
         Avtale avtale = TestData.enAvtaleMedAltUtfylt();
         Thread.sleep(10);
         avtale.avbryt(TestData.enVeileder(avtale), new AvbruttInfo());
@@ -653,7 +653,7 @@ public class AvtaleTest {
 
     @Test
     public void sistEndretNå__kalles_ved_låsOppAvtale() throws InterruptedException {
-        Instant førEndringen = Instant.now();
+        Instant førEndringen = Now.instant();
         Avtale avtale = TestData.enAvtaleMedAltUtfyltGodkjentAvVeileder();
         Thread.sleep(10);
         avtale.låsOppAvtale();
@@ -676,14 +676,14 @@ public class AvtaleTest {
     @Test
     public void avtale_kan_være_ufordelt_selv_om_alt_er_utfylt() {
         Avtale avtale = Avtale.arbeidsgiverOppretterAvtale(new OpprettAvtale(TestData.etFodselsnummer(), TestData.etBedriftNr(), Tiltakstype.MIDLERTIDIG_LONNSTILSKUDD));
-        avtale.endreAvtale(Instant.now(), TestData.endringPåAlleFelter(), Avtalerolle.ARBEIDSGIVER, EnumSet.of(avtale.getTiltakstype()));
+        avtale.endreAvtale(Now.instant(), TestData.endringPåAlleFelter(), Avtalerolle.ARBEIDSGIVER, EnumSet.of(avtale.getTiltakstype()));
         assertThat(avtale.erUfordelt()).isTrue();
     }
 
     @Test
     public void avtale_skal_kunne_godkjennes_når_den_erUfordelt() {
         Avtale avtale = Avtale.arbeidsgiverOppretterAvtale(new OpprettAvtale(TestData.etFodselsnummer(), TestData.etBedriftNr(), Tiltakstype.MIDLERTIDIG_LONNSTILSKUDD));
-        avtale.endreAvtale(Instant.now(), TestData.endringPåAlleFelter(), Avtalerolle.ARBEIDSGIVER, EnumSet.of(avtale.getTiltakstype()));
+        avtale.endreAvtale(Now.instant(), TestData.endringPåAlleFelter(), Avtalerolle.ARBEIDSGIVER, EnumSet.of(avtale.getTiltakstype()));
         avtale.godkjennForArbeidsgiver(TestData.enIdentifikator());
         avtale.godkjennForDeltaker(TestData.enIdentifikator());
         assertThat(avtale.erGodkjentAvArbeidsgiver()).isTrue();
@@ -694,7 +694,7 @@ public class AvtaleTest {
     public void ufordelt_avtale_må_tildeles_før_veileder_godkjenner() {
         Avtale avtale = Avtale.arbeidsgiverOppretterAvtale(
             new OpprettAvtale(TestData.etFodselsnummer(), TestData.etBedriftNr(), Tiltakstype.MIDLERTIDIG_LONNSTILSKUDD));
-        avtale.endreAvtale(Instant.now(), TestData.endringPåAlleFelter(), Avtalerolle.ARBEIDSGIVER, EnumSet.of(avtale.getTiltakstype()));
+        avtale.endreAvtale(Now.instant(), TestData.endringPåAlleFelter(), Avtalerolle.ARBEIDSGIVER, EnumSet.of(avtale.getTiltakstype()));
         avtale.godkjennForArbeidsgiver(TestData.enIdentifikator());
         avtale.godkjennForDeltaker(TestData.enIdentifikator());
         assertThatThrownBy(() -> avtale.godkjennForVeileder(TestData.enNavIdent())).isInstanceOf(AvtaleErIkkeFordeltException.class);
@@ -708,7 +708,7 @@ public class AvtaleTest {
                 new NavIdent("Z123456"));
         EndreAvtale endreAvtale = TestData.endringPåAlleFelter();
         endreAvtale.setLonnstilskuddProsent(20);
-        assertThatThrownBy(() -> avtale.endreAvtale(Instant.now(), endreAvtale, Avtalerolle.VEILEDER, EnumSet.of(avtale.getTiltakstype())))
+        assertThatThrownBy(() -> avtale.endreAvtale(Now.instant(), endreAvtale, Avtalerolle.VEILEDER, EnumSet.of(avtale.getTiltakstype())))
             .isInstanceOf(FeilLonnstilskuddsprosentException.class);
     }
 
@@ -719,7 +719,7 @@ public class AvtaleTest {
                 new NavIdent("Z123456"));
         EndreAvtale endreAvtale = TestData.endringPåAlleFelter();
         endreAvtale.setLonnstilskuddProsent(67);
-        assertThatThrownBy(() -> avtale.endreAvtale(Instant.now(), endreAvtale, Avtalerolle.VEILEDER, EnumSet.of(avtale.getTiltakstype())))
+        assertThatThrownBy(() -> avtale.endreAvtale(Now.instant(), endreAvtale, Avtalerolle.VEILEDER, EnumSet.of(avtale.getTiltakstype())))
             .isInstanceOf(FeilLonnstilskuddsprosentException.class);
     }
 
@@ -731,7 +731,7 @@ public class AvtaleTest {
                 new NavIdent("Z123456"));
         EndreAvtale endreAvtale = TestData.endringPåAlleFelter();
         endreAvtale.setLonnstilskuddProsent(-1);
-        assertThatThrownBy(() -> avtale.endreAvtale(Instant.now(), endreAvtale, Avtalerolle.VEILEDER, EnumSet.of(avtale.getTiltakstype())))
+        assertThatThrownBy(() -> avtale.endreAvtale(Now.instant(), endreAvtale, Avtalerolle.VEILEDER, EnumSet.of(avtale.getTiltakstype())))
             .isInstanceOf(FeilLonnstilskuddsprosentException.class);
     }
 
@@ -742,7 +742,7 @@ public class AvtaleTest {
                 new NavIdent("Z123456"));
         EndreAvtale endreAvtale = TestData.endringPåAlleFelter();
         endreAvtale.setLonnstilskuddProsent(100);
-        assertThatThrownBy(() -> avtale.endreAvtale(Instant.now(), endreAvtale, Avtalerolle.VEILEDER, EnumSet.of(avtale.getTiltakstype())))
+        assertThatThrownBy(() -> avtale.endreAvtale(Now.instant(), endreAvtale, Avtalerolle.VEILEDER, EnumSet.of(avtale.getTiltakstype())))
             .isInstanceOf(FeilLonnstilskuddsprosentException.class);
     }
 
@@ -878,18 +878,18 @@ public class AvtaleTest {
         Avtale avtale = Avtale.veilederOppretterAvtale(new OpprettAvtale(TestData.etFodselsnummer(), TestData.etBedriftNr(), Tiltakstype.MIDLERTIDIG_LONNSTILSKUDD), TestData.enNavIdent());
         EndreAvtale endreAvtale = TestData.endringPåAlleFelter();
         endreAvtale.setLonnstilskuddProsent(60);
-        endreAvtale.setStartDato(LocalDate.now());
-        endreAvtale.setSluttDato(LocalDate.now().plusMonths(12).minusDays(1));
-        avtale.endreAvtale(Instant.now(), endreAvtale, Avtalerolle.VEILEDER, EnumSet.noneOf(Tiltakstype.class));
+        endreAvtale.setStartDato(Now.localDate());
+        endreAvtale.setSluttDato(Now.localDate().plusMonths(12).minusDays(1));
+        avtale.endreAvtale(Now.instant(), endreAvtale, Avtalerolle.VEILEDER, EnumSet.noneOf(Tiltakstype.class));
         avtale.godkjennForDeltaker(TestData.etFodselsnummer());
         avtale.godkjennForArbeidsgiver(TestData.etFodselsnummer());
         avtale.godkjennForVeileder(TestData.enNavIdent());
 
-        avtale.forlengAvtale(LocalDate.now().plusMonths(12), TestData.enNavIdent());
-        assertThat(avtale.getDatoForRedusertProsent()).isEqualTo(LocalDate.now().plusMonths(12));
+        avtale.forlengAvtale(Now.localDate().plusMonths(12), TestData.enNavIdent());
+        assertThat(avtale.getDatoForRedusertProsent()).isEqualTo(Now.localDate().plusMonths(12));
         assertThat(avtale.getSumLønnstilskuddRedusert()).isNotNull();
 
-        avtale.forkortAvtale(LocalDate.now().plusMonths(12).minusDays(1), "grunn", "", TestData.enNavIdent());
+        avtale.forkortAvtale(Now.localDate().plusMonths(12).minusDays(1), "grunn", "", TestData.enNavIdent());
         assertThat(avtale.getDatoForRedusertProsent()).isNull();
         assertThat(avtale.getSumLønnstilskuddRedusert()).isNull();
     }

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtalepartTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtalepartTest.java
@@ -4,10 +4,9 @@ import no.nav.tag.tiltaksgjennomforing.exceptions.ArbeidsgiverSkalGodkjenneFørV
 import no.nav.tag.tiltaksgjennomforing.exceptions.Feilkode;
 import no.nav.tag.tiltaksgjennomforing.exceptions.KanIkkeEndreException;
 import no.nav.tag.tiltaksgjennomforing.exceptions.SamtidigeEndringerException;
+import no.nav.tag.tiltaksgjennomforing.utils.Now;
 import org.junit.jupiter.api.Test;
 
-import java.time.Instant;
-import java.time.LocalDateTime;
 import java.util.EnumSet;
 
 import static no.nav.tag.tiltaksgjennomforing.AssertFeilkode.assertFeilkode;
@@ -47,14 +46,14 @@ public class AvtalepartTest {
     public void endreAvtale__skal_fungere_for_arbeidsgiver() {
         Avtale avtale = TestData.enAvtaleMedAltUtfylt();
         Arbeidsgiver arbeidsgiver = TestData.enArbeidsgiver(avtale);
-        arbeidsgiver.endreAvtale(Instant.now(), TestData.ingenEndring(), avtale, EnumSet.of(avtale.getTiltakstype()));
+        arbeidsgiver.endreAvtale(Now.instant(), TestData.ingenEndring(), avtale, EnumSet.of(avtale.getTiltakstype()));
     }
 
     @Test
     public void endreAvtale__skal_fungere_for_veileder() {
         Avtale avtale = TestData.enAvtaleMedAltUtfylt();
         Veileder veileder = TestData.enVeileder(avtale);
-        veileder.endreAvtale(Instant.now(), TestData.ingenEndring(), avtale, EnumSet.of(avtale.getTiltakstype()));
+        veileder.endreAvtale(Now.instant(), TestData.ingenEndring(), avtale, EnumSet.of(avtale.getTiltakstype()));
     }
 
     @Test
@@ -87,8 +86,8 @@ public class AvtalepartTest {
     @Test
     public void godkjennForAvtalepart__skal_fungere_for_veileder() {
         Avtale avtale = TestData.enAvtaleMedAltUtfylt();
-        avtale.setGodkjentAvDeltaker(LocalDateTime.now());
-        avtale.setGodkjentAvArbeidsgiver(LocalDateTime.now());
+        avtale.setGodkjentAvDeltaker(Now.localDateTime());
+        avtale.setGodkjentAvArbeidsgiver(Now.localDateTime());
         Veileder veileder = TestData.enVeileder(avtale);
         veileder.godkjennAvtale(avtale.getSistEndret(), avtale);
         assertThat(avtale.erGodkjentAvArbeidsgiver()).isTrue();
@@ -97,7 +96,7 @@ public class AvtalepartTest {
     @Test
     public void opphevGodkjenninger__veileder_skal_kunne_trekke_tilbake_egen_godkjenning() {
         Avtale avtale = TestData.enAvtaleMedAltUtfylt();
-        avtale.setGodkjentAvVeileder(LocalDateTime.now());
+        avtale.setGodkjentAvVeileder(Now.localDateTime());
         Veileder veileder = TestData.enVeileder(avtale);
         veileder.opphevGodkjenninger(avtale);
         assertThat(avtale.erGodkjentAvVeileder()).isFalse();

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/GjeldendeTilskuddsperiodeTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/GjeldendeTilskuddsperiodeTest.java
@@ -1,5 +1,6 @@
 package no.nav.tag.tiltaksgjennomforing.avtale;
 
+import no.nav.tag.tiltaksgjennomforing.utils.Now;
 import org.junit.jupiter.api.Test;
 
 import java.time.LocalDate;
@@ -11,12 +12,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class GjeldendeTilskuddsperiodeTest {
 
     // 1 og 4
-    // Bør skrives om til å bruke fastsatte tider, i stedet for LocalDate.now(). Slik den er nå utledes det 4 perioder
+    // Bør skrives om til å bruke fastsatte tider, i stedet for Now.localDate(). Slik den er nå utledes det 4 perioder
     // hvis avtalestart blir før nyttår og avtaleslutt er etter nyttår. 3 perioder utledes hvis avtalestart og avtaleslutt er innenfor samme år.
     @Test
     public void godkjenner_og_neste_kan_behandles() {
-        LocalDate avtaleStart = LocalDate.now().minusMonths(3).plusDays(13);
-        LocalDate avtaleSlutt = LocalDate.now().plusMonths(6);
+        LocalDate avtaleStart = Now.localDate().minusMonths(3).plusDays(13);
+        LocalDate avtaleSlutt = Now.localDate().plusMonths(6);
         Avtale avtale = enLønnstilskuddsAvtaleMedStartOgSluttGodkjentAvAlleParter(avtaleStart, avtaleSlutt);
 
         // 4
@@ -41,8 +42,8 @@ public class GjeldendeTilskuddsperiodeTest {
     // 2
     @Test
     public void en_periode() {
-        LocalDate avtaleStart = LocalDate.now();
-        LocalDate avtaleSlutt = LocalDate.now();
+        LocalDate avtaleStart = Now.localDate();
+        LocalDate avtaleSlutt = Now.localDate();
         Avtale avtale = enLønnstilskuddsAvtaleMedStartOgSluttGodkjentAvAlleParter(avtaleStart, avtaleSlutt);
         assertThat(avtale.tilskuddsperiode(0)).isEqualTo(avtale.gjeldendeTilskuddsperiode());
     }
@@ -50,8 +51,8 @@ public class GjeldendeTilskuddsperiodeTest {
     // 5
     @Test
     public void frem_i_tid() {
-        LocalDate avtaleStart = LocalDate.now().plusDays(15);
-        LocalDate avtaleSlutt = LocalDate.now().plusMonths(8);
+        LocalDate avtaleStart = Now.localDate().plusDays(15);
+        LocalDate avtaleSlutt = Now.localDate().plusMonths(8);
         Avtale avtale = enLønnstilskuddsAvtaleMedStartOgSluttGodkjentAvAlleParter(avtaleStart, avtaleSlutt);
         assertThat(avtale.tilskuddsperiode(0)).isEqualTo(avtale.gjeldendeTilskuddsperiode());
     }
@@ -59,8 +60,8 @@ public class GjeldendeTilskuddsperiodeTest {
     // 6
     @Test
     public void første_avslått__neste_kan_behandles() {
-        LocalDate avtaleStart = LocalDate.now().minusMonths(6);
-        LocalDate avtaleSlutt = LocalDate.now().plusMonths(8);
+        LocalDate avtaleStart = Now.localDate().minusMonths(6);
+        LocalDate avtaleSlutt = Now.localDate().plusMonths(8);
         Avtale avtale = enLønnstilskuddsAvtaleMedStartOgSluttGodkjentAvAlleParter(avtaleStart, avtaleSlutt);
         avtale.avslåTilskuddsperiode(TestData.enNavIdent2(), EnumSet.of(Avslagsårsak.ANNET), "Forklaring");
         assertThat(avtale.tilskuddsperiode(0)).isEqualTo(avtale.gjeldendeTilskuddsperiode());
@@ -69,8 +70,8 @@ public class GjeldendeTilskuddsperiodeTest {
     // 7
     @Test
     public void første_avslått__neste_kan_ikke_behandles() {
-        LocalDate avtaleStart = LocalDate.now();
-        LocalDate avtaleSlutt = LocalDate.now().plusMonths(8);
+        LocalDate avtaleStart = Now.localDate();
+        LocalDate avtaleSlutt = Now.localDate().plusMonths(8);
         Avtale avtale = enLønnstilskuddsAvtaleMedStartOgSluttGodkjentAvAlleParter(avtaleStart, avtaleSlutt);
         avtale.avslåTilskuddsperiode(TestData.enNavIdent2(), EnumSet.of(Avslagsårsak.ANNET), "Forklaring");
         assertThat(avtale.tilskuddsperiode(0)).isEqualTo(avtale.gjeldendeTilskuddsperiode());
@@ -79,13 +80,15 @@ public class GjeldendeTilskuddsperiodeTest {
     // 8
     @Test
     public void godkjenner_og_neste_kan_ikke_behandles() {
-        LocalDate avtaleStart = LocalDate.now();
-        LocalDate avtaleSlutt = LocalDate.now().plusMonths(6);
+        Now.fixedDate(LocalDate.of(2021, 11, 30));
+        LocalDate avtaleStart = Now.localDate();
+        LocalDate avtaleSlutt = Now.localDate().plusMonths(6);
         Avtale avtale = enLønnstilskuddsAvtaleMedStartOgSluttGodkjentAvAlleParter(avtaleStart, avtaleSlutt);
         assertThat(avtale.gjeldendeTilskuddsperiode().getStartDato()).isEqualTo(avtaleStart);
         avtale.godkjennTilskuddsperiode(TestData.enNavIdent2(), avtale.getEnhetGeografisk());
         assertThat(avtale.gjeldendeTilskuddsperiode().getStartDato()).isEqualTo(avtaleStart);
         assertThat(avtale.gjeldendeTilskuddsperiode().getStatus()).isEqualTo(TilskuddPeriodeStatus.GODKJENT);
+        Now.resetClock();
     }
 
 

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/LonnstilskuddStartOgSluttDatoStrategyTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/LonnstilskuddStartOgSluttDatoStrategyTest.java
@@ -1,9 +1,9 @@
 package no.nav.tag.tiltaksgjennomforing.avtale;
 
 import no.nav.tag.tiltaksgjennomforing.exceptions.Feilkode;
+import no.nav.tag.tiltaksgjennomforing.utils.Now;
 import org.junit.jupiter.api.Test;
 
-import java.time.Instant;
 import java.time.LocalDate;
 import java.util.EnumSet;
 
@@ -22,13 +22,13 @@ class LonnstilskuddStartOgSluttDatoStrategyTest {
     }
 
     private void endreAvtale(Avtale avtale, EndreAvtale endreAvtale) {
-        avtale.endreAvtale(Instant.now(), endreAvtale, Avtalerolle.VEILEDER, EnumSet.noneOf(Tiltakstype.class));
+        avtale.endreAvtale(Now.instant(), endreAvtale, Avtalerolle.VEILEDER, EnumSet.noneOf(Tiltakstype.class));
     }
 
     @Test
     public void endreMidlertidigLønnstilskudd__startdato_og_sluttdato_satt_24mnd() {
         EndreAvtale endreAvtale = TestData.endringPåAlleFelter();
-        LocalDate startDato = LocalDate.now();
+        LocalDate startDato = Now.localDate();
         LocalDate sluttDato = startDato.plusMonths(24);
         endreAvtale.setStartDato(startDato);
         endreAvtale.setSluttDato(sluttDato);
@@ -38,7 +38,7 @@ class LonnstilskuddStartOgSluttDatoStrategyTest {
     @Test
     public void endreMidlertidigLønnstilskudd__startdato_og_sluttdato_satt_over_24mnd() {
         EndreAvtale endreAvtale = TestData.endringPåAlleFelter();
-        LocalDate startDato = LocalDate.now();
+        LocalDate startDato = Now.localDate();
         LocalDate sluttDato = startDato.plusMonths(24).plusDays(1);
         endreAvtale.setStartDato(startDato);
         endreAvtale.setSluttDato(sluttDato);
@@ -48,7 +48,7 @@ class LonnstilskuddStartOgSluttDatoStrategyTest {
     @Test
     public void endreVarigLønnstilskudd__startdato_og_sluttdato_satt_over_24mnd() {
         EndreAvtale endreAvtale = TestData.endringPåAlleFelter();
-        LocalDate startDato = LocalDate.now();
+        LocalDate startDato = Now.localDate();
         LocalDate sluttDato = startDato.plusMonths(24).plusDays(1);
         endreAvtale.setStartDato(startDato);
         endreAvtale.setSluttDato(sluttDato);

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/MentorStrategyTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/MentorStrategyTest.java
@@ -1,10 +1,10 @@
 package no.nav.tag.tiltaksgjennomforing.avtale;
 
 import no.nav.tag.tiltaksgjennomforing.exceptions.Feilkode;
+import no.nav.tag.tiltaksgjennomforing.utils.Now;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.time.Instant;
 import java.time.LocalDate;
 import java.util.EnumSet;
 
@@ -23,7 +23,7 @@ public class MentorStrategyTest {
     @Test
     public void endreMentortilskudd__startdato_er_etter_sluttdato() {
         EndreAvtale endreAvtale = TestData.endringPåAlleFelter();
-        LocalDate startDato = LocalDate.now();
+        LocalDate startDato = Now.localDate();
         LocalDate sluttDato = startDato.minusDays(1);
         endreAvtale.setStartDato(startDato);
         endreAvtale.setSluttDato(sluttDato);
@@ -31,13 +31,13 @@ public class MentorStrategyTest {
     }
 
     private void endreAvtale(EndreAvtale endreAvtale) {
-        avtale.endreAvtale(Instant.now(), endreAvtale, Avtalerolle.VEILEDER, EnumSet.noneOf(Tiltakstype.class));
+        avtale.endreAvtale(Now.instant(), endreAvtale, Avtalerolle.VEILEDER, EnumSet.noneOf(Tiltakstype.class));
     }
 
     @Test
     public void endreMentortilskudd__startdato_og_sluttdato_satt_36mnd() {
         EndreAvtale endreAvtale = TestData.endringPåAlleFelter();
-        LocalDate startDato = LocalDate.now();
+        LocalDate startDato = Now.localDate();
         LocalDate sluttDato = startDato.plusMonths(36);
         endreAvtale.setStartDato(startDato);
         endreAvtale.setSluttDato(sluttDato);
@@ -47,7 +47,7 @@ public class MentorStrategyTest {
     @Test
     public void endreMentortilskudd__startdato_og_sluttdato_satt_over_36mnd() {
         EndreAvtale endreAvtale = TestData.endringPåAlleFelter();
-        LocalDate startDato = LocalDate.now();
+        LocalDate startDato = Now.localDate();
         LocalDate sluttDato = startDato.plusMonths(36).plusDays(1);
         endreAvtale.setStartDato(startDato);
         endreAvtale.setSluttDato(sluttDato);

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/RegnUtTilskuddsperioderForAvtaleTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/RegnUtTilskuddsperioderForAvtaleTest.java
@@ -1,8 +1,8 @@
 package no.nav.tag.tiltaksgjennomforing.avtale;
 
+import no.nav.tag.tiltaksgjennomforing.utils.Now;
 import org.junit.jupiter.api.Test;
 
-import java.time.Instant;
 import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
 import java.util.*;
@@ -21,7 +21,7 @@ public class RegnUtTilskuddsperioderForAvtaleTest {
         EndreAvtale endreAvtale = TestData.endringPåAlleFelter();
         endreAvtale.setStartDato(fra);
         endreAvtale.setSluttDato(til);
-        avtale.endreAvtale(Instant.now(), endreAvtale, Avtalerolle.VEILEDER, EnumSet.of(avtale.getTiltakstype()));
+        avtale.endreAvtale(Now.instant(), endreAvtale, Avtalerolle.VEILEDER, EnumSet.of(avtale.getTiltakstype()));
 
         assertThat(avtale.getTilskuddPeriode().size()).isEqualTo(1);
         assertThat(avtale.getTilskuddPeriode().first().getBeløp()).isEqualTo(avtale.getSumLonnstilskudd() * 3);
@@ -37,7 +37,7 @@ public class RegnUtTilskuddsperioderForAvtaleTest {
         EndreAvtale endreAvtale = TestData.endringPåAlleFelter();
         endreAvtale.setStartDato(fra);
         endreAvtale.setSluttDato(til);
-        avtale.endreAvtale(Instant.now(), endreAvtale, Avtalerolle.VEILEDER, EnumSet.of(avtale.getTiltakstype()));
+        avtale.endreAvtale(Now.instant(), endreAvtale, Avtalerolle.VEILEDER, EnumSet.of(avtale.getTiltakstype()));
         var tilskuddPerioder = avtale.getTilskuddPeriode();
 
         assertThat(tilskuddPerioder.size()).isEqualTo(2);
@@ -53,7 +53,7 @@ public class RegnUtTilskuddsperioderForAvtaleTest {
         Avtale avtale = TestData.enLonnstilskuddAvtaleMedAltUtfylt();
         EndreAvtale endreAvtale = TestData.endringPåAlleFelter();
         endreAvtale.setLonnstilskuddProsent(40);
-        avtale.endreAvtale(Instant.now(), endreAvtale, Avtalerolle.VEILEDER, EnumSet.of(avtale.getTiltakstype()));
+        avtale.endreAvtale(Now.instant(), endreAvtale, Avtalerolle.VEILEDER, EnumSet.of(avtale.getTiltakstype()));
         TilskuddPeriode tilskuddpeirode6mndEtterStart = finnTilskuddsperiodeForDato(avtale.getStartDato().plusMonths(6), avtale);
         TilskuddPeriode tilskuddperiodeDagenFør6Mnd = finnTilskuddsperiodeForDato(avtale.getStartDato().plusMonths(6).minusDays(1), avtale);
 
@@ -78,7 +78,7 @@ public class RegnUtTilskuddsperioderForAvtaleTest {
         EndreAvtale endreAvtale = TestData.endringPåAlleFelter();
         endreAvtale.setStartDato(LocalDate.of(2021, 1, 1));
         endreAvtale.setSluttDato(LocalDate.of(2021, 10, 1));
-        avtale.endreAvtale(Instant.now(), endreAvtale, Avtalerolle.VEILEDER, EnumSet.of(avtale.getTiltakstype()));
+        avtale.endreAvtale(Now.instant(), endreAvtale, Avtalerolle.VEILEDER, EnumSet.of(avtale.getTiltakstype()));
 
         TilskuddPeriode tilskuddPeriode1 = finnTilskuddsperiodeForDato(LocalDate.of(2021, 1, 1), avtale);
         TilskuddPeriode tilskuddPeriode2 = finnTilskuddsperiodeForDato(LocalDate.of(2021, 4, 1), avtale);
@@ -104,7 +104,7 @@ public class RegnUtTilskuddsperioderForAvtaleTest {
         assertThat(avtale.tilskuddsperiode(1).getEnhet()).isEqualTo(ENHETS_NR);
         assertThat(avtale.tilskuddsperiode(2).getEnhetsnavn()).isEqualTo(ENHETS_NAVN);
 
-        avtale.endreAvtale(Instant.now(), endreAvtale, Avtalerolle.VEILEDER, EnumSet.of(avtale.getTiltakstype()));
+        avtale.endreAvtale(Now.instant(), endreAvtale, Avtalerolle.VEILEDER, EnumSet.of(avtale.getTiltakstype()));
         assertThat(avtale.tilskuddsperiode(0).getEnhet()).isEqualTo(ENHETS_NR);
         assertThat(avtale.tilskuddsperiode(0).getEnhetsnavn()).isEqualTo(ENHETS_NAVN);
         assertThat(avtale.tilskuddsperiode(1).getEnhet()).isEqualTo(ENHETS_NR);
@@ -117,7 +117,7 @@ public class RegnUtTilskuddsperioderForAvtaleTest {
         EndreAvtale endreAvtale = TestData.endringPåAlleFelter();
         endreAvtale.setLonnstilskuddProsent(60);
         endreAvtale.setSluttDato(endreAvtale.getStartDato().plusMonths(13));
-        avtale.endreAvtale(Instant.now(), endreAvtale, Avtalerolle.VEILEDER, EnumSet.of(avtale.getTiltakstype()));
+        avtale.endreAvtale(Now.instant(), endreAvtale, Avtalerolle.VEILEDER, EnumSet.of(avtale.getTiltakstype()));
 
         TilskuddPeriode sisteTilskuddsperiode = avtale.tilskuddsperiode(avtale.getTilskuddPeriode().size() - 1);
         assertThat(sisteTilskuddsperiode.getLonnstilskuddProsent()).isEqualTo(50);
@@ -135,7 +135,7 @@ public class RegnUtTilskuddsperioderForAvtaleTest {
         endreAvtale.setStartDato(startDato);
         endreAvtale.setSluttDato(sluttDato);
 
-        avtale.endreAvtale(Instant.now(), endreAvtale, Avtalerolle.VEILEDER, EnumSet.of(avtale.getTiltakstype()));
+        avtale.endreAvtale(Now.instant(), endreAvtale, Avtalerolle.VEILEDER, EnumSet.of(avtale.getTiltakstype()));
         assertThat(avtale.getTilskuddPeriode().size()).isEqualTo(4);
         harRiktigeEgenskaper(avtale);
     }
@@ -149,7 +149,7 @@ public class RegnUtTilskuddsperioderForAvtaleTest {
         endreAvtale.setStartDato(startDato);
         endreAvtale.setSluttDato(sluttDato);
         endreAvtale.setLonnstilskuddProsent(40);
-        avtale.endreAvtale(Instant.now(), endreAvtale, Avtalerolle.VEILEDER, EnumSet.of(avtale.getTiltakstype()));
+        avtale.endreAvtale(Now.instant(), endreAvtale, Avtalerolle.VEILEDER, EnumSet.of(avtale.getTiltakstype()));
 
         assertThat(avtale.getDatoForRedusertProsent()).isEqualTo(LocalDate.of(2021, 7, 1));
         harRiktigeEgenskaper(avtale);
@@ -164,7 +164,7 @@ public class RegnUtTilskuddsperioderForAvtaleTest {
         endreAvtale.setStartDato(startDato);
         endreAvtale.setSluttDato(sluttDato);
         endreAvtale.setLonnstilskuddProsent(60);
-        avtale.endreAvtale(Instant.now(), endreAvtale, Avtalerolle.VEILEDER, EnumSet.of(avtale.getTiltakstype()));
+        avtale.endreAvtale(Now.instant(), endreAvtale, Avtalerolle.VEILEDER, EnumSet.of(avtale.getTiltakstype()));
 
         assertThat(avtale.getDatoForRedusertProsent()).isEqualTo(LocalDate.of(2022, 1, 1));
         harRiktigeEgenskaper(avtale);
@@ -179,7 +179,7 @@ public class RegnUtTilskuddsperioderForAvtaleTest {
         endreAvtale.setStartDato(startDato);
         endreAvtale.setSluttDato(sluttDato);
         endreAvtale.setLonnstilskuddProsent(60);
-        avtale.endreAvtale(Instant.now(), endreAvtale, Avtalerolle.VEILEDER, EnumSet.of(avtale.getTiltakstype()));
+        avtale.endreAvtale(Now.instant(), endreAvtale, Avtalerolle.VEILEDER, EnumSet.of(avtale.getTiltakstype()));
 
         assertThat(avtale.getDatoForRedusertProsent()).isNull();
         harRiktigeEgenskaper(avtale);
@@ -192,7 +192,7 @@ public class RegnUtTilskuddsperioderForAvtaleTest {
         endreAvtale.setStartDato(LocalDate.of(2021, 1, 1));
         endreAvtale.setSluttDato(LocalDate.of(2031, 1, 1));
         endreAvtale.setLonnstilskuddProsent(60);
-        avtale.endreAvtale(Instant.now(), endreAvtale, Avtalerolle.VEILEDER, EnumSet.of(avtale.getTiltakstype()));
+        avtale.endreAvtale(Now.instant(), endreAvtale, Avtalerolle.VEILEDER, EnumSet.of(avtale.getTiltakstype()));
 
         assertThat(avtale.tilskuddsperiode(avtale.getTilskuddPeriode().size() - 1).getLonnstilskuddProsent()).isEqualTo(60);
         assertThat(avtale.getDatoForRedusertProsent()).isNull();

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/TestData.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/TestData.java
@@ -8,13 +8,12 @@ import no.nav.tag.tiltaksgjennomforing.featuretoggles.enhet.AxsysService;
 import no.nav.tag.tiltaksgjennomforing.featuretoggles.enhet.NavEnhet;
 import no.nav.tag.tiltaksgjennomforing.okonomi.KontoregisterService;
 import no.nav.tag.tiltaksgjennomforing.persondata.*;
+import no.nav.tag.tiltaksgjennomforing.utils.Now;
 import no.nav.tag.tiltaksgjennomforing.varsel.VarslbarHendelse;
 import no.nav.tag.tiltaksgjennomforing.varsel.VarslbarHendelseType;
 
 import java.math.BigDecimal;
-import java.time.Instant;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.*;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -75,12 +74,12 @@ public class TestData {
 
     public static Avtale enAvtaleMedAltUtfyltGodkjentAvVeileder() {
         Avtale avtale = enAvtaleMedAltUtfylt();
-        avtale.setGodkjentAvArbeidsgiver(LocalDateTime.now());
-        avtale.setGodkjentAvDeltaker(LocalDateTime.now());
-        avtale.setGodkjentAvVeileder(LocalDateTime.now());
-        avtale.setAvtaleInngått(LocalDateTime.now());
+        avtale.setGodkjentAvArbeidsgiver(Now.localDateTime());
+        avtale.setGodkjentAvDeltaker(Now.localDateTime());
+        avtale.setGodkjentAvVeileder(Now.localDateTime());
+        avtale.setAvtaleInngått(Now.localDateTime());
         avtale.setGodkjentAvNavIdent(TestData.enNavIdent());
-        avtale.setIkrafttredelsestidspunkt(LocalDateTime.now());
+        avtale.setIkrafttredelsestidspunkt(Now.localDateTime());
         avtale.setJournalpostId("1");
         return avtale;
     }
@@ -94,7 +93,7 @@ public class TestData {
         EndreAvtale endring = TestData.endringPåAlleFelter();
         endring.setStartDato(startDato);
         endring.setSluttDato(sluttDato);
-        avtale.endreAvtale(Instant.now(), endring, Avtalerolle.VEILEDER, EnumSet.of(avtale.getTiltakstype()));
+        avtale.endreAvtale(Now.instant(), endring, Avtalerolle.VEILEDER, EnumSet.of(avtale.getTiltakstype()));
         return avtale;
     }
 
@@ -107,7 +106,7 @@ public class TestData {
         EndreAvtale endring = TestData.endringPåAlleFelter();
         endring.setStartDato(startDato);
         endring.setSluttDato(sluttDato);
-        avtale.endreAvtale(Instant.now(), endring, Avtalerolle.VEILEDER, EnumSet.of(avtale.getTiltakstype()));
+        avtale.endreAvtale(Now.instant(), endring, Avtalerolle.VEILEDER, EnumSet.of(avtale.getTiltakstype()));
         avtale.godkjennForArbeidsgiver(TestData.enIdentifikator());
         avtale.godkjennForDeltaker(TestData.enIdentifikator());
         avtale.godkjennForVeileder(TestData.enNavIdent());
@@ -140,12 +139,12 @@ public class TestData {
 
     public static Avtale enLonnstilskuddAvtaleGodkjentAvVeileder() {
         Avtale avtale = enLonnstilskuddAvtaleMedAltUtfylt();
-        avtale.setGodkjentAvArbeidsgiver(LocalDateTime.now());
-        avtale.setGodkjentAvDeltaker(LocalDateTime.now());
-        avtale.setGodkjentAvVeileder(LocalDateTime.now());
-        avtale.setAvtaleInngått(LocalDateTime.now());
+        avtale.setGodkjentAvArbeidsgiver(Now.localDateTime());
+        avtale.setGodkjentAvDeltaker(Now.localDateTime());
+        avtale.setGodkjentAvVeileder(Now.localDateTime());
+        avtale.setAvtaleInngått(Now.localDateTime());
         avtale.setGodkjentAvNavIdent(TestData.enNavIdent());
-        avtale.setIkrafttredelsestidspunkt(LocalDateTime.now());
+        avtale.setIkrafttredelsestidspunkt(Now.localDateTime());
         avtale.setJournalpostId("1");
         return avtale;
     }
@@ -154,14 +153,14 @@ public class TestData {
         Avtale avtale = enLonnstilskuddAvtaleMedAltUtfylt();
         avtale.setDeltakerFornavn("Geir");
         avtale.setDeltakerEtternavn("Geirsen");
-        avtale.setGodkjentAvArbeidsgiver(LocalDateTime.now());
-        avtale.setGodkjentAvDeltaker(LocalDateTime.now());
-        avtale.setGodkjentAvVeileder(LocalDateTime.now());
-        avtale.setAvtaleInngått(LocalDateTime.now());
+        avtale.setGodkjentAvArbeidsgiver(Now.localDateTime());
+        avtale.setGodkjentAvDeltaker(Now.localDateTime());
+        avtale.setGodkjentAvVeileder(Now.localDateTime());
+        avtale.setAvtaleInngått(Now.localDateTime());
         avtale.setGodkjentAvNavIdent(TestData.enNavIdent());
-        avtale.setIkrafttredelsestidspunkt(LocalDateTime.now());
-        avtale.setStartDato(LocalDate.now().minusMonths(3));
-        avtale.setSluttDato(LocalDate.now().plusMonths(1));
+        avtale.setIkrafttredelsestidspunkt(Now.localDateTime());
+        avtale.setStartDato(Now.localDate().minusMonths(3));
+        avtale.setSluttDato(Now.localDate().plusMonths(1));
         avtale.setJournalpostId("1");
         return avtale;
     }
@@ -178,10 +177,10 @@ public class TestData {
         endreAvtale.setArbeidsgiveravgift(new BigDecimal("0.141"));
         endreAvtale.setStartDato(LocalDate.of(2021, 6, 1));
         endreAvtale.setSluttDato(LocalDate.of(2021, 6, 1).plusWeeks(4).minusDays(1));
-        avtale.endreAvtale(Instant.now(), endreAvtale, Avtalerolle.VEILEDER, EnumSet.of(avtale.getTiltakstype()));
-        avtale.setGodkjentAvArbeidsgiver(LocalDateTime.now());
-        avtale.setGodkjentAvDeltaker(LocalDateTime.now());
-        avtale.setGodkjentAvVeileder(LocalDateTime.now());
+        avtale.endreAvtale(Now.instant(), endreAvtale, Avtalerolle.VEILEDER, EnumSet.of(avtale.getTiltakstype()));
+        avtale.setGodkjentAvArbeidsgiver(Now.localDateTime());
+        avtale.setGodkjentAvDeltaker(Now.localDateTime());
+        avtale.setGodkjentAvVeileder(Now.localDateTime());
         NavIdent veileder = TestData.enNavIdent();
         avtale.setGodkjentAvNavIdent(veileder);
         avtale.setVeilederNavIdent(veileder);
@@ -201,13 +200,13 @@ public class TestData {
         endreAvtale.setArbeidsgiveravgift(new BigDecimal("0.141"));
         endreAvtale.setStartDato(LocalDate.of(2021, 6, 1));
         endreAvtale.setSluttDato(LocalDate.of(2021, 6, 1).plusWeeks(4).minusDays(1));
-        avtale.endreAvtale(Instant.now(), endreAvtale, Avtalerolle.VEILEDER, EnumSet.of(avtale.getTiltakstype()));
-        avtale.setGodkjentAvArbeidsgiver(LocalDateTime.now());
-        avtale.setGodkjentAvDeltaker(LocalDateTime.now());
-        avtale.setGodkjentAvVeileder(LocalDateTime.now());
-        avtale.setGodkjentAvBeslutter(LocalDateTime.now());
-        avtale.setAvtaleInngått(LocalDateTime.now());
-        avtale.setIkrafttredelsestidspunkt(LocalDateTime.now());
+        avtale.endreAvtale(Now.instant(), endreAvtale, Avtalerolle.VEILEDER, EnumSet.of(avtale.getTiltakstype()));
+        avtale.setGodkjentAvArbeidsgiver(Now.localDateTime());
+        avtale.setGodkjentAvDeltaker(Now.localDateTime());
+        avtale.setGodkjentAvVeileder(Now.localDateTime());
+        avtale.setGodkjentAvBeslutter(Now.localDateTime());
+        avtale.setAvtaleInngått(Now.localDateTime());
+        avtale.setIkrafttredelsestidspunkt(Now.localDateTime());
         avtale.setGodkjentAvNavIdent(TestData.enNavIdent());
         return avtale;
     }
@@ -224,9 +223,9 @@ public class TestData {
         endreAvtale.setArbeidsgiveravgift(new BigDecimal("0.141"));
         endreAvtale.setStartDato(LocalDate.of(2021, 6, 1));
         endreAvtale.setSluttDato(LocalDate.of(2021, 6, 1).plusWeeks(4).minusDays(1));
-        avtale.endreAvtale(Instant.now(), endreAvtale, Avtalerolle.VEILEDER, EnumSet.of(avtale.getTiltakstype()));
-        avtale.setGodkjentAvArbeidsgiver(LocalDateTime.now());
-        avtale.setGodkjentAvDeltaker(LocalDateTime.now());
+        avtale.endreAvtale(Now.instant(), endreAvtale, Avtalerolle.VEILEDER, EnumSet.of(avtale.getTiltakstype()));
+        avtale.setGodkjentAvArbeidsgiver(Now.localDateTime());
+        avtale.setGodkjentAvDeltaker(Now.localDateTime());
         return avtale;
     }
 
@@ -268,7 +267,7 @@ public class TestData {
         endreAvtale.setVeilederTlf("44444444");
         endreAvtale.setOppfolging("Telefon hver uke");
         endreAvtale.setTilrettelegging("Ingen");
-        endreAvtale.setStartDato(LocalDate.now());
+        endreAvtale.setStartDato(Now.localDate());
         endreAvtale.setSluttDato(endreAvtale.getStartDato().plusWeeks(2));
         endreAvtale.setStillingprosent(50);
         endreAvtale.setStillingStyrk08(500);
@@ -294,7 +293,7 @@ public class TestData {
         endreAvtale.setVeilederTlf("44444444");
         endreAvtale.setOppfolging("Telefon hver uke");
         endreAvtale.setTilrettelegging("Ingen");
-        endreAvtale.setStartDato(LocalDate.now());
+        endreAvtale.setStartDato(Now.localDate());
         endreAvtale.setSluttDato(endreAvtale.getStartDato().plusMonths(12));
         endreAvtale.setStillingprosent(50);
         endreAvtale.getMaal().add(TestData.etMaal());
@@ -412,25 +411,25 @@ public class TestData {
         endreAvtale.setDeltakerFornavn("Atle");
         endreAvtale.setDeltakerEtternavn("Jørgensen");
         endreAvtale.setOppfolging("Trenger mer oppfølging");
-        avtale.endreAvtale(Instant.now(), endreAvtale, Avtalerolle.VEILEDER, EnumSet.of(avtale.getTiltakstype()));
-        avtale.setGodkjentAvDeltaker(LocalDateTime.now());
-        avtale.setGodkjentAvArbeidsgiver(LocalDateTime.now());
-        avtale.setGodkjentAvVeileder(LocalDateTime.now());
-        avtale.setAvtaleInngått(LocalDateTime.now());
-        avtale.setIkrafttredelsestidspunkt(LocalDateTime.now());
+        avtale.endreAvtale(Now.instant(), endreAvtale, Avtalerolle.VEILEDER, EnumSet.of(avtale.getTiltakstype()));
+        avtale.setGodkjentAvDeltaker(Now.localDateTime());
+        avtale.setGodkjentAvArbeidsgiver(Now.localDateTime());
+        avtale.setGodkjentAvVeileder(Now.localDateTime());
+        avtale.setAvtaleInngått(Now.localDateTime());
+        avtale.setIkrafttredelsestidspunkt(Now.localDateTime());
         return avtale;
     }
 
     public static Avtale enAvtaleKlarForOppstart() {
         Avtale avtale = enAvtaleMedAltUtfylt();
-        avtale.setStartDato(LocalDate.now().plusDays(7));
+        avtale.setStartDato(Now.localDate().plusDays(7));
         avtale.setSluttDato(avtale.getStartDato().plusMonths(1));
-        avtale.setGodkjentAvArbeidsgiver(LocalDateTime.now());
-        avtale.setGodkjentAvDeltaker(LocalDateTime.now());
-        avtale.setGodkjentAvVeileder(LocalDateTime.now());
-        avtale.setAvtaleInngått(LocalDateTime.now());
+        avtale.setGodkjentAvArbeidsgiver(Now.localDateTime());
+        avtale.setGodkjentAvDeltaker(Now.localDateTime());
+        avtale.setGodkjentAvVeileder(Now.localDateTime());
+        avtale.setAvtaleInngått(Now.localDateTime());
         avtale.setGodkjentAvNavIdent(TestData.enNavIdent());
-        avtale.setIkrafttredelsestidspunkt(LocalDateTime.now());
+        avtale.setIkrafttredelsestidspunkt(Now.localDateTime());
         avtale.setJournalpostId("1");
         return avtale;
     }
@@ -488,11 +487,11 @@ public class TestData {
     public static Avtale enArbeidstreningAvtaleGodkjentAvVeileder() {
         Avtale avtale = TestData.enArbeidstreningAvtale();
         avtale.endreAvtale(avtale.getSistEndret(), endringPåAlleFelter(), Avtalerolle.VEILEDER, EnumSet.of(avtale.getTiltakstype()));
-        avtale.setGodkjentAvArbeidsgiver(LocalDateTime.now());
-        avtale.setGodkjentAvDeltaker(LocalDateTime.now());
-        avtale.setGodkjentAvVeileder(LocalDateTime.now());
-        avtale.setAvtaleInngått(LocalDateTime.now());
-        avtale.setIkrafttredelsestidspunkt(LocalDateTime.now());
+        avtale.setGodkjentAvArbeidsgiver(Now.localDateTime());
+        avtale.setGodkjentAvDeltaker(Now.localDateTime());
+        avtale.setGodkjentAvVeileder(Now.localDateTime());
+        avtale.setAvtaleInngått(Now.localDateTime());
+        avtale.setIkrafttredelsestidspunkt(Now.localDateTime());
         avtale.setJournalpostId("1");
         return avtale;
     }

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/VeilederTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/VeilederTest.java
@@ -11,10 +11,9 @@ import no.nav.tag.tiltaksgjennomforing.exceptions.VeilederSkalGodkjenneSistExcep
 import no.nav.tag.tiltaksgjennomforing.featuretoggles.enhet.NavEnhet;
 import no.nav.tag.tiltaksgjennomforing.persondata.PdlRespons;
 import no.nav.tag.tiltaksgjennomforing.persondata.PersondataService;
+import no.nav.tag.tiltaksgjennomforing.utils.Now;
 import org.junit.jupiter.api.Test;
 
-import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Set;
 
@@ -33,8 +32,8 @@ public class VeilederTest {
     @Test
     public void godkjennAvtale__kan_godkjenne_sist() {
         Avtale avtale = TestData.enAvtaleMedAltUtfylt();
-        avtale.setGodkjentAvDeltaker(LocalDateTime.now());
-        avtale.setGodkjentAvArbeidsgiver(LocalDateTime.now());
+        avtale.setGodkjentAvDeltaker(Now.localDateTime());
+        avtale.setGodkjentAvArbeidsgiver(Now.localDateTime());
         Veileder veileder = TestData.enVeileder(avtale);
         veileder.godkjennAvtale(avtale.getSistEndret(), avtale);
         assertThat(avtale.erGodkjentAvVeileder()).isTrue();
@@ -43,8 +42,8 @@ public class VeilederTest {
     @Test
     public void godkjennAvtale__kan_ikke_godkjenne_kode6() {
         Avtale avtale = TestData.enAvtaleMedAltUtfylt();
-        avtale.setGodkjentAvDeltaker(LocalDateTime.now());
-        avtale.setGodkjentAvArbeidsgiver(LocalDateTime.now());
+        avtale.setGodkjentAvDeltaker(Now.localDateTime());
+        avtale.setGodkjentAvArbeidsgiver(Now.localDateTime());
         PersondataService persondataService = mock(PersondataService.class);
         when(persondataService.erKode6(avtale.getDeltakerFnr())).thenReturn(true);
         Veileder veileder = TestData.enVeileder(avtale, persondataService);
@@ -54,8 +53,8 @@ public class VeilederTest {
     @Test
     public void godkjennForVeilederOgDeltaker__kan_ikke_godkjenne_kode6() {
         Avtale avtale = TestData.enAvtaleMedAltUtfylt();
-        avtale.setGodkjentAvDeltaker(LocalDateTime.now());
-        avtale.setGodkjentAvArbeidsgiver(LocalDateTime.now());
+        avtale.setGodkjentAvDeltaker(Now.localDateTime());
+        avtale.setGodkjentAvArbeidsgiver(Now.localDateTime());
         PersondataService persondataService = mock(PersondataService.class);
         when(persondataService.erKode6(avtale.getDeltakerFnr())).thenReturn(true);
         Veileder veileder = TestData.enVeileder(avtale, persondataService);
@@ -65,9 +64,9 @@ public class VeilederTest {
     @Test
     public void opphevGodkjenninger__kan_alltid_oppheve_godkjenninger() {
         Avtale avtale = TestData.enAvtaleMedAltUtfylt();
-        avtale.setGodkjentAvVeileder(LocalDateTime.now());
-        avtale.setGodkjentAvDeltaker(LocalDateTime.now());
-        avtale.setGodkjentAvArbeidsgiver(LocalDateTime.now());
+        avtale.setGodkjentAvVeileder(Now.localDateTime());
+        avtale.setGodkjentAvDeltaker(Now.localDateTime());
+        avtale.setGodkjentAvArbeidsgiver(Now.localDateTime());
         Veileder veileder = TestData.enVeileder(avtale);
         veileder.opphevGodkjenninger(avtale);
         assertThat(avtale.erGodkjentAvDeltaker()).isFalse();
@@ -78,11 +77,11 @@ public class VeilederTest {
     @Test
     public void avbrytAvtale__kan_avbryt_avtale_etter_veiledergodkjenning() {
         Avtale avtale = TestData.enAvtaleMedAltUtfylt();
-        avtale.setGodkjentAvVeileder(LocalDateTime.now());
-        avtale.setGodkjentAvDeltaker(LocalDateTime.now());
-        avtale.setGodkjentAvArbeidsgiver(LocalDateTime.now());
+        avtale.setGodkjentAvVeileder(Now.localDateTime());
+        avtale.setGodkjentAvDeltaker(Now.localDateTime());
+        avtale.setGodkjentAvArbeidsgiver(Now.localDateTime());
         Veileder veileder = TestData.enVeileder(avtale);
-        veileder.avbrytAvtale(avtale.getSistEndret(), new AvbruttInfo(LocalDate.now(), "enGrunn"), avtale);
+        veileder.avbrytAvtale(avtale.getSistEndret(), new AvbruttInfo(Now.localDate(), "enGrunn"), avtale);
         assertThat(avtale.isAvbrutt()).isTrue();
         assertThat(avtale.getAvbruttDato()).isNotNull();
         assertThat(avtale.getAvbruttGrunn()).isEqualTo("enGrunn");
@@ -91,10 +90,10 @@ public class VeilederTest {
     @Test
     public void avbrytAvtale__kan_avbryte_avtale_foer_veiledergodkjenning() {
         Avtale avtale = TestData.enAvtaleMedAltUtfylt();
-        avtale.setGodkjentAvDeltaker(LocalDateTime.now());
-        avtale.setGodkjentAvArbeidsgiver(LocalDateTime.now());
+        avtale.setGodkjentAvDeltaker(Now.localDateTime());
+        avtale.setGodkjentAvArbeidsgiver(Now.localDateTime());
         Veileder veileder = TestData.enVeileder(avtale);
-        veileder.avbrytAvtale(avtale.getSistEndret(), new AvbruttInfo(LocalDate.now(), "enGrunn"), avtale);
+        veileder.avbrytAvtale(avtale.getSistEndret(), new AvbruttInfo(Now.localDate(), "enGrunn"), avtale);
         assertThat(avtale.isAvbrutt()).isTrue();
         assertThat(avtale.getAvbruttDato()).isNotNull();
         assertThat(avtale.getAvbruttGrunn()).isEqualTo("enGrunn");
@@ -103,12 +102,12 @@ public class VeilederTest {
     @Test
     public void gjenopprettAvtale__kan_gjenopprette_avtale_etter_veiledergodkjenning() {
         Avtale avtale = TestData.enAvtaleMedAltUtfylt();
-        avtale.setGodkjentAvVeileder(LocalDateTime.now());
-        avtale.setGodkjentAvDeltaker(LocalDateTime.now());
-        avtale.setGodkjentAvArbeidsgiver(LocalDateTime.now());
+        avtale.setGodkjentAvVeileder(Now.localDateTime());
+        avtale.setGodkjentAvDeltaker(Now.localDateTime());
+        avtale.setGodkjentAvArbeidsgiver(Now.localDateTime());
         avtale.setAvbrutt(true);
         avtale.setAvbruttGrunn("enGrunn");
-        avtale.setAvbruttDato(LocalDate.now());
+        avtale.setAvbruttDato(Now.localDate());
 
         Veileder veileder = TestData.enVeileder(avtale);
         veileder.gjenopprettAvtale(avtale);
@@ -120,11 +119,11 @@ public class VeilederTest {
     @Test
     public void gjenopprettAvtale__kan_gjenopprette_avtale_foer_veiledergodkjenning() {
         Avtale avtale = TestData.enAvtaleMedAltUtfylt();
-        avtale.setGodkjentAvDeltaker(LocalDateTime.now());
-        avtale.setGodkjentAvArbeidsgiver(LocalDateTime.now());
+        avtale.setGodkjentAvDeltaker(Now.localDateTime());
+        avtale.setGodkjentAvArbeidsgiver(Now.localDateTime());
         avtale.setAvbrutt(true);
         avtale.setAvbruttGrunn("enGrunn");
-        avtale.setAvbruttDato(LocalDate.now());
+        avtale.setAvbruttDato(Now.localDate());
         Veileder veileder = TestData.enVeileder(avtale);
 
         veileder.gjenopprettAvtale(avtale);

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/hendelselogg/LyttPåHendelseTilHendelseloggTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/hendelselogg/LyttPåHendelseTilHendelseloggTest.java
@@ -2,6 +2,7 @@ package no.nav.tag.tiltaksgjennomforing.hendelselogg;
 
 import no.nav.tag.tiltaksgjennomforing.Miljø;
 import no.nav.tag.tiltaksgjennomforing.avtale.*;
+import no.nav.tag.tiltaksgjennomforing.utils.Now;
 import no.nav.tag.tiltaksgjennomforing.varsel.VarselRepository;
 import no.nav.tag.tiltaksgjennomforing.varsel.VarslbarHendelseType;
 import org.junit.jupiter.api.BeforeEach;
@@ -12,8 +13,6 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 
-import java.time.Instant;
-import java.time.LocalDate;
 import java.util.EnumSet;
 import java.util.List;
 
@@ -166,22 +165,22 @@ class LyttPåHendelseTilHendelseloggTest {
     }
 
     private void ogEndretAvtale(Avtale avtale) {
-        avtale.endreAvtale(Instant.now(), TestData.endringPåAlleFelter(), Avtalerolle.ARBEIDSGIVER, EnumSet.of(avtale.getTiltakstype()));
+        avtale.endreAvtale(Now.instant(), TestData.endringPåAlleFelter(), Avtalerolle.ARBEIDSGIVER, EnumSet.of(avtale.getTiltakstype()));
         avtaleRepository.save(avtale);
     }
 
     private void ogGodkjentAvDeltaker(Avtale avtale) {
-        new Deltaker(avtale.getDeltakerFnr()).godkjennAvtale(Instant.now(), avtale);
+        new Deltaker(avtale.getDeltakerFnr()).godkjennAvtale(Now.instant(), avtale);
         avtaleRepository.save(avtale);
     }
 
     private void ogGodkjentAvArbeidsgiver(Avtale avtale) {
-        TestData.enArbeidsgiver(avtale).godkjennAvtale(Instant.now(), avtale);
+        TestData.enArbeidsgiver(avtale).godkjennAvtale(Now.instant(), avtale);
         avtaleRepository.save(avtale);
     }
 
     private void ogGodkjentAvVeileder(Avtale avtale) {
-        TestData.enVeileder(avtale).godkjennAvtale(Instant.now(), avtale);
+        TestData.enVeileder(avtale).godkjennAvtale(Now.instant(), avtale);
         avtaleRepository.save(avtale);
     }
 
@@ -207,9 +206,9 @@ class LyttPåHendelseTilHendelseloggTest {
 
     private void ogAvbrutt(Avtale avtale) {
         AvbruttInfo avbruttInfo = new AvbruttInfo();
-        avbruttInfo.setAvbruttDato(LocalDate.now());
+        avbruttInfo.setAvbruttDato(Now.localDate());
         avbruttInfo.setAvbruttGrunn("En grunn");
-        TestData.enVeileder(avtale).avbrytAvtale(Instant.now(), avbruttInfo, avtale);
+        TestData.enVeileder(avtale).avbrytAvtale(Now.instant(), avbruttInfo, avtale);
         avtaleRepository.save(avtale);
     }
 

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/journalfoering/AvtaleTilJournalfoeringMapperTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/journalfoering/AvtaleTilJournalfoeringMapperTest.java
@@ -1,11 +1,11 @@
 package no.nav.tag.tiltaksgjennomforing.journalfoering;
 
 import no.nav.tag.tiltaksgjennomforing.avtale.*;
+import no.nav.tag.tiltaksgjennomforing.utils.Now;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.UUID;
 
@@ -37,7 +37,7 @@ public class AvtaleTilJournalfoeringMapperTest {
         final UUID avtaleId = UUID.randomUUID();
         avtale.setId(avtaleId);
         avtale.setGodkjentPaVegneAv(true);
-        avtale.setOpprettetTidspunkt(LocalDateTime.now());
+        avtale.setOpprettetTidspunkt(Now.localDateTime());
         avtale.setStillingstype(Stillingstype.FAST);
 
         tilJournalfoering = tilJournalfoering(avtaleInnhold);

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/journalfoering/InternalAvtaleControllerTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/journalfoering/InternalAvtaleControllerTest.java
@@ -3,13 +3,13 @@ package no.nav.tag.tiltaksgjennomforing.journalfoering;
 import no.nav.tag.tiltaksgjennomforing.autorisasjon.InnloggingService;
 import no.nav.tag.tiltaksgjennomforing.avtale.*;
 import no.nav.tag.tiltaksgjennomforing.exceptions.TilgangskontrollException;
+import no.nav.tag.tiltaksgjennomforing.utils.Now;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.time.LocalDateTime;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -79,10 +79,10 @@ public class InternalAvtaleControllerTest {
         Avtale avtale = TestData.enAvtaleMedAltUtfyltGodkjentAvVeileder();
         avtale.setId(AVTALE_ID_1);
         Avtale avtale2 = TestData.enAvtaleMedFlereVersjoner();
-        avtale2.getVersjoner().get(0).setGodkjentAvVeileder(LocalDateTime.now());
+        avtale2.getVersjoner().get(0).setGodkjentAvVeileder(Now.localDateTime());
         avtale2.setId(AVTALE_ID_2);
         Avtale avtale3 = TestData.enAvtaleMedFlereVersjoner();
-        avtale3.getVersjoner().get(0).setGodkjentAvVeileder(LocalDateTime.now());
+        avtale3.getVersjoner().get(0).setGodkjentAvVeileder(Now.localDateTime());
         avtale3.setId(AVTALE_ID_3);
         return Arrays.asList(avtale, avtale2, avtale3);
     }

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/tilskuddsperiode/TilskuddsperiodeGodkjentKafkaProducerTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/tilskuddsperiode/TilskuddsperiodeGodkjentKafkaProducerTest.java
@@ -1,19 +1,9 @@
 package no.nav.tag.tiltaksgjennomforing.tilskuddsperiode;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.when;
-
-import java.time.LocalDate;
-import java.util.Map;
-import java.util.UUID;
 import no.nav.tag.tiltaksgjennomforing.Miljø;
-import no.nav.tag.tiltaksgjennomforing.avtale.BedriftNr;
-import no.nav.tag.tiltaksgjennomforing.avtale.Fnr;
-import no.nav.tag.tiltaksgjennomforing.avtale.Identifikator;
-import no.nav.tag.tiltaksgjennomforing.avtale.NavIdent;
-import no.nav.tag.tiltaksgjennomforing.avtale.Tiltakstype;
+import no.nav.tag.tiltaksgjennomforing.avtale.*;
 import no.nav.tag.tiltaksgjennomforing.featuretoggles.FeatureToggleService;
+import no.nav.tag.tiltaksgjennomforing.utils.Now;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.serialization.StringDeserializer;
@@ -29,6 +19,14 @@ import org.springframework.kafka.test.context.EmbeddedKafka;
 import org.springframework.kafka.test.utils.KafkaTestUtils;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
+
+import java.time.LocalDate;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
 
 @SpringBootTest(properties = { "tiltaksgjennomforing.kafka.enabled=true" })
 @DirtiesContext
@@ -68,8 +66,8 @@ class TilskuddsperiodeGodkjentKafkaProducerTest {
         final String bedriftNavn = "Donald Delivery";
         final BedriftNr bedriftnummer = new BedriftNr("99999999");
         final Integer tilskuddBeløp = 12000;
-        final LocalDate tilskuddFraDato = LocalDate.now().minusDays(15);
-        final LocalDate tilskuddTilDato = LocalDate.now().plusMonths(2);
+        final LocalDate tilskuddFraDato = Now.localDate().minusDays(15);
+        final LocalDate tilskuddTilDato = Now.localDate().plusMonths(2);
         final Integer avtaleNr = 234234234;
         final Integer løpenummer = 3;
         final NavIdent beslutterNavIdent = new NavIdent("X234567");

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/varsel/LagVarselFraAvtaleHendelserTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/varsel/LagVarselFraAvtaleHendelserTest.java
@@ -3,6 +3,7 @@ package no.nav.tag.tiltaksgjennomforing.varsel;
 import no.nav.tag.tiltaksgjennomforing.Miljø;
 import no.nav.tag.tiltaksgjennomforing.avtale.*;
 import no.nav.tag.tiltaksgjennomforing.hendelselogg.HendelseloggRepository;
+import no.nav.tag.tiltaksgjennomforing.utils.Now;
 import no.nav.tag.tiltaksgjennomforing.varsel.notifikasjon.ArbeidsgiverNotifikasjonRepository;
 import no.nav.tag.tiltaksgjennomforing.varsel.oppgave.LagGosysVarselLytter;
 import org.junit.jupiter.api.BeforeEach;
@@ -13,8 +14,6 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 
-import java.time.Instant;
-import java.time.LocalDate;
 import java.util.EnumSet;
 
 import static no.nav.tag.tiltaksgjennomforing.avtale.Avtalerolle.*;
@@ -52,7 +51,7 @@ class LagVarselFraAvtaleHendelserTest {
         assertHendelse(OPPRETTET, VEILEDER, ARBEIDSGIVER, true);
         assertHendelse(OPPRETTET, VEILEDER, DELTAKER, true);
 
-        avtale.endreAvtale(Instant.now(), TestData.endringPåAlleFelter(), ARBEIDSGIVER, EnumSet.of(avtale.getTiltakstype()));
+        avtale.endreAvtale(Now.instant(), TestData.endringPåAlleFelter(), ARBEIDSGIVER, EnumSet.of(avtale.getTiltakstype()));
         avtale = avtaleRepository.save(avtale);
         assertHendelse(ENDRET, ARBEIDSGIVER, VEILEDER, true);
         assertHendelse(ENDRET, ARBEIDSGIVER, ARBEIDSGIVER, false);
@@ -71,7 +70,7 @@ class LagVarselFraAvtaleHendelserTest {
         assertIngenHendelse(DELT_MED_ARBEIDSGIVER, DELTAKER);
 
         Deltaker deltaker = TestData.enDeltaker(avtale);
-        deltaker.godkjennAvtale(Instant.now(), avtale);
+        deltaker.godkjennAvtale(Now.instant(), avtale);
         avtale = avtaleRepository.save(avtale);
         assertHendelse(GODKJENT_AV_DELTAKER, DELTAKER, VEILEDER, true);
         assertHendelse(GODKJENT_AV_DELTAKER, DELTAKER, ARBEIDSGIVER, true);
@@ -85,7 +84,7 @@ class LagVarselFraAvtaleHendelserTest {
         assertHendelse(GODKJENNINGER_OPPHEVET_AV_VEILEDER, VEILEDER, DELTAKER, true);
 
         Arbeidsgiver arbeidsgiver = TestData.enArbeidsgiver(avtale);
-        arbeidsgiver.godkjennAvtale(Instant.now(), avtale);
+        arbeidsgiver.godkjennAvtale(Now.instant(), avtale);
         avtale = avtaleRepository.save(avtale);
         assertHendelse(GODKJENT_AV_ARBEIDSGIVER, ARBEIDSGIVER, VEILEDER, true);
         assertHendelse(GODKJENT_AV_ARBEIDSGIVER, ARBEIDSGIVER, ARBEIDSGIVER, false);
@@ -97,7 +96,7 @@ class LagVarselFraAvtaleHendelserTest {
         assertHendelse(GODKJENNINGER_OPPHEVET_AV_ARBEIDSGIVER, ARBEIDSGIVER, ARBEIDSGIVER, false);
         assertHendelse(GODKJENNINGER_OPPHEVET_AV_ARBEIDSGIVER, ARBEIDSGIVER, DELTAKER, true);
 
-        arbeidsgiver.godkjennAvtale(Instant.now(), avtale);
+        arbeidsgiver.godkjennAvtale(Now.instant(), avtale);
         veileder.godkjennForVeilederOgDeltaker(TestData.enGodkjentPaVegneGrunn(), avtale);
         avtale = avtaleRepository.save(avtale);
         assertHendelse(GODKJENT_PAA_VEGNE_AV, VEILEDER, VEILEDER, false);
@@ -117,7 +116,7 @@ class LagVarselFraAvtaleHendelserTest {
         assertHendelse(LÅST_OPP, VEILEDER, ARBEIDSGIVER, true);
         assertHendelse(LÅST_OPP, VEILEDER, DELTAKER, true);
 
-        veileder.avbrytAvtale(Instant.now(), new AvbruttInfo(LocalDate.now(), "Annet"), avtale);
+        veileder.avbrytAvtale(Now.instant(), new AvbruttInfo(Now.localDate(), "Annet"), avtale);
         avtale = avtaleRepository.save(avtale);
         assertHendelse(AVBRUTT, VEILEDER, VEILEDER, false);
         assertHendelse(AVBRUTT, VEILEDER, ARBEIDSGIVER, true);
@@ -136,10 +135,10 @@ class LagVarselFraAvtaleHendelserTest {
         assertHendelse(NY_VEILEDER, VEILEDER, ARBEIDSGIVER, true);
         assertHendelse(NY_VEILEDER, VEILEDER, DELTAKER, true);
 
-        avtale.endreAvtale(Instant.now(), TestData.endringPåAlleFelter(), VEILEDER, EnumSet.of(avtale.getTiltakstype()));
-        deltaker.godkjennAvtale(Instant.now(), avtale);
-        arbeidsgiver.godkjennAvtale(Instant.now(), avtale);
-        veileder.godkjennAvtale(Instant.now(), avtale);
+        avtale.endreAvtale(Now.instant(), TestData.endringPåAlleFelter(), VEILEDER, EnumSet.of(avtale.getTiltakstype()));
+        deltaker.godkjennAvtale(Now.instant(), avtale);
+        arbeidsgiver.godkjennAvtale(Now.instant(), avtale);
+        veileder.godkjennAvtale(Now.instant(), avtale);
         beslutter.avslåTilskuddsperiode(avtale, EnumSet.of(Avslagsårsak.FEIL_I_REGELFORSTÅELSE), "Forklaring");
         avtale = avtaleRepository.save(avtale);
         assertHendelse(TILSKUDDSPERIODE_AVSLATT, BESLUTTER, VEILEDER, true);


### PR DESCRIPTION
For å kunne sette tidspunkt man ønsker skal være "systemklokka". Nyttig for tester som oppfører seg forskjellig basert på hvilken dato det er.