### PR TITLE
Nyere versjon av notifikasjon-api

### DIFF
--- a/src/main/resources/config/application-dev-fss.yaml
+++ b/src/main/resources/config/application-dev-fss.yaml
@@ -123,7 +123,7 @@ tiltaksgjennomforing:
       url: https://app-q1.adeo.no/norg2/api/v1/enhet/
   notifikasjoner:
     uri: https://ag-notifikasjon-produsent-api.dev.intern.nav.no/api/graphql
-    lenke: https://arbeidsgiver-q.nav.no/tiltaksgjennomforing/avtale/
+    lenke: https://tiltaksgjennomforing.dev.nav.no/tiltaksgjennomforing/avtale/
     enabled: true
   dvh-melding:
     feature-enabled: true

--- a/src/main/resources/varsler/opprettNyBeskjed.graphql
+++ b/src/main/resources/varsler/opprettNyBeskjed.graphql
@@ -12,14 +12,16 @@ mutation OpprettNyBeskjed(
     metadata: {
       eksternId: $eksternId
       grupperingsid: $grupperingsId
+      virksomhetsnummer: $virksomhetsnummer
     }
-    mottaker: {
-      altinn: {
-        serviceCode: $serviceCode
-        serviceEdition: $serviceEdition
-        virksomhetsnummer: $virksomhetsnummer
+    mottakere: [
+      {
+        altinn: {
+          serviceCode: $serviceCode
+          serviceEdition: $serviceEdition
+        }
       }
-    }
+    ]
     notifikasjon: {
       merkelapp: $merkelapp
       tekst: $tekst

--- a/src/main/resources/varsler/opprettNyOppgave.graphql
+++ b/src/main/resources/varsler/opprettNyOppgave.graphql
@@ -12,14 +12,16 @@ mutation OpprettNyOppgave(
     metadata: {
       eksternId: $eksternId
       grupperingsid: $grupperingsId
+      virksomhetsnummer: $virksomhetsnummer
     }
-    mottaker: {
-      altinn: {
-        serviceCode: $serviceCode
-        serviceEdition: $serviceEdition
-        virksomhetsnummer: $virksomhetsnummer
+    mottakere: [
+      {
+        altinn: {
+          serviceCode: $serviceCode
+          serviceEdition: $serviceEdition
+        }
       }
-    }
+    ]
     notifikasjon: {
       merkelapp: $merkelapp
       tekst: $tekst


### PR DESCRIPTION
I forbindelse med en forenkling av produsent-apiet for notifikasjoner,
så ønsker vi å migrere alle over på det nye formatet, slik at vi kan
slette det gamle formatet.

Si bare i fra, så tester jeg i dev.