### PR TITLE
Utlede 1 måned tilskuddsperioder i steden for 3.

### DIFF
--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/RegnUtTilskuddsperioderForAvtale.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/RegnUtTilskuddsperioderForAvtale.java
@@ -67,27 +67,35 @@ public class RegnUtTilskuddsperioderForAvtale {
         ArrayList<Periode> datoPar = new ArrayList<>();
         for (int i = 0; i < startDatoer.size(); i++) {
 
-            if (i == 0) {
-                LocalDate fra = startDatoer.get(i);
-                LocalDate til = LocalDate.of(fra.getYear(), fra.getMonth(), fra.lengthOfMonth());
-                datoPar.addAll(splittHvisNyttÅr(fra, til));
-            } else if (i > 0 && startDatoer.get(i).getMonth() != startDatoer.get(i - 1).getMonth()) {
-                // Havnet i ny mnd - start på 01
-                LocalDate fra = LocalDate.of(startDatoer.get(i).getYear(), startDatoer.get(i).getMonth(), 01);
-                LocalDate til = fra.plusDays(fra.lengthOfMonth()).minusDays(1).isAfter(datoTilOgMed) ? datoTilOgMed : fra.plusDays(fra.lengthOfMonth()).minusDays(1);
-                //LocalDate til = fra.plusDays(fra.lengthOfMonth()).minusDays(1);//startDatoer.get(i + 1).minusDays(1);
-                datoPar.addAll(splittHvisNyttÅr(fra, til));
-            } else {
-                LocalDate fra = startDatoer.get(i);
-                LocalDate til = startDatoer.get(i + 1).minusDays(1);
-                datoPar.addAll(splittHvisNyttÅr(fra, til));
-            }
+            // fra: Hvis startdato er lik datoFraOgMed, bruk denne, hvis ikke, bruk første datoen i mnd.
+            LocalDate fra = startDatoer.get(i).equals(datoFraOgMed) ? startDatoer.get(i) : førsteDatoIMnd(startDatoer.get(i));
+            // til: Hvis siste dag i mnd. er mindre enn datoTilOgMed, bruk siste dag i mnd, ellers bruk datoTilOgMed
+            LocalDate til = sisteDagIMnd(startDatoer.get(i)).isBefore(datoTilOgMed) ? sisteDagIMnd(startDatoer.get(i)) : datoTilOgMed;
 
+
+
+            datoPar.addAll(splittHvisNyttÅr(fra, til));
+
+
+
+            //LocalDate fra = startDatoer.get(i);
+            //LocalDate til = startDatoer.get(i + 1).minusDays(1);
+            //datoPar.addAll(splittHvisNyttÅr(fra, til));
         }
-        LocalDate sisteFra = LocalDate.of(datoTilOgMed.getYear(), datoTilOgMed.getMonth(), 01);
-        datoPar.addAll(splittHvisNyttÅr(sisteFra, datoTilOgMed));
         //datoPar.addAll(splittHvisNyttÅr(startDatoer.get(startDatoer.size() - 1), datoTilOgMed));
+        // Legg til siste periode hvis den ikke kom med i loopen
+        if (datoPar.get(datoPar.size() - 1).getSlutt() != datoTilOgMed) {
+            datoPar.addAll(splittHvisNyttÅr(førsteDatoIMnd(datoTilOgMed), datoTilOgMed));
+        }
+
         return datoPar;
+    }
+
+    private LocalDate førsteDatoIMnd(LocalDate dato) {
+        return LocalDate.of(dato.getYear(), dato.getMonth(), 01);
+    }
+    private LocalDate sisteDagIMnd(LocalDate dato) {
+        return LocalDate.of(dato.getYear(), dato.getMonth(), dato.lengthOfMonth());
     }
 
     private static List<Periode> splittHvisNyttÅr (LocalDate fraDato, LocalDate tilDato) {

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/RegnUtTilskuddsperioderForAvtale.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/RegnUtTilskuddsperioderForAvtale.java
@@ -66,28 +66,17 @@ public class RegnUtTilskuddsperioderForAvtale {
         List<LocalDate> startDatoer = datoFraOgMed.datesUntil(datoTilOgMed.plusDays(1), Period.ofMonths(ANTALL_MÅNEDER_I_EN_PERIODE)).collect(Collectors.toList());
         ArrayList<Periode> datoPar = new ArrayList<>();
         for (int i = 0; i < startDatoer.size(); i++) {
-
             // fra: Hvis startdato er lik datoFraOgMed, bruk denne, hvis ikke, bruk første datoen i mnd.
             LocalDate fra = startDatoer.get(i).equals(datoFraOgMed) ? startDatoer.get(i) : førsteDatoIMnd(startDatoer.get(i));
             // til: Hvis siste dag i mnd. er mindre enn datoTilOgMed, bruk siste dag i mnd, ellers bruk datoTilOgMed
             LocalDate til = sisteDagIMnd(startDatoer.get(i)).isBefore(datoTilOgMed) ? sisteDagIMnd(startDatoer.get(i)) : datoTilOgMed;
 
-
-
             datoPar.addAll(splittHvisNyttÅr(fra, til));
-
-
-
-            //LocalDate fra = startDatoer.get(i);
-            //LocalDate til = startDatoer.get(i + 1).minusDays(1);
-            //datoPar.addAll(splittHvisNyttÅr(fra, til));
         }
-        //datoPar.addAll(splittHvisNyttÅr(startDatoer.get(startDatoer.size() - 1), datoTilOgMed));
         // Legg til siste periode hvis den ikke kom med i loopen
         if (datoPar.get(datoPar.size() - 1).getSlutt() != datoTilOgMed) {
             datoPar.addAll(splittHvisNyttÅr(førsteDatoIMnd(datoTilOgMed), datoTilOgMed));
         }
-
         return datoPar;
     }
 

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/RegnUtTilskuddsperioderForAvtale.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/RegnUtTilskuddsperioderForAvtale.java
@@ -69,7 +69,7 @@ public class RegnUtTilskuddsperioderForAvtale {
             // fra: Hvis startdato er lik datoFraOgMed, bruk denne, hvis ikke, bruk første datoen i mnd.
             LocalDate fra = startDatoer.get(i).equals(datoFraOgMed) ? startDatoer.get(i) : førsteDatoIMnd(startDatoer.get(i));
             // til: Hvis siste dag i mnd. er mindre enn datoTilOgMed, bruk siste dag i mnd, ellers bruk datoTilOgMed
-            LocalDate til = sisteDagIMnd(startDatoer.get(i)).isBefore(datoTilOgMed) ? sisteDagIMnd(startDatoer.get(i)) : datoTilOgMed;
+            LocalDate til = sisteDatoIMnd(startDatoer.get(i)).isBefore(datoTilOgMed) ? sisteDatoIMnd(startDatoer.get(i)) : datoTilOgMed;
 
             datoPar.addAll(splittHvisNyttÅr(fra, til));
         }
@@ -83,7 +83,7 @@ public class RegnUtTilskuddsperioderForAvtale {
     private LocalDate førsteDatoIMnd(LocalDate dato) {
         return LocalDate.of(dato.getYear(), dato.getMonth(), 01);
     }
-    private LocalDate sisteDagIMnd(LocalDate dato) {
+    private LocalDate sisteDatoIMnd(LocalDate dato) {
         return LocalDate.of(dato.getYear(), dato.getMonth(), dato.lengthOfMonth());
     }
 

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/TilskuddPeriode.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/TilskuddPeriode.java
@@ -112,7 +112,7 @@ public class TilskuddPeriode implements Comparable<TilskuddPeriode> {
         if (løpenummer == 1) {
             return LocalDate.MIN;
         }
-        return startDato.minusMonths(1);
+        return startDato.minusMonths(3);
     }
 
     void godkjenn(NavIdent beslutter, String enhet) {

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleRepositoryTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleRepositoryTest.java
@@ -243,7 +243,7 @@ public class AvtaleRepositoryTest {
     @Test
     public void finnGodkjenteAvtalerMedTilskuddsperiodestatusOgNavEnheter__skal_ikke_kunne_hente_avtale_med_godkjent_tilskuddsperioder() {
         Now.fixedDate(LocalDate.of(2021, 10, 1));
-        Avtale lagretAvtale = TestData.enLønnstilskuddsAvtaleMedStartOgSluttGodkjentAvAlleParter(LocalDate.of(2021, 10, 1), LocalDate.of(2021, 12, 1));
+        Avtale lagretAvtale = TestData.enLønnstilskuddsAvtaleMedStartOgSluttGodkjentAvAlleParter(LocalDate.of(2021, 10, 1), LocalDate.of(2021, 10, 31));
         Set<String> navEnheter = Set.of(ENHET_OPPFØLGING.getVerdi());
 
         lagretAvtale.godkjennTilskuddsperiode(TestData.enInnloggetBeslutter().getIdentifikator(), lagretAvtale.getEnhetGeografisk());

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/GjeldendeTilskuddsperiodeTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/GjeldendeTilskuddsperiodeTest.java
@@ -1,7 +1,7 @@
 package no.nav.tag.tiltaksgjennomforing.avtale;
 
-import no.nav.tag.tiltaksgjennomforing.enhet.Kvalifiseringsgruppe;
 import no.nav.tag.tiltaksgjennomforing.utils.Now;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.time.LocalDate;
@@ -26,7 +26,21 @@ public class GjeldendeTilskuddsperiodeTest {
         assertThat(avtale.tilskuddsperiode(1)).isEqualTo(avtale.gjeldendeTilskuddsperiode());
 
         avtale.godkjennTilskuddsperiode(TestData.enNavIdent2(), "0000");
-        assertThat(avtale.tilskuddsperiode(1)).isEqualTo(avtale.gjeldendeTilskuddsperiode());
+        assertThat(avtale.tilskuddsperiode(2)).isEqualTo(avtale.gjeldendeTilskuddsperiode());
+
+        avtale.godkjennTilskuddsperiode(TestData.enNavIdent2(), "0000");
+        assertThat(avtale.tilskuddsperiode(3)).isEqualTo(avtale.gjeldendeTilskuddsperiode());
+
+        avtale.godkjennTilskuddsperiode(TestData.enNavIdent2(), "0000");
+        assertThat(avtale.tilskuddsperiode(4)).isEqualTo(avtale.gjeldendeTilskuddsperiode());
+
+
+        avtale.godkjennTilskuddsperiode(TestData.enNavIdent2(), "0000");
+        assertThat(avtale.tilskuddsperiode(5)).isEqualTo(avtale.gjeldendeTilskuddsperiode());
+
+        // Tilskuddsperiode index 5 har startdato som er mer enn 3 mnd frem i tid og vil ikke bli godkjent, slik den vil fortsatt være gjeldende.
+        avtale.godkjennTilskuddsperiode(TestData.enNavIdent2(), "0000");
+        assertThat(avtale.tilskuddsperiode(5)).isEqualTo(avtale.gjeldendeTilskuddsperiode());
 
         Now.resetClock();
     }
@@ -73,6 +87,7 @@ public class GjeldendeTilskuddsperiodeTest {
     }
 
     // 8
+    @Disabled("Vil ikke virke lenger pga. tilskuddsperioder er 1mnd. nå istedenfor 3.")
     @Test
     public void godkjenner_og_neste_kan_ikke_behandles() {
         Now.fixedDate(LocalDate.of(2021, 11, 30));
@@ -86,5 +101,25 @@ public class GjeldendeTilskuddsperiodeTest {
         Now.resetClock();
     }
 
+    @Test
+    public void godkjenner_3_første_tilskuddsperioder_neste_kan_ikke_behandles() {
+        Now.fixedDate(LocalDate.of(2021, 11, 30));
+        LocalDate avtaleStart = Now.localDate();
+        LocalDate avtaleSlutt = Now.localDate().plusMonths(6);
+        Avtale avtale = enLønnstilskuddsAvtaleMedStartOgSluttGodkjentAvAlleParter(avtaleStart, avtaleSlutt);
+
+        assertThat(avtale.gjeldendeTilskuddsperiode().getStartDato()).isEqualTo(avtaleStart);
+        avtale.godkjennTilskuddsperiode(TestData.enNavIdent2(), avtale.getEnhetGeografisk());
+        assertThat(avtale.gjeldendeTilskuddsperiode()).isEqualTo(avtale.tilskuddsperiode(1));
+        avtale.godkjennTilskuddsperiode(TestData.enNavIdent2(), avtale.getEnhetGeografisk());
+        assertThat(avtale.gjeldendeTilskuddsperiode()).isEqualTo(avtale.tilskuddsperiode(2));
+        avtale.godkjennTilskuddsperiode(TestData.enNavIdent2(), avtale.getEnhetGeografisk());
+        assertThat(avtale.gjeldendeTilskuddsperiode()).isEqualTo(avtale.tilskuddsperiode(3));
+        avtale.godkjennTilskuddsperiode(TestData.enNavIdent2(), avtale.getEnhetGeografisk());
+        assertThat(avtale.gjeldendeTilskuddsperiode()).isEqualTo(avtale.tilskuddsperiode(3));
+        assertThat(avtale.gjeldendeTilskuddsperiode().getStatus()).isEqualTo(TilskuddPeriodeStatus.GODKJENT);
+
+
+    }
 
 }

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/RegnUtTilskuddsperioderForAvtaleTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/RegnUtTilskuddsperioderForAvtaleTest.java
@@ -37,8 +37,8 @@ public class RegnUtTilskuddsperioderForAvtaleTest {
         avtale.endreAvtale(Now.instant(), endreAvtale, Avtalerolle.VEILEDER, EnumSet.of(avtale.getTiltakstype()));
 
 
-        assertThat(avtale.getTilskuddPeriode().size()).isEqualTo(1);
-        assertThat(avtale.getTilskuddPeriode().first().getBeløp()).isEqualTo(avtale.getGjeldendeInnhold().getSumLonnstilskudd() * 3);
+        assertThat(avtale.getTilskuddPeriode().size()).isEqualTo(3);
+        assertThat(avtale.getTilskuddPeriode().first().getBeløp()).isEqualTo(avtale.getGjeldendeInnhold().getSumLonnstilskudd());
         harRiktigeEgenskaper(avtale);
         Now.resetClock();
     }
@@ -100,7 +100,7 @@ public class RegnUtTilskuddsperioderForAvtaleTest {
         avtale.endreAvtale(Now.instant(), endreAvtale, Avtalerolle.VEILEDER, EnumSet.of(avtale.getTiltakstype()));
 
         TilskuddPeriode tilskuddPeriode1 = finnTilskuddsperiodeForDato(LocalDate.of(2021, 1, 1), avtale);
-        TilskuddPeriode tilskuddPeriode2 = finnTilskuddsperiodeForDato(LocalDate.of(2021, 4, 1), avtale);
+        TilskuddPeriode tilskuddPeriode2 = finnTilskuddsperiodeForDato(LocalDate.of(2021, 2, 1), avtale);
 
         assertThat(tilskuddPeriode1).isEqualTo(avtale.tilskuddsperiode(0));
         assertThat(tilskuddPeriode2).isEqualTo(avtale.tilskuddsperiode(1));
@@ -157,7 +157,7 @@ public class RegnUtTilskuddsperioderForAvtaleTest {
         endreAvtale.setSluttDato(sluttDato);
 
         avtale.endreAvtale(Now.instant(), endreAvtale, Avtalerolle.VEILEDER, EnumSet.of(avtale.getTiltakstype()));
-        assertThat(avtale.getTilskuddPeriode().size()).isEqualTo(4);
+        assertThat(avtale.getTilskuddPeriode().size()).isEqualTo(9);
         harRiktigeEgenskaper(avtale);
         Now.resetClock();
     }


### PR DESCRIPTION
- Tilskuddsperioder er redusert fra 3mnd til maks 1mnd.
- Alltid splitting ved månedsskifte.
- Fristen fro å godkjenne/beslutte tilskuddsperioder er økt fra 1mnd frem i tid til 3mnd. Dette vil gi samme lengde på avholding av midler som før, siden hver tilskuddsperiode nå er 1mnd.
- Justert tester til å passe til logikk for 1 måneds perioder i steden for 3.