### PR TITLE
Lønnstilskudd til datavarehus i dev

### DIFF
--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/datavarehus/DvhMeldingFilter.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/datavarehus/DvhMeldingFilter.java
@@ -17,7 +17,7 @@ public class DvhMeldingFilter {
             log.info("Feature arbeidsgiver.tiltaksgjennomforing-api.dvh-melding er ikke skrudd på, sender ingen melding til datavarehus");
             return false;
         }
-        return avtale.erAvtaleInngått() && avtale.getTiltakstype() == Tiltakstype.SOMMERJOBB;
+        return avtale.erAvtaleInngått() && dvhMeldingFeatureProperties.getTiltakstyper().contains(avtale.getTiltakstype());
     }
 
     public boolean erFeatureSkruddPå() {

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/datavarehus/DvhMeldingProperties.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/datavarehus/DvhMeldingProperties.java
@@ -1,9 +1,11 @@
 package no.nav.tag.tiltaksgjennomforing.datavarehus;
 
 import lombok.Data;
+import no.nav.tag.tiltaksgjennomforing.avtale.Tiltakstype;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 
+import java.util.EnumSet;
 import java.util.UUID;
 
 @Data
@@ -12,4 +14,5 @@ import java.util.UUID;
 public class DvhMeldingProperties {
     private boolean featureEnabled;
     private UUID gruppeTilgang;
+    private EnumSet<Tiltakstype> tiltakstyper = EnumSet.noneOf(Tiltakstype.class);
 }

--- a/src/main/resources/config/application-dev-fss.yaml
+++ b/src/main/resources/config/application-dev-fss.yaml
@@ -127,6 +127,7 @@ tiltaksgjennomforing:
     enabled: true
   dvh-melding:
     feature-enabled: true
+    tiltakstyper: SOMMERJOBB, MIDLERTIDIG_LONNSTILSKUDD, VARIG_LONNSTILSKUDD
   tilskuddsperioder:
     tiltakstyper: SOMMERJOBB, MIDLERTIDIG_LONNSTILSKUDD, VARIG_LONNSTILSKUDD
 

--- a/src/main/resources/config/application-prod-fss.yaml
+++ b/src/main/resources/config/application-prod-fss.yaml
@@ -128,6 +128,7 @@ tiltaksgjennomforing:
     enabled: true
   dvh-melding:
     feature-enabled: true
+      tiltakstyper: SOMMERJOBB
 http:
   proxy:
     parametername: nothing

--- a/src/main/resources/config/application-prod-fss.yaml
+++ b/src/main/resources/config/application-prod-fss.yaml
@@ -128,7 +128,7 @@ tiltaksgjennomforing:
     enabled: true
   dvh-melding:
     feature-enabled: true
-      tiltakstyper: SOMMERJOBB
+    tiltakstyper: SOMMERJOBB
 http:
   proxy:
     parametername: nothing

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/datavarehus/DvhMeldingFilterTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/datavarehus/DvhMeldingFilterTest.java
@@ -1,0 +1,36 @@
+package no.nav.tag.tiltaksgjennomforing.datavarehus;
+
+import no.nav.tag.tiltaksgjennomforing.avtale.*;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.EnumSet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+public class DvhMeldingFilterTest {
+
+    @Test
+    public void kun_spesifiserte_tiltakstyper_blir_sendt_til_datavarehus() {
+        DvhMeldingProperties dvhMeldingProperties = new DvhMeldingProperties();
+        dvhMeldingProperties.setFeatureEnabled(true);
+        dvhMeldingProperties.setTiltakstyper(EnumSet.of(Tiltakstype.SOMMERJOBB, Tiltakstype.MIDLERTIDIG_LONNSTILSKUDD));
+        DvhMeldingFilter dvhMeldingFilter = new DvhMeldingFilter(dvhMeldingProperties);
+
+        Avtale midlertidigLonnstilskuddAvtale = TestData.enLonnstilskuddAvtaleGodkjentAvVeileder();
+        Avtale varigLonnstilskuddAvtale = TestData.enLonnstilskuddAvtaleMedAltUtfylt(Tiltakstype.VARIG_LONNSTILSKUDD);
+        Avtale arbeidstreningAvtale = TestData.enArbeidstreningAvtaleGodkjentAvVeileder();
+
+        Arbeidsgiver arbeidsgiver = TestData.enArbeidsgiver(varigLonnstilskuddAvtale);
+        Veileder veileder = TestData.enVeileder(midlertidigLonnstilskuddAvtale);
+        arbeidsgiver.godkjennAvtale(Instant.now(), varigLonnstilskuddAvtale);
+        veileder.godkjennForVeilederOgDeltaker(TestData.enGodkjentPaVegneGrunn(), varigLonnstilskuddAvtale);
+
+        assertThat(dvhMeldingFilter.skalTilDatavarehus(midlertidigLonnstilskuddAvtale)).isTrue();
+        assertThat(dvhMeldingFilter.skalTilDatavarehus(varigLonnstilskuddAvtale)).isFalse();
+        assertThat(dvhMeldingFilter.skalTilDatavarehus(arbeidstreningAvtale)).isFalse();
+
+    }
+
+}


### PR DESCRIPTION
Gjør om sjekk som avgjør om avtalehendelser skal til datavarehus elller ikke. Istedenfor å sjekke om tiltakstype er sommerjobb sjekkes det om avtalens tiltakstype finnes på en miljøvariabel på dvhMeldingFeatureProperties.

Lagt inn følgende:

 Dev:
```
  dvh-melding:
    feature-enabled: true
    tiltakstyper: SOMMERJOBB, MIDLERTIDIG_LONNSTILSKUDD, VARIG_LONNSTILSKUDD
```
Prod:
```
  dvh-melding:
    feature-enabled: true
    tiltakstyper: SOMMERJOBB
```