### PR TITLE
Maks 4 uker varighet på sommerjobb.

### DIFF
--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/startOgSluttDatoStrategy/SommerjobbStartOgSluttDatoStrategy.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/startOgSluttDatoStrategy/SommerjobbStartOgSluttDatoStrategy.java
@@ -17,7 +17,7 @@ public class SommerjobbStartOgSluttDatoStrategy implements StartOgSluttDatoStrat
                 }
         }
       if (startDato != null && sluttDato != null) {
-        if (startDato.plusWeeks(4).isBefore(sluttDato)) {
+        if (startDato.plusWeeks(4).minusDays(1).isBefore(sluttDato)) {
           throw new FeilkodeException(Feilkode.SOMMERJOBB_FOR_LANG_VARIGHET);
         }else{
           if (sluttDato.isBefore(LocalDate.of(sluttDato.getYear(), 6, 1)) ) {

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/startOgSluttDatoStrategy/SommerjobbStartOgSluttDatoStrategyTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/startOgSluttDatoStrategy/SommerjobbStartOgSluttDatoStrategyTest.java
@@ -23,7 +23,7 @@ public class SommerjobbStartOgSluttDatoStrategyTest {
     @Test
     public void sjekkStartOgSluttDatoTilbakeITidUtenEtterregistreringInnenForFireUkerSommerjobbPeriode(){
         LocalDate avtaleStart = LocalDate.of(LocalDate.now().minusYears(2).getYear(), 8,31);
-        LocalDate avtaleSlutt = LocalDate.of(LocalDate.now().minusYears(2).getYear(),9,28);
+        LocalDate avtaleSlutt = LocalDate.of(LocalDate.now().minusYears(2).getYear(),9,27);
 
 
         boolean erAvtaleInngått = true;
@@ -66,6 +66,22 @@ public class SommerjobbStartOgSluttDatoStrategyTest {
         boolean erGodkjentForEtterregistrering = true;
         SommerjobbStartOgSluttDatoStrategy sommerjobbStartOgSluttDatoStrategy = new SommerjobbStartOgSluttDatoStrategy();
         assertFeilkode(Feilkode.SOMMERJOBB_FOR_LANG_VARIGHET, () -> sommerjobbStartOgSluttDatoStrategy.sjekkStartOgSluttDato(avtaleStart, avtaleSlutt ,erGodkjentForEtterregistrering, erAvtaleInngått));
+    }
+
+    @Test
+    public void avtale_periode_kan_ikke_være_over_4_uker() {
+        LocalDate avtaleStart = LocalDate.of(LocalDate.now().plusYears(1).getYear(),6,1);
+        LocalDate avtaleSlutt = LocalDate.of(LocalDate.now().plusYears(1).getYear(),6,29);
+        SommerjobbStartOgSluttDatoStrategy sommerjobbStartOgSluttDatoStrategy = new SommerjobbStartOgSluttDatoStrategy();
+        assertFeilkode(Feilkode.SOMMERJOBB_FOR_LANG_VARIGHET, () -> sommerjobbStartOgSluttDatoStrategy.sjekkStartOgSluttDato(avtaleStart, avtaleSlutt, false, false));
+    }
+
+    @Test
+    public void avtale_periode_akkurat_4_uker() {
+        LocalDate avtaleStart = LocalDate.of(LocalDate.now().plusYears(1).getYear(),6,1);
+        LocalDate avtaleSlutt = LocalDate.of(LocalDate.now().plusYears(1).getYear(),6,28);
+        SommerjobbStartOgSluttDatoStrategy sommerjobbStartOgSluttDatoStrategy = new SommerjobbStartOgSluttDatoStrategy();
+        sommerjobbStartOgSluttDatoStrategy.sjekkStartOgSluttDato(avtaleStart, avtaleSlutt, false, false);
     }
 
     @Test


### PR DESCRIPTION
Maks 4 uker varighet på sommerjobb.
Trekker i fra 1 dag på kalkuleringen, fordi vi regner fom og tom.

Eksempel:
7 dager (1 uke) x 4 = 28.
01.06 - 28.06 (28 dager / 4 uker).

Teller man 01.06.plusWekkes(4) ender man opp på 29.06. 29.06 er den første dagen i uke 5. Derfor må vi trekke fra 1 dag. Illustrert med kalender som viser en periode på 4 uker.

![image](https://user-images.githubusercontent.com/5412607/172581940-21b46c15-81f5-4801-a388-95f8b7f13011.png)
