### PR TITLE
Henting av Altinn tilganger for mentor og inkluderingstilskudd

### DIFF
--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/altinntilgangsstyring/AltinnTilgangsstyringProperties.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/altinntilgangsstyring/AltinnTilgangsstyringProperties.java
@@ -23,4 +23,8 @@ public class AltinnTilgangsstyringProperties {
     private Integer arbtreningServiceEdition;
     private Integer sommerjobbServiceCode;
     private Integer sommerjobbServiceEdition;
+    private Integer inkluderingstilskuddServiceCode;
+    private Integer inkluderingstilskuddServiceEdition;
+    private Integer mentorServiceCode;
+    private Integer mentorServiceEdition;
 }

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/altinntilgangsstyring/AltinnTilgangsstyringService.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/altinntilgangsstyring/AltinnTilgangsstyringService.java
@@ -78,6 +78,12 @@ public class AltinnTilgangsstyringService {
         AltinnReportee[] sommerjobbOrger = kallAltinn(altinnTilgangsstyringProperties.getSommerjobbServiceCode(), altinnTilgangsstyringProperties.getSommerjobbServiceEdition(), fnr, arbeidsgiverToken);
         leggTil(tilganger, sommerjobbOrger, Tiltakstype.SOMMERJOBB);
 
+        AltinnReportee[] mentorOrger = kallAltinn(altinnTilgangsstyringProperties.getMentorServiceCode(), altinnTilgangsstyringProperties.getMentorServiceEdition(), fnr, arbeidsgiverToken);
+        leggTil(tilganger, mentorOrger, Tiltakstype.MENTOR);
+
+        AltinnReportee[] inkluderingstilskuddOrger = kallAltinn(altinnTilgangsstyringProperties.getInkluderingstilskuddServiceCode(), altinnTilgangsstyringProperties.getInkluderingstilskuddServiceEdition(), fnr, arbeidsgiverToken);
+        leggTil(tilganger, inkluderingstilskuddOrger, Tiltakstype.INKLUDERINGSTILSKUDD);
+
         return tilganger.asMap();
     }
 

--- a/src/main/resources/config/application-dev-fss.yaml
+++ b/src/main/resources/config/application-dev-fss.yaml
@@ -88,6 +88,10 @@ tiltaksgjennomforing:
     ltsVarigServiceEdition: 2
     sommerjobbServiceCode: 5516
     sommerjobbServiceEdition: 3
+    mentorServiceCode: 5516
+    mentorServiceEdition: 4
+    inkluderingstilskuddServiceCode: 5516
+    inkluderingstilskuddServiceEdition: 5
     arbtreningServiceCode: 5332
     arbtreningServiceEdition: 1
   altinn-varsel:

--- a/src/main/resources/config/application-labs-gcp.yaml
+++ b/src/main/resources/config/application-labs-gcp.yaml
@@ -42,6 +42,10 @@ tiltaksgjennomforing:
     ltsVarigServiceEdition: 2
     sommerjobbServiceCode: 5516
     sommerjobbServiceEdition: 3
+    mentorServiceCode: 5516
+    mentorServiceEdition: 4
+    inkluderingstilskuddServiceCode: 5516
+    inkluderingstilskuddServiceEdition: 5
     arbtreningServiceCode: 5332
     arbtreningServiceEdition: 1
     altinnApiKey: foo

--- a/src/main/resources/config/application-prod-fss.yaml
+++ b/src/main/resources/config/application-prod-fss.yaml
@@ -91,6 +91,10 @@ tiltaksgjennomforing:
     ltsVarigServiceEdition: 2
     arbtreningServiceCode: 5332
     arbtreningServiceEdition: 2
+    mentorServiceCode: 5516
+    mentorServiceEdition: 4
+    inkluderingstilskuddServiceCode: 5516
+    inkluderingstilskuddServiceEdition: 5
   altinn-varsel:
     uri: https://pep-gw.oera.no:9443/ekstern/altinn/notificationagencyexternalbasic/v1
   ereg:

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/AltinnTilgangsstyringServiceTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/AltinnTilgangsstyringServiceTest.java
@@ -63,7 +63,7 @@ public class AltinnTilgangsstyringServiceTest {
         assertThat(tilganger).doesNotContainKeys(new BedriftNr("910825550"), new BedriftNr("910825555"));
 
         // Virksomheter skal være i tilgang-map
-        assertThat(tilganger.get(new BedriftNr("999999999"))).containsOnly(Tiltakstype.ARBEIDSTRENING, Tiltakstype.MIDLERTIDIG_LONNSTILSKUDD, Tiltakstype.VARIG_LONNSTILSKUDD, Tiltakstype.SOMMERJOBB);
+        assertThat(tilganger.get(new BedriftNr("999999999"))).containsOnly(Tiltakstype.ARBEIDSTRENING, Tiltakstype.MIDLERTIDIG_LONNSTILSKUDD, Tiltakstype.VARIG_LONNSTILSKUDD, Tiltakstype.SOMMERJOBB, Tiltakstype.MENTOR, Tiltakstype.INKLUDERINGSTILSKUDD);
         assertThat(tilganger.get(new BedriftNr("910712314"))).containsOnly(Tiltakstype.MIDLERTIDIG_LONNSTILSKUDD);
         assertThat(tilganger.get(new BedriftNr("910712306"))).containsOnly(Tiltakstype.VARIG_LONNSTILSKUDD);
 

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/AltinnTilgangsstyringServiceTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/AltinnTilgangsstyringServiceTest.java
@@ -85,7 +85,7 @@ public class AltinnTilgangsstyringServiceTest {
         assertThat(tilganger).doesNotContainKey(new BedriftNr("910825555"));
 
         // Virksomheter skal være i tilgang-map
-        assertThat(tilganger.get(new BedriftNr("999999999"))).containsOnly(Tiltakstype.ARBEIDSTRENING, Tiltakstype.MIDLERTIDIG_LONNSTILSKUDD, Tiltakstype.VARIG_LONNSTILSKUDD, Tiltakstype.SOMMERJOBB); // TODO: Tilgangsstyring skal skille på midlertidig lønnstilskudd og sommerjobb
+        assertThat(tilganger.get(new BedriftNr("999999999"))).containsOnly(Tiltakstype.ARBEIDSTRENING, Tiltakstype.MIDLERTIDIG_LONNSTILSKUDD, Tiltakstype.VARIG_LONNSTILSKUDD, Tiltakstype.SOMMERJOBB, Tiltakstype.MENTOR, Tiltakstype.INKLUDERINGSTILSKUDD); // TODO: Tilgangsstyring skal skille på midlertidig lønnstilskudd og sommerjobb
     }
 
     @Test

--- a/src/test/resources/config/application-local.yaml
+++ b/src/test/resources/config/application-local.yaml
@@ -63,6 +63,10 @@ tiltaksgjennomforing:
     ltsVarigServiceEdition: 2
     sommerjobbServiceCode: 5516
     sommerjobbServiceEdition: 3
+    mentorServiceCode: 5516
+    mentorServiceEdition: 4
+    inkluderingstilskuddServiceCode: 5516
+    inkluderingstilskuddServiceEdition: 5
     arbtreningServiceCode: 5332
     arbtreningServiceEdition: 1
     altinnApiKey: foo

--- a/src/test/resources/mappings/altinn_10.json
+++ b/src/test/resources/mappings/altinn_10.json
@@ -232,7 +232,7 @@
             "equalTo": "5516"
           },
           "serviceEdition": {
-            "equalTo": "3"
+            "matches": "3|4|5"
           }
         }
       },

--- a/src/test/resources/mappings/altinn_20.json
+++ b/src/test/resources/mappings/altinn_20.json
@@ -54,7 +54,7 @@
             "matches": "5332|5516"
           },
           "serviceEdition": {
-            "matches": "1|2|3"
+            "matches": "1|2|3|4|5"
           }
         }
       },

--- a/src/test/resources/mappings/altinn_ikke_treff.json
+++ b/src/test/resources/mappings/altinn_ikke_treff.json
@@ -13,7 +13,7 @@
             "matches": "5332|5516|^$"
           },
           "serviceEdition": {
-            "matches": "1|2|3|^$"
+            "matches": "1|2|3|4|5|^$"
           }
         }
       },


### PR DESCRIPTION
Altinn tilganger for `mentor` og `inkluderingstilskudd` er nå i prod hos altinn. Da kan vi begynne å hente inn disse for arbeidsgiver.
lagt inn mocking så man lokalt og på labs alltid har tilgang til disse også.

Opprettelse av inkluderingstilskudd for veileder er togglet bort med featureToggle på samme måte som med mentor.
Det er nå også lagt inn toggle på opprettelse for arbeidsgiver for både mentor og inkluderingstilskudd, fordi arbeidsgiver får lov til å opprette avtaler på de tiltakstypene de har tilgang på.