### PR TITLE
Oppdater audience for loginservice.

### DIFF
--- a/src/main/resources/config/application-dev-fss.yaml
+++ b/src/main/resources/config/application-dev-fss.yaml
@@ -20,7 +20,7 @@ no.nav.security.jwt:
       accepted_audience: ${TOKEN_X_CLIENT_ID}
     selvbetjening:
       discoveryurl: ${LOGINSERVICE_IDPORTEN_DISCOVERY_URL}
-      accepted_audience: 0090b6e1-ffcc-4c37-bc21-049f7d1f0fe5
+      accepted_audience: ${LOGINSERVICE_IDPORTEN_AUDIENCE}
       cookie_name: selvbetjening-idtoken
     isso:
       discoveryurl: https://login.microsoftonline.com/NAVQ.onmicrosoft.com/.well-known/openid-configuration

--- a/src/main/resources/config/application-prod-fss.yaml
+++ b/src/main/resources/config/application-prod-fss.yaml
@@ -20,7 +20,7 @@ no.nav.security.jwt:
       accepted_audience: ${TOKEN_X_CLIENT_ID}
     selvbetjening:
       discoveryurl: ${LOGINSERVICE_IDPORTEN_DISCOVERY_URL}
-      accepted_audience: 45104d6a-f5bc-4e8c-b352-4bbfc9381f25
+      accepted_audience: ${LOGINSERVICE_IDPORTEN_AUDIENCE}
       cookie_name: selvbetjening-idtoken
     isso:
       discoveryurl: https://login.microsoftonline.com/navno.onmicrosoft.com/.well-known/openid-configuration


### PR DESCRIPTION
I forbindelse med at Azure B2C ble skrudd av i loginservice,
så har audience endret seg. Ved å bruke audience fra environemnt-
variabler blir dette riktig. Selvbetjenings-autentisering har ikke
fungert i prod siden 19. mai.

Se tråd her: https://nav-it.slack.com/archives/C01DE3M9YBV/p1647867506386019