### PR TITLE
Beslutterspørring bugfiks

### DIFF
--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/Beslutter.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/Beslutter.java
@@ -69,7 +69,9 @@ public class Beslutter extends Avtalepart<NavIdent> {
 
     private Integer getPlussdato() {
         if(LocalDate.now().getYear() != LocalDate.now().plusMonths(3).getYear()) {
-            return 0;
+            long antallDagerTilSisteDagIÅr = ChronoUnit.DAYS.between(LocalDate.now(), LocalDate.of(LocalDate.now().getYear(), 12, 31));
+            return (int) antallDagerTilSisteDagIÅr;
+            //return 0;
         }
         return ((int) ChronoUnit.DAYS.between(LocalDate.now(), LocalDate.now().plusMonths(3)));
     }

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/Beslutter.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/Beslutter.java
@@ -68,10 +68,12 @@ public class Beslutter extends Avtalepart<NavIdent> {
     }
 
     private Integer getPlussdato() {
+
+        // TODO: DENNE KODEN MÅ FJERNES NÅR VI FÅR BESKJED OM AT DET ER OK Å HOLDE AV PENGER FOR NESTE ÅR
         if(LocalDate.now().getYear() != LocalDate.now().plusMonths(3).getYear()) {
             long antallDagerTilSisteDagIÅr = ChronoUnit.DAYS.between(LocalDate.now(), LocalDate.of(LocalDate.now().getYear(), 12, 31));
             return (int) antallDagerTilSisteDagIÅr;
-            //return 0;
+          //  return 0;
         }
         return ((int) ChronoUnit.DAYS.between(LocalDate.now(), LocalDate.now().plusMonths(3)));
     }

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/TilskuddPeriode.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/TilskuddPeriode.java
@@ -2,34 +2,19 @@ package no.nav.tag.tiltaksgjennomforing.avtale;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.util.EnumSet;
-import java.util.Set;
-import java.util.UUID;
-import javax.persistence.Convert;
-import javax.persistence.ElementCollection;
-import javax.persistence.Entity;
-import javax.persistence.EnumType;
-import javax.persistence.Enumerated;
-import javax.persistence.FetchType;
-import javax.persistence.Id;
-import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.NoArgsConstructor;
-import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
-import lombok.ToString;
+import lombok.*;
 import no.nav.tag.tiltaksgjennomforing.exceptions.Feilkode;
 import no.nav.tag.tiltaksgjennomforing.exceptions.FeilkodeException;
 import no.nav.tag.tiltaksgjennomforing.utils.Now;
 import org.apache.commons.lang3.builder.CompareToBuilder;
 import org.jetbrains.annotations.NotNull;
+
+import javax.persistence.*;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.EnumSet;
+import java.util.Set;
+import java.util.UUID;
 
 @Entity
 @Data
@@ -115,7 +100,10 @@ public class TilskuddPeriode implements Comparable<TilskuddPeriode> {
 
         // TODO: DENNE KODEN MÅ FJERNES NÅR VI FÅR BESKJED OM AT DET ER OK Å HOLDE AV PENGER FOR NESTE ÅR
         if (LocalDate.now().getYear() == 2022 && startDato.getYear() == 2023) {
-            return LocalDate.of(2023, 01, 1);
+            if (startDato.minusMonths(3).getYear() != 2023) {
+                // Setter kun 01-01-2023 hvis den opprinnelig hadde blitt satt til 2022.
+                return LocalDate.of(2023, 01, 1);
+            }
         }
 
         if (løpenummer == 1) {


### PR DESCRIPTION
Fiks for beslutter spørring ifbm. regel at tilskuddsperioder ikke kan godkjennes for neste år.
Omdefinerer hvor langt frem man skal lete for å finne ubehandlede tilskuddsperioder. Sjekker her på alle som har startdato frem til siste dagen i året.