### PR TITLE
Arena ryddeavtaler

### DIFF
--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/ArenaRyddeAvtale.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/ArenaRyddeAvtale.java
@@ -1,0 +1,20 @@
+package no.nav.tag.tiltaksgjennomforing.avtale;
+
+import lombok.*;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.OneToOne;
+import java.util.UUID;
+
+@Entity
+@Data
+@NoArgsConstructor
+public class ArenaRyddeAvtale {
+    @Id
+    private UUID id = UUID.randomUUID();
+    @OneToOne
+    @JoinColumn(name = "avtale")
+    private Avtale avtale;
+}

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/ArenaRyddeAvtaleRepository.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/ArenaRyddeAvtaleRepository.java
@@ -1,0 +1,14 @@
+package no.nav.tag.tiltaksgjennomforing.avtale;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface ArenaRyddeAvtaleRepository extends JpaRepository<ArenaRyddeAvtale, UUID>, JpaSpecificationExecutor {
+    @Override
+    Optional<ArenaRyddeAvtale> findById(UUID id);
+
+}

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/Avtale.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/Avtale.java
@@ -2,6 +2,7 @@ package no.nav.tag.tiltaksgjennomforing.avtale;
 
 import static no.nav.tag.tiltaksgjennomforing.utils.Utils.sjekkAtIkkeNull;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.time.Instant;
 import java.time.LocalDate;
@@ -116,6 +117,9 @@ public class Avtale extends AbstractAggregateRoot<Avtale> {
     private SortedSet<TilskuddPeriode> tilskuddPeriode = new TreeSet<>();
     private boolean feilregistrert;
 
+    @JsonIgnore
+    @OneToOne(mappedBy = "avtale", fetch = FetchType.EAGER)
+    private ArenaRyddeAvtale arenaRyddeAvtale;
 
     private Avtale(OpprettAvtale opprettAvtale) {
         sjekkAtIkkeNull(opprettAvtale.getDeltakerFnr(), "Deltakers fnr må være satt.");
@@ -350,6 +354,9 @@ public class Avtale extends AbstractAggregateRoot<Avtale> {
     }
 
     private Boolean erPilotVirksomhet(List<BedriftNr> pilotvirksomheter, List<String> pilotEnheter) {
+        if(arenaRyddeAvtale != null) {
+            return false;
+        }
         boolean erPilot = false;
         if(pilotvirksomheter.contains(bedriftNr) && (tiltakstype == Tiltakstype.MIDLERTIDIG_LONNSTILSKUDD || tiltakstype == Tiltakstype.VARIG_LONNSTILSKUDD)) {
             erPilot = true;

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleController.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleController.java
@@ -44,6 +44,7 @@ public class AvtaleController {
 
     private final AvtaleRepository avtaleRepository;
     private final AvtaleInnholdRepository avtaleInnholdRepository;
+    private final ArenaRyddeAvtaleRepository arenaRyddeAvtaleRepository;
     private final InnloggingService innloggingService;
     private final EregService eregService;
     private final Norg2Client norg2Client;
@@ -220,15 +221,28 @@ public class AvtaleController {
         return new ResponseEntity<List<AlleredeRegistrertAvtale>>(avtaler, HttpStatus.OK);
     }
 
+    @PostMapping("/sjekk-om-vil-bli-pilot")
+    @Transactional
+    public boolean sjekkOmAvtaleKanVærePilot(@RequestBody SjekkOmPilotRequest sjekkOmPilotRequest) {
+        Veileder veileder = innloggingService.hentVeileder();
+        boolean erPilot = veileder.sjekkOmPilot(sjekkOmPilotRequest);
+        return erPilot;
+    }
+
     @PostMapping
     @Transactional
-    public ResponseEntity<?> opprettAvtaleSomVeileder(@RequestBody OpprettAvtale opprettAvtale) {
+    public ResponseEntity<?> opprettAvtaleSomVeileder(@RequestBody OpprettAvtale opprettAvtale, @RequestParam(value = "pilotType", required = false) String pilottype) {
         Veileder veileder = innloggingService.hentVeileder();
         Avtale avtale = veileder.opprettAvtale(opprettAvtale);
         avtale.leggTilBedriftNavn(eregService.hentVirksomhet(avtale.getBedriftNr()).getBedriftNavn());
         veileder.sjekkOppfølgingStatusOgSettLønnstilskuddsprosentsats(avtale, veilarbArenaClient);
         veileder.leggTilOppfølingEnhetsnavn(avtale, norg2Client);
         Avtale opprettetAvtale = avtaleRepository.save(avtale);
+        if (pilottype != null) {
+            ArenaRyddeAvtale arenaRyddeAvtale = new ArenaRyddeAvtale();
+            arenaRyddeAvtale.setAvtale(avtale);
+            arenaRyddeAvtaleRepository.save(arenaRyddeAvtale);
+        }
         URI uri = lagUri("/avtaler/" + opprettetAvtale.getId());
         return ResponseEntity.created(uri).build();
     }

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleController.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleController.java
@@ -238,7 +238,7 @@ public class AvtaleController {
         veileder.sjekkOppfølgingStatusOgSettLønnstilskuddsprosentsats(avtale, veilarbArenaClient);
         veileder.leggTilOppfølingEnhetsnavn(avtale, norg2Client);
         Avtale opprettetAvtale = avtaleRepository.save(avtale);
-        if (pilottype != null) {
+        if (pilottype != null && pilottype.equals("ARENARYDDING")) {
             ArenaRyddeAvtale arenaRyddeAvtale = new ArenaRyddeAvtale();
             arenaRyddeAvtale.setAvtale(avtale);
             arenaRyddeAvtaleRepository.save(arenaRyddeAvtale);

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/SjekkOmPilotRequest.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/SjekkOmPilotRequest.java
@@ -1,0 +1,14 @@
+package no.nav.tag.tiltaksgjennomforing.avtale;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class SjekkOmPilotRequest {
+    private Fnr deltakerFnr;
+    private BedriftNr bedriftNr;
+    private Tiltakstype tiltakstype;
+}

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/Veileder.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/Veileder.java
@@ -326,4 +326,23 @@ public class Veileder extends Avtalepart<NavIdent> {
         leggTilGeografiskEnhet(avtale, persondata, norg2Client);
         return avtale;
     }
+
+    public boolean sjekkOmPilot(SjekkOmPilotRequest sjekkOmPilotRequest) {
+        boolean erPilot = false;
+        String enhetOppfolging = veilarbArenaClient.hentOppfølgingsEnhet(sjekkOmPilotRequest.getDeltakerFnr().asString());
+        BedriftNr bedriftNr = sjekkOmPilotRequest.getBedriftNr();
+        Tiltakstype tiltakstype = sjekkOmPilotRequest.getTiltakstype();
+        List<BedriftNr> pilotvirksomheter = tilskuddsperiodeConfig.getPilotvirksomheter();
+        List<String> pilotEnheter = tilskuddsperiodeConfig.getPilotenheter();
+
+        if(pilotvirksomheter.contains(bedriftNr) && (tiltakstype == Tiltakstype.MIDLERTIDIG_LONNSTILSKUDD || tiltakstype == Tiltakstype.VARIG_LONNSTILSKUDD)) {
+            erPilot = true;
+        }
+        if(enhetOppfolging != null && pilotEnheter.contains(enhetOppfolging) && (tiltakstype == Tiltakstype.MIDLERTIDIG_LONNSTILSKUDD || tiltakstype == Tiltakstype.VARIG_LONNSTILSKUDD)) {
+            erPilot = true;
+        }
+        return erPilot;
+    }
+
+
 }

--- a/src/main/resources/db/migration/V93__arenaryddeavtaler_tabell.sql
+++ b/src/main/resources/db/migration/V93__arenaryddeavtaler_tabell.sql
@@ -1,0 +1,5 @@
+create table arena_rydde_avtale
+(
+    id     uuid primary key,
+    avtale uuid references avtale (id)
+);

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleControllerTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleControllerTest.java
@@ -236,7 +236,7 @@ public class AvtaleControllerTest {
         when(avtaleRepository.save(any(Avtale.class))).thenReturn(avtale);
         when(eregService.hentVirksomhet(avtale.getBedriftNr())).thenReturn(new Organisasjon(avtale.getBedriftNr(), avtale.getGjeldendeInnhold().getBedriftNavn()));
         lenient().when(veilarbArenaClient.sjekkOgHentOppfølgingStatus(any())).thenReturn(new Oppfølgingsstatus(Formidlingsgruppe.ARBEIDSSOKER, Kvalifiseringsgruppe.SITUASJONSBESTEMT_INNSATS, "0906"));
-        ResponseEntity svar = avtaleController.opprettAvtaleSomVeileder(opprettAvtale);
+        ResponseEntity svar = avtaleController.opprettAvtaleSomVeileder(opprettAvtale, null);
         assertThat(svar.getStatusCode()).isEqualTo(HttpStatus.CREATED);
         assertThat(svar.getHeaders().getLocation().getPath()).isEqualTo("/avtaler/" + avtale.getId());
     }
@@ -294,7 +294,7 @@ public class AvtaleControllerTest {
         værInnloggetSom(enNavAnsatt);
         Fnr deltakerFnr = new Fnr("11111100000");
         when(tilgangskontrollService.harSkrivetilgangTilKandidat(enNavAnsatt.getIdentifikator(), deltakerFnr)).thenReturn(false);
-        assertThatThrownBy(() -> avtaleController.opprettAvtaleSomVeileder(new OpprettAvtale(deltakerFnr, new BedriftNr("111222333"), Tiltakstype.ARBEIDSTRENING))).isInstanceOf(IkkeTilgangTilDeltakerException.class);
+        assertThatThrownBy(() -> avtaleController.opprettAvtaleSomVeileder(new OpprettAvtale(deltakerFnr, new BedriftNr("111222333"), Tiltakstype.ARBEIDSTRENING), null)).isInstanceOf(IkkeTilgangTilDeltakerException.class);
     }
 
     @Test
@@ -308,7 +308,7 @@ public class AvtaleControllerTest {
         PdlRespons pdlRespons = TestData.enPdlrespons(true);
         when(persondataServiceIMetode.hentPersondata(deltakerFnr)).thenReturn(pdlRespons);
         when(persondataServiceIMetode.erKode6(pdlRespons)).thenCallRealMethod();
-        assertThatThrownBy(() -> avtaleController.opprettAvtaleSomVeileder(new OpprettAvtale(deltakerFnr, new BedriftNr("111222333"), Tiltakstype.ARBEIDSTRENING))).isInstanceOf(KanIkkeOppretteAvtalePåKode6Exception.class);
+        assertThatThrownBy(() -> avtaleController.opprettAvtaleSomVeileder(new OpprettAvtale(deltakerFnr, new BedriftNr("111222333"), Tiltakstype.ARBEIDSTRENING), null)).isInstanceOf(KanIkkeOppretteAvtalePåKode6Exception.class);
     }
 
     @Test

--- a/src/test/resources/config/application-local.yaml
+++ b/src/test/resources/config/application-local.yaml
@@ -109,7 +109,7 @@ tiltaksgjennomforing:
     fixed-delay: 20000
     tiltakstyper: SOMMERJOBB, MIDLERTIDIG_LONNSTILSKUDD, VARIG_LONNSTILSKUDD, MENTOR, INKLUDERINGSTILSKUDD
   tilskuddsperioder:
-    tiltakstyper: SOMMERJOBB, MIDLERTIDIG_LONNSTILSKUDD, VARIG_LONNSTILSKUDD
+    tiltakstyper: SOMMERJOBB
     pilotvirksomheter: '999999999'
 
 ELECTOR_PATH: null


### PR DESCRIPTION
Funksjonalitet for å merke en lønnstilskuddavtale som Arena ryddeavtale slik at det ikke genereres tilskuddsperioder på denne uansett om den er pilot eller ikke.



Denne funksjonaliteten må endres litt etter 01.02.2023. Da skal alt få tilskuddsperioder, men de som blir merket med denne ryddefunksjonen skal få status BEHANDLET_I_ARENA på alt før 01.02.2023.