### PR TITLE
Generer tilskuddsperioder ved overtagelse av ufordelt avtale

### DIFF
--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/Avtale.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/Avtale.java
@@ -624,6 +624,7 @@ public class Avtale extends AbstractAggregateRoot<Avtale> {
         getGjeldendeInnhold().reberegnLønnstilskudd();
         sistEndretNå();
         if (gammelNavIdent == null) {
+            nyeTilskuddsperioder();
             this.registerEvent(new AvtaleOpprettetAvArbeidsgiverErFordelt(this));
         } else {
             registerEvent(new AvtaleNyVeileder(this, gammelNavIdent));

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/TestData.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/TestData.java
@@ -87,6 +87,10 @@ public class TestData {
         return Avtale.arbeidsgiverOppretterAvtale(lagOpprettAvtale(Tiltakstype.ARBEIDSTRENING));
     }
 
+    public static Avtale enAvtaleOpprettetAvArbeidsgiver(Tiltakstype tiltakstype) {
+        return Avtale.arbeidsgiverOppretterAvtale(lagOpprettAvtale(tiltakstype));
+    }
+
     public static Avtale setOppfølgingPåAvtale(Avtale avtale) {
         avtale.setEnhetOppfolging(ENHET_OPPFØLGING.getVerdi());
         avtale.setEnhetsnavnOppfolging(ENHET_OPPFØLGING.getNavn());

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/VeilederTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/VeilederTest.java
@@ -206,6 +206,28 @@ public class VeilederTest {
     }
 
     @Test
+    public void overtaAvtale__skal_genere_tilskuddsperioder_hvis_ufordelt() {
+        Avtale avtale = TestData.enAvtaleOpprettetAvArbeidsgiver(Tiltakstype.MIDLERTIDIG_LONNSTILSKUDD);
+        Arbeidsgiver arbeidsgiver = TestData.enArbeidsgiver(avtale);
+        arbeidsgiver.endreAvtale(Instant.now(), TestData.endringPåAlleLønnstilskuddFelter(), avtale, EnumSet.of(Tiltakstype.MIDLERTIDIG_LONNSTILSKUDD));
+
+        assertThat(avtale.getTilskuddPeriode()).isEmpty();
+
+        Veileder veileder = TestData.enVeileder(new NavIdent("Z123456"));
+
+        //Tilsvarende operasjon som gjøres fra endepunketet overta avtalecontrolleren
+        avtale.setKvalifiseringsgruppe(Kvalifiseringsgruppe.SITUASJONSBESTEMT_INNSATS);
+        avtale.getGjeldendeInnhold().setLonnstilskuddProsent(60);
+        veileder.overtaAvtale(avtale);
+
+        assertThat(avtale.getTilskuddPeriode()).isNotEmpty();
+
+
+
+
+    }
+
+    @Test
     public void oprettAvtale__setter_startverdier_på_avtale() {
         OpprettAvtale opprettAvtale = new OpprettAvtale(TestData.etFodselsnummer(), TestData.etBedriftNr(), Tiltakstype.MIDLERTIDIG_LONNSTILSKUDD);
         TilgangskontrollService tilgangskontrollService = mock(TilgangskontrollService.class);


### PR DESCRIPTION
Generer tilskuddsperioder ved overtagelse av avtale som er ufordelt.
Dette retter en feil som kunne skje hvis arbeidsgiver oppretter avtale, fyller ut alt, så overtar veileder og godkjenner.
Grunnen er at ved opprettelse av avtale for arbeidsgiver, settes ikke enhet oppfølging og kvalifiseringsgruppe. Lønnstilskuddprosent settes automatisk ut ifra kvalifiseringsgruppe på midlertidig lønnstilskudd.