### PR TITLE
Mulighet for å velge når det skal genereres nye tilskuddsperioder på manuell ryddejobb

### DIFF
--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/AdminController.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/AdminController.java
@@ -47,7 +47,7 @@ public class AdminController {
                     && avtale.getGjeldendeInnhold().getSumLonnstilskudd() != null) {
 
                 avtale.reUtregnRedusert();
-                avtale.nyeTilskuddsperioderEtterMigreringFraArena(migreringsDato, false);
+                avtale.nyeTilskuddsperioderEtterMigreringFraArena(migreringsDato, false, false);
                 avtaleRepository.save(avtale);
                 antallUnder67.getAndIncrement();
             }

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/Avtale.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/Avtale.java
@@ -992,10 +992,6 @@ public class Avtale extends AbstractAggregateRoot<Avtale> {
         }
     }
 
-    private boolean periodeErFørMigreringsdato(TilskuddPeriode tilskuddsperiode, LocalDate migreringsdato) {
-        return tilskuddsperiode.getStartDato().minusDays(1).isBefore(migreringsdato);
-    }
-
     public void forkortAvtale(LocalDate nySluttDato, String grunn, String annetGrunn, NavIdent utførtAv) {
         sjekkAtIkkeAvtaleErAnnullertEllerAvbrutt();
 

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/tilskuddsperiode/InternalArenaMigreringController.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/tilskuddsperiode/InternalArenaMigreringController.java
@@ -12,10 +12,7 @@ import no.nav.tag.tiltaksgjennomforing.exceptions.RessursFinnesIkkeException;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.client.HttpClientErrorException;
 
 import java.time.LocalDate;
@@ -42,12 +39,15 @@ public class InternalArenaMigreringController {
 
     @PostMapping("/lag-tilskuddsperioder-for-en-avtale/{avtaleId}/{migreringsDato}")
     @Transactional
-    public void lagTilskuddsperioderPåEnAvtale(@PathVariable("avtaleId") UUID id, @PathVariable @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate migreringsDato) {
+    public void lagTilskuddsperioderPåEnAvtale(
+            @PathVariable("avtaleId") UUID id,
+            @PathVariable @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate migreringsDato,
+            @RequestParam(value = "nyeTilskuddsperioderKunFremTilMigreringsdato", required = false, defaultValue = "false") boolean nyeTilskuddsperioderKunFremTilMigreringsdato) {
         sjekkTilgang();
         log.info("Lager tilskuddsperioder på en enkelt avtale {} fra dato {}", id, migreringsDato);
         Avtale avtale = avtaleRepository.findById(id)
                 .orElseThrow(RessursFinnesIkkeException::new);
-        avtale.nyeTilskuddsperioderEtterMigreringFraArena(migreringsDato, false);
+        avtale.nyeTilskuddsperioderEtterMigreringFraArena(migreringsDato, false, nyeTilskuddsperioderKunFremTilMigreringsdato);
         avtaleRepository.save(avtale);
     }
 

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/TestData.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/TestData.java
@@ -219,7 +219,7 @@ public class TestData {
         Avtale avtale = enLonnstilskuddAvtaleMedAltUtfylt(Tiltakstype.VARIG_LONNSTILSKUDD);
         avtale.getGjeldendeInnhold().setStartDato(LocalDate.now().minusYears(1));
         avtale.getGjeldendeInnhold().setSluttDato(LocalDate.now().plusYears(1));
-        avtale.nyeTilskuddsperioderEtterMigreringFraArena(LocalDate.of(2023, 2, 1), false);
+        avtale.nyeTilskuddsperioderEtterMigreringFraArena(LocalDate.of(2023, 2, 1), false, false);
 
         // Godkjenning
         Arbeidsgiver arbeidsgiver = enArbeidsgiver(avtale);


### PR DESCRIPTION
Mulig å velge å kun generee nye tiskuddsperioder før migreringsdato. Kan brukes i de tilfellene der hvor noe er godkjent og det er riktig etter migreringsdatoen, men det er feil før.