### PR TITLE
Oebs håndterer ikke at en tilskuddsperiode kommer to ganger

### DIFF
--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/events/TilskuddsperiodeGodkjent.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/events/TilskuddsperiodeGodkjent.java
@@ -10,4 +10,5 @@ public class TilskuddsperiodeGodkjent {
     Avtale avtale;
     TilskuddPeriode tilskuddsperiode;
     Identifikator utfortAv;
+    Integer resendingsNummer;
 }

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/tilskuddsperiode/InternalTilskuddsperiodeController.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/tilskuddsperiode/InternalTilskuddsperiodeController.java
@@ -9,7 +9,6 @@ import no.nav.tag.tiltaksgjennomforing.autorisasjon.UtviklerTilgangProperties;
 import no.nav.tag.tiltaksgjennomforing.avtale.Avtale;
 import no.nav.tag.tiltaksgjennomforing.avtale.AvtaleRepository;
 import no.nav.tag.tiltaksgjennomforing.avtale.TilskuddPeriode;
-import no.nav.tag.tiltaksgjennomforing.avtale.Tiltakstype;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.http.HttpStatus;
 import org.springframework.transaction.annotation.Transactional;
@@ -19,10 +18,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.client.HttpClientErrorException;
 
-import java.time.LocalDate;
-import java.util.List;
 import java.util.UUID;
-import java.util.concurrent.atomic.AtomicInteger;
 
 @RestController
 @RequestMapping("/utvikler-admin/tilskuddsperioder")
@@ -49,7 +45,7 @@ public class InternalTilskuddsperiodeController {
         // Endepunkt for å sende melding til Kafka om en tilskuddsperiode som ikke ble sendt pga. toggle som feilaktig var avskrudd
         Avtale avtale = avtaleRepository.findById(request.getAvtaleId()).orElseThrow();
         TilskuddPeriode tilskuddPeriode = avtale.getTilskuddPeriode().stream().filter(tp -> tp.getId().equals(request.getTilskuddsperiodeId())).findFirst().orElseThrow();
-        TilskuddsperiodeGodkjentMelding melding = TilskuddsperiodeGodkjentMelding.create(avtale, tilskuddPeriode);
+        TilskuddsperiodeGodkjentMelding melding = TilskuddsperiodeGodkjentMelding.create(avtale, tilskuddPeriode, 0);
         tilskuddsperiodeKafkaProducer.publiserTilskuddsperiodeGodkjentMelding(melding);
     }
 

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/tilskuddsperiode/TilskuddsperiodeFakeKafkaProducer.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/tilskuddsperiode/TilskuddsperiodeFakeKafkaProducer.java
@@ -28,7 +28,7 @@ public class TilskuddsperiodeFakeKafkaProducer {
 
     @TransactionalEventListener
     public void tilskuddsperiodeGodkjent(TilskuddsperiodeGodkjent event) {
-        TilskuddsperiodeGodkjentMelding melding = TilskuddsperiodeGodkjentMelding.create(event.getAvtale(), event.getTilskuddsperiode());
+        TilskuddsperiodeGodkjentMelding melding = TilskuddsperiodeGodkjentMelding.create(event.getAvtale(), event.getTilskuddsperiode(), event.getResendingsNummer());
         try {
             restTemplate.exchange(url + "/tilskuddsperiode-godkjent", HttpMethod.POST, new HttpEntity<>(melding), Void.class);
         } catch (RestClientException e) {

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/tilskuddsperiode/TilskuddsperiodeGodkjentMelding.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/tilskuddsperiode/TilskuddsperiodeGodkjentMelding.java
@@ -40,11 +40,12 @@ public class TilskuddsperiodeGodkjentMelding {
     Integer lønnstilskuddsprosent;
     Integer avtaleNr;
     Integer løpenummer;
+    Integer resendingsNummer;
     String enhet;
     NavIdent beslutterNavIdent;
     LocalDateTime godkjentTidspunkt;
 
-    public static TilskuddsperiodeGodkjentMelding create(Avtale avtale, TilskuddPeriode tilskuddsperiode) {
+    public static TilskuddsperiodeGodkjentMelding create(Avtale avtale, TilskuddPeriode tilskuddsperiode, int resendingsNummer) {
         return new TilskuddsperiodeGodkjentMelding
                 (avtale.getId(),
                 tilskuddsperiode.getId(),
@@ -68,6 +69,7 @@ public class TilskuddsperiodeGodkjentMelding {
                 tilskuddsperiode.getLonnstilskuddProsent(),
                 avtale.getAvtaleNr(),
                 tilskuddsperiode.getLøpenummer(),
+                resendingsNummer,
                 tilskuddsperiode.getEnhet(),
                 tilskuddsperiode.getGodkjentAvNavIdent(),
                 tilskuddsperiode.getGodkjentTidspunkt()

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/tilskuddsperiode/TilskuddsperiodeKafkaProducer.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/tilskuddsperiode/TilskuddsperiodeKafkaProducer.java
@@ -37,7 +37,7 @@ public class TilskuddsperiodeKafkaProducer {
 
     @TransactionalEventListener
     public void tilskuddsperiodeGodkjent(TilskuddsperiodeGodkjent event) {
-        TilskuddsperiodeGodkjentMelding melding = TilskuddsperiodeGodkjentMelding.create(event.getAvtale(), event.getTilskuddsperiode());
+        TilskuddsperiodeGodkjentMelding melding = TilskuddsperiodeGodkjentMelding.create(event.getAvtale(), event.getTilskuddsperiode(), event.getResendingsNummer());
         publiserTilskuddsperiodeGodkjentMelding(melding);
     }
 

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/RegnUtTilskuddsperioderForAvtaleTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/RegnUtTilskuddsperioderForAvtaleTest.java
@@ -590,4 +590,5 @@ public class RegnUtTilskuddsperioderForAvtaleTest {
         TilskuddPeriode tilskuddPeriode2 = new TilskuddPeriode(1000, LocalDate.of(2021, 4, 1), LocalDate.of(2021, 5, 25), 60);
         assertThatThrownBy(() -> harAlleDageneIAvtalenperioden(List.of(tilskuddPeriode1, tilskuddPeriode2), LocalDate.of(2021, 1, 1), LocalDate.of(2021, 5, 26))).isInstanceOf(AssertionError.class);
     }
+
 }

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/tilskuddsperiode/TilskuddsperiodeGodkjentKafkaProducerTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/tilskuddsperiode/TilskuddsperiodeGodkjentKafkaProducerTest.java
@@ -2,29 +2,24 @@ package no.nav.tag.tiltaksgjennomforing.tilskuddsperiode;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Map;
 import java.util.UUID;
 import no.nav.tag.tiltaksgjennomforing.Miljø;
-import no.nav.tag.tiltaksgjennomforing.avtale.BedriftNr;
-import no.nav.tag.tiltaksgjennomforing.avtale.Fnr;
-import no.nav.tag.tiltaksgjennomforing.avtale.Identifikator;
-import no.nav.tag.tiltaksgjennomforing.avtale.NavIdent;
-import no.nav.tag.tiltaksgjennomforing.avtale.Tiltakstype;
+import no.nav.tag.tiltaksgjennomforing.avtale.*;
 import no.nav.tag.tiltaksgjennomforing.featuretoggles.FeatureToggleService;
 import no.nav.tag.tiltaksgjennomforing.infrastruktur.kafka.Topics;
 import no.nav.tag.tiltaksgjennomforing.utils.Now;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.json.JSONException;
 import org.json.JSONObject;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -54,6 +49,8 @@ class TilskuddsperiodeGodkjentKafkaProducerTest {
 
     @Autowired
     private EmbeddedKafkaBroker embeddedKafka;
+    @Autowired
+    private AvtaleRepository avtaleRepository;
 
     @MockBean
     private FeatureToggleService featureToggleService;
@@ -92,7 +89,7 @@ class TilskuddsperiodeGodkjentKafkaProducerTest {
 
         final TilskuddsperiodeGodkjentMelding tilskuddMelding = new TilskuddsperiodeGodkjentMelding(avtaleId,
                 tilskuddPeriodeId, avtaleInnholdId, tiltakstype, deltakerFornavn, deltakerEtternavn,
-                deltakerFnr, arbeidsgiverFornavn, arbeidsgiverEtternavn, arbeidsgiverTlf, veilederNavIdent, bedriftNavn, bedriftnummer, tilskuddBeløp, tilskuddFraDato, tilskuddTilDato, 10.6, 0.02, 14.1, 60, avtaleNr, løpenummer,
+                deltakerFnr, arbeidsgiverFornavn, arbeidsgiverEtternavn, arbeidsgiverTlf, veilederNavIdent, bedriftNavn, bedriftnummer, tilskuddBeløp, tilskuddFraDato, tilskuddTilDato, 10.6, 0.02, 14.1, 60, avtaleNr, løpenummer, 0,
             "4808", beslutterNavIdent, LocalDateTime.now());
 
         //NÅR
@@ -126,4 +123,5 @@ class TilskuddsperiodeGodkjentKafkaProducerTest {
         assertThat(jsonRefusjonRecord.get("beslutterNavIdent")).isNotNull();
         assertThat(jsonRefusjonRecord.get("godkjentTidspunkt")).isNotNull();
     }
+
 }

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/tilskuddsperiode/TilskuddsperiodeResendingTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/tilskuddsperiode/TilskuddsperiodeResendingTest.java
@@ -1,0 +1,91 @@
+package no.nav.tag.tiltaksgjennomforing.tilskuddsperiode;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import no.nav.tag.tiltaksgjennomforing.Miljø;
+import no.nav.tag.tiltaksgjennomforing.avtale.Avtale;
+import no.nav.tag.tiltaksgjennomforing.avtale.AvtaleRepository;
+import no.nav.tag.tiltaksgjennomforing.avtale.TestData;
+import no.nav.tag.tiltaksgjennomforing.featuretoggles.FeatureToggleService;
+import no.nav.tag.tiltaksgjennomforing.infrastruktur.kafka.Topics;
+import no.nav.tag.tiltaksgjennomforing.utils.Now;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.test.EmbeddedKafkaBroker;
+import org.springframework.kafka.test.context.EmbeddedKafka;
+import org.springframework.kafka.test.utils.KafkaTestUtils;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.LocalDate;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+@SpringBootTest(properties = { "tiltaksgjennomforing.kafka.enabled=true" })
+@DirtiesContext
+@ActiveProfiles({ Miljø.LOCAL })
+@EmbeddedKafka(partitions = 1, topics = { Topics.TILSKUDDSPERIODE_GODKJENT })
+public class TilskuddsperiodeResendingTest {
+
+    @Autowired
+    private EmbeddedKafkaBroker embeddedKafka;
+    @Autowired
+    private AvtaleRepository avtaleRepository;
+
+    @MockBean
+    private FeatureToggleService featureToggleService;
+
+    @Test
+    public void sjekk_at_godkjent_med_samme_løpenummer_får_resendings_nummer() throws JSONException {
+        when(featureToggleService.isEnabled(anyString())).thenReturn(true);
+
+        Map<String, Object> consumerProps = KafkaTestUtils.consumerProps("testGroup", "false", embeddedKafka);
+        consumerProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        consumerProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        var consumerFactory = new DefaultKafkaConsumerFactory<String, String>(consumerProps);
+        var consumer = consumerFactory.createConsumer();
+        embeddedKafka.consumeFromAllEmbeddedTopics(consumer);
+
+        Now.fixedDate(LocalDate.of(2023, 03, 1));
+        LocalDate avtaleStart = LocalDate.of(2022, 10, 20);
+        LocalDate avtaleSlutt = LocalDate.of(2024, 3, 2);
+        Avtale avtale = TestData.enLønnstilskuddsAvtaleMedStartOgSluttGodkjentAvAlleParter(avtaleStart, avtaleSlutt);
+        // Godkjenner første gang. Denne skal ikke ha noen resendingsNummer
+        avtale.godkjennTilskuddsperiode(TestData.enNavIdent2(), "4321");
+        avtale.nyeTilskuddsperioderEtterMigreringFraArena(LocalDate.of(2022, 10, 20), false);
+        // Nå er perioden annullert en gang, godkjenner igjen. Da den nå har den samme løpenr må den få resendingsNummer = 1
+        avtale.godkjennTilskuddsperiode(TestData.enNavIdent2(), "1234");
+        avtale.getTilskuddPeriode().forEach(periode -> System.out.println(periode.getStartDato() + " " + periode.getLøpenummer() + " " + periode.getStatus()));
+        avtaleRepository.save(avtale);
+
+        //SÅ
+        ConsumerRecords<String, String> records = KafkaTestUtils.getRecords(consumer);
+        records.records("Topics.TILSKUDDSPERIODE_GODKJENT").forEach(record -> {
+            try {
+                JSONObject jsonRefusjonRecord = new JSONObject(record.value());
+                String enhet = (String)jsonRefusjonRecord.get("enhet");
+                if("4321".equals(enhet)) {
+                    assertThat(jsonRefusjonRecord.get("resendingsNummer")).isNull();
+                }
+                if("1234".equals(enhet)) {
+                    assertThat((int)jsonRefusjonRecord.get("resendingsNummer")).isEqualTo(1);
+                }
+                assertThat(jsonRefusjonRecord.get("avtaleId")).isNotNull();
+            } catch (JSONException e) {
+                throw new RuntimeException(e);
+            }
+        });
+        Now.resetClock();
+
+    }
+}


### PR DESCRIPTION
Obes håndterer ikke følgende scenario
Tilskuddsperiode godkjennes -> penger holdes av
Perioden blir annullers -> annulleringsmelding til oebs
Tilskuddsperioden godkjennes igjen med samme løpenr -> Oebs kaster exception.

Løser det ved å legge til et "resendingsNummer" på godkjenninger på samme løpenr. Det kan brukes i økonimi-appen for å lage unik id.