### PR TITLE
Beslutter kan overstyre enhet ved godkjenn tilskuddsperiode. Det blir…

### DIFF
--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/InnloggingService.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/InnloggingService.java
@@ -73,7 +73,7 @@ public class InnloggingService {
         } else if (issuer == Issuer.ISSUER_AAD && avtalerolle == Avtalerolle.BESLUTTER) {
             boolean harAdGruppeForBeslutter = tokenUtils.harAdGruppe(beslutterAdGruppeProperties.getId());
             if (harAdGruppeForBeslutter) {
-                return new Beslutter(new NavIdent(brukerOgIssuer.getBrukerIdent()), tilgangskontrollService, axsysService);
+                return new Beslutter(new NavIdent(brukerOgIssuer.getBrukerIdent()), tilgangskontrollService, axsysService, norg2Client);
             } else {
                 throw new FeilkodeException(Feilkode.MANGLER_AD_GRUPPE_BESLUTTER);
             }

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/Beslutter.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/Beslutter.java
@@ -8,6 +8,10 @@ import lombok.extern.slf4j.Slf4j;
 import no.nav.tag.tiltaksgjennomforing.autorisasjon.InnloggetBeslutter;
 import no.nav.tag.tiltaksgjennomforing.autorisasjon.InnloggetBruker;
 import no.nav.tag.tiltaksgjennomforing.autorisasjon.abac.TilgangskontrollService;
+import no.nav.tag.tiltaksgjennomforing.enhet.Norg2Client;
+import no.nav.tag.tiltaksgjennomforing.enhet.Norg2OppfølgingResponse;
+import no.nav.tag.tiltaksgjennomforing.exceptions.Feilkode;
+import no.nav.tag.tiltaksgjennomforing.exceptions.FeilkodeException;
 import no.nav.tag.tiltaksgjennomforing.exceptions.NavEnhetIkkeFunnetException;
 import no.nav.tag.tiltaksgjennomforing.exceptions.TilgangskontrollException;
 import no.nav.tag.tiltaksgjennomforing.featuretoggles.enhet.AxsysService;
@@ -15,18 +19,24 @@ import no.nav.tag.tiltaksgjennomforing.featuretoggles.enhet.NavEnhet;
 
 @Slf4j
 public class Beslutter extends Avtalepart<NavIdent> {
-
-    private TilgangskontrollService tilgangskontrollService;
     private AxsysService axsysService;
+    private Norg2Client norg2Client;
+    private TilgangskontrollService tilgangskontrollService;
 
-    public Beslutter(NavIdent identifikator, TilgangskontrollService tilgangskontrollService, AxsysService axsysService) {
+    public Beslutter(NavIdent identifikator, TilgangskontrollService tilgangskontrollService, AxsysService axsysService, Norg2Client norg2Client) {
         super(identifikator);
         this.tilgangskontrollService = tilgangskontrollService;
         this.axsysService = axsysService;
+        this.norg2Client = norg2Client;
     }
 
     public void godkjennTilskuddsperiode(Avtale avtale, String enhet) {
         sjekkTilgang(avtale);
+        final Norg2OppfølgingResponse response = norg2Client.hentOppfølgingsEnhetsnavn(enhet);
+
+        if (response == null) {
+            throw new FeilkodeException(Feilkode.ENHET_FINNES_IKKE);
+        }
         avtale.godkjennTilskuddsperiode(getIdentifikator(), enhet);
     }
 

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/TestData.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/TestData.java
@@ -678,9 +678,12 @@ public class TestData {
     public static Beslutter enBeslutter(Avtale avtale) {
         TilgangskontrollService tilgangskontrollService = mock(TilgangskontrollService.class);
         AxsysService axsysService = mock(AxsysService.class);
+        Norg2Client norg2Client = mock(Norg2Client.class);
         NavIdent navIdent = new NavIdent("B999999");
         when(tilgangskontrollService.harSkrivetilgangTilKandidat(eq(navIdent), eq(avtale.getDeltakerFnr()))).thenReturn(true);
-        return new Beslutter(navIdent, tilgangskontrollService, axsysService);
+        when(norg2Client.hentOppfølgingsEnhetsnavn(eq("0000"))).thenReturn(new Norg2OppfølgingResponse(0, "0000", "Oslo"));
+        when(norg2Client.hentOppfølgingsEnhetsnavn(eq("0906"))).thenReturn(new Norg2OppfølgingResponse(906, "0906", "Oslo"));
+        return new Beslutter(navIdent, tilgangskontrollService, axsysService, norg2Client);
     }
 
     public static Maal etMaal() {

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/varsel/LagVarselFraAvtaleHendelserTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/varsel/LagVarselFraAvtaleHendelserTest.java
@@ -8,6 +8,7 @@ import static no.nav.tag.tiltaksgjennomforing.avtale.Avtalerolle.VEILEDER;
 import static no.nav.tag.tiltaksgjennomforing.avtale.HendelseType.*;
 import static no.nav.tag.tiltaksgjennomforing.avtale.TestData.avtalerMedTilskuddsperioder;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
 
 import java.util.EnumSet;
 import java.util.List;


### PR DESCRIPTION
Tidligere kunne beslutter sette hva som helst på fire siffer. Nå blir det validert at enheten som evt overstyres ved godkjenning av tilskuddsperiode faktisk finnes.