### PR TITLE
Endre url for tiltak-fakelogin

### DIFF
--- a/src/test/resources/config/application-dockercompose.yml
+++ b/src/test/resources/config/application-dockercompose.yml
@@ -85,10 +85,10 @@ no.nav.gcp.kafka.aiven:
 no.nav.security.jwt:
   issuer:
     aad:
-      discoveryurl: https://tiltak-fakelogin.labs.nais.io/metadata?issuer=aad
+      discoveryurl: https://tiltak-fakelogin.ekstern.dev.nav.no/metadata?issuer=aad
       accepted_audience: fake-aad
     tokenx:
-      discoveryurl: https://tiltak-fakelogin.labs.nais.io/metadata?issuer=tokenx
+      discoveryurl: https://tiltak-fakelogin.ekstern.dev.nav.no/metadata?issuer=tokenx
       accepted_audience: fake-tokenx
   client: null
 

--- a/src/test/resources/config/application-local.yaml
+++ b/src/test/resources/config/application-local.yaml
@@ -35,10 +35,10 @@ no.nav.gcp.kafka.aiven:
 no.nav.security.jwt:
   issuer:
     aad:
-      discoveryurl: https://tiltak-fakelogin.labs.nais.io/metadata?issuer=aad
+      discoveryurl: https://tiltak-fakelogin.ekstern.dev.nav.no/metadata?issuer=aad
       accepted_audience: fake-aad
     tokenx:
-      discoveryurl: https://tiltak-fakelogin.labs.nais.io/metadata?issuer=tokenx
+      discoveryurl: https://tiltak-fakelogin.ekstern.dev.nav.no/metadata?issuer=tokenx
       accepted_audience: fake-tokenx
   client: null
 


### PR DESCRIPTION
Appen som brukes for å opprette innlogginger
i test kjørte tidligere på labs, men har nå
blitt migrert til dev-gcp.