### PR TITLE
Oppgrader workflows

### DIFF
--- a/.github/workflows/bygg-og-deploy-dev.yml
+++ b/.github/workflows/bygg-og-deploy-dev.yml
@@ -18,18 +18,11 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Oppsett Java 17
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: 17
           distribution: 'zulu'
-
-      - name: Gjenopprett Maven-cache
-        uses: actions/cache@v3
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
+          cache: maven
 
       - name: Bygg og test med Maven
         run: mvn package -B -Dsurefire.useFile=false

--- a/.github/workflows/bygg-og-deploy-master.yml
+++ b/.github/workflows/bygg-og-deploy-master.yml
@@ -19,18 +19,11 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Oppsett Java 17
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: 17
           distribution: 'zulu'
-
-      - name: Gjenopprett Maven-cache
-        uses: actions/cache@v3
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
+          cache: maven
 
       - name: Bygg og test med Maven
         run: mvn package -B -Dsurefire.useFile=false


### PR DESCRIPTION
setup-jave har en cache-option, så vi
behøver ikke en separat action for det.

Oppgradert til setup-java@v3 for å bli
kvitt en deprecation warning