### PR TITLE
Støtte syntetiske fødselsnummere fra dolly

### DIFF
--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/Fnr.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/Fnr.java
@@ -87,7 +87,11 @@ public class Fnr extends Identifikator {
         if (!isSynthetic(fodselsnummer)) {
             return fodselsnummer;
         } else {
-            return fodselsnummer.substring(0, 2) + (getThirdDigit(fodselsnummer) - 8) + fodselsnummer.substring(3);
+            if (getThirdDigit(fodselsnummer) > 8) {
+                return fodselsnummer.substring(0, 2) + (getThirdDigit(fodselsnummer) - 8) + fodselsnummer.substring(3);
+            } else {
+                return fodselsnummer.substring(0, 2) + (getThirdDigit(fodselsnummer) - 4) + fodselsnummer.substring(3);
+            }
         }
     }
 
@@ -95,6 +99,9 @@ public class Fnr extends Identifikator {
         try {
             int thirdDigit = getThirdDigit(fodselsnummer);
             if (thirdDigit == 8 || thirdDigit == 9) {
+                return true;
+            }
+            if (thirdDigit > 3) {
                 return true;
             }
         } catch (IllegalArgumentException e) {

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/FnrTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/FnrTest.java
@@ -111,4 +111,10 @@ public class FnrTest {
 
         Now.resetClock();
     }
+
+    @Test
+    void testOver67ÅrFørsteJanuar() {
+        Fnr fnr = new Fnr("07459742977");
+        fnr.erUnder16år();
+    }
 }

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/FnrTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/FnrTest.java
@@ -113,7 +113,7 @@ public class FnrTest {
     }
 
     @Test
-    void testOver67ÅrFørsteJanuar() {
+    void testAtAldersjekkKanGjøresPåSyntetiskFnr() {
         Fnr fnr = new Fnr("07459742977");
         fnr.erUnder16år();
     }


### PR DESCRIPTION
Syntetiske fnr fra dolly har økt måneden med 40. Trekker dette fra for å kunne regne ut alder.