### PR TITLE
Refaktorer TilgangskontrollService

### DIFF
--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/InnloggingService.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/InnloggingService.java
@@ -69,11 +69,11 @@ public class InnloggingService {
             NavIdent navIdent = new NavIdent(brukerOgIssuer.getBrukerIdent());
             Set<NavEnhet> navEnheter = hentNavEnheter(navIdent);
             boolean harAdGruppeForBeslutter = tokenUtils.harAdGruppe(beslutterAdGruppeProperties.getId());
-            return new Veileder(navIdent, tilgangskontrollService, persondataService, norg2Client, navEnheter, slettemerkeProperties, harAdGruppeForBeslutter, veilarbArenaClient);
+            return new Veileder(navIdent, tokenUtils.hentAzureOid(), tilgangskontrollService, persondataService, norg2Client, navEnheter, slettemerkeProperties, harAdGruppeForBeslutter, veilarbArenaClient);
         } else if (issuer == Issuer.ISSUER_AAD && avtalerolle == Avtalerolle.BESLUTTER) {
             boolean harAdGruppeForBeslutter = tokenUtils.harAdGruppe(beslutterAdGruppeProperties.getId());
             if (harAdGruppeForBeslutter) {
-                return new Beslutter(new NavIdent(brukerOgIssuer.getBrukerIdent()), tilgangskontrollService, axsysService, norg2Client);
+                return new Beslutter(new NavIdent(brukerOgIssuer.getBrukerIdent()), tokenUtils.hentAzureOid(), tilgangskontrollService, axsysService, norg2Client);
             } else {
                 throw new FeilkodeException(Feilkode.MANGLER_AD_GRUPPE_BESLUTTER);
             }

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/TokenUtils.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/TokenUtils.java
@@ -19,7 +19,11 @@ public class TokenUtils {
     private static final String ACR = "acr";
     private static final String LEVEL4 = "Level4";
 
-   public enum Issuer {
+    public UUID hentAzureOid() {
+        return hentClaim(ISSUER_AAD, "oid").map(UUID::fromString).orElse(null);
+    }
+
+    public enum Issuer {
         ISSUER_AAD("aad"),
         ISSUER_SYSTEM("system"),
         ISSUER_TOKENX("tokenx");

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/abac/TilgangskontrollService.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/abac/TilgangskontrollService.java
@@ -4,10 +4,10 @@ import java.util.Map;
 import java.util.Set;
 
 import no.nav.tag.tiltaksgjennomforing.avtale.Fnr;
-import no.nav.tag.tiltaksgjennomforing.avtale.NavIdent;
+import no.nav.tag.tiltaksgjennomforing.avtale.InternBruker;
 
 public interface TilgangskontrollService {
-  boolean harSkrivetilgangTilKandidat(NavIdent navIdent, Fnr fnr);
+  boolean harSkrivetilgangTilKandidat(InternBruker internBruker, Fnr fnr);
 
-  Map<Fnr, Boolean> skriveTilganger(NavIdent navIdent, Set<Fnr> fnr);
+  Map<Fnr, Boolean> skriveTilganger(InternBruker internBruker, Set<Fnr> fnr);
 }

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/abac/TilgangskontrollService.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/abac/TilgangskontrollService.java
@@ -1,8 +1,13 @@
 package no.nav.tag.tiltaksgjennomforing.autorisasjon.abac;
 
+import java.util.Map;
+import java.util.Set;
+
 import no.nav.tag.tiltaksgjennomforing.avtale.Fnr;
 import no.nav.tag.tiltaksgjennomforing.avtale.NavIdent;
 
 public interface TilgangskontrollService {
   boolean harSkrivetilgangTilKandidat(NavIdent navIdent, Fnr fnr);
+
+  Map<Fnr, Boolean> skriveTilganger(NavIdent navIdent, Set<Fnr> fnr);
 }

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/abac/TilgangskontrollServiceImpl.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/abac/TilgangskontrollServiceImpl.java
@@ -1,25 +1,29 @@
 package no.nav.tag.tiltaksgjennomforing.autorisasjon.abac;
 
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
 import lombok.RequiredArgsConstructor;
 import no.nav.tag.tiltaksgjennomforing.autorisasjon.abac.adapter.AbacAdapter;
 import no.nav.tag.tiltaksgjennomforing.avtale.Fnr;
 import no.nav.tag.tiltaksgjennomforing.avtale.NavIdent;
-import no.nav.tag.tiltaksgjennomforing.exceptions.IkkeTilgangTilDeltakerException;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
 public class TilgangskontrollServiceImpl implements TilgangskontrollService {
 
-  private final AbacAdapter abacAdapter;
+    private final AbacAdapter abacAdapter;
 
-  public boolean harSkrivetilgangTilKandidat(NavIdent navIdent, Fnr fnr) {
-    return abacAdapter.harLeseTilgang(navIdent.asString(), fnr.asString());
-  }
-
-  private void harTilgang(NavIdent navIdent, Fnr fnr) {
-    if (!harSkrivetilgangTilKandidat(navIdent, fnr)) {
-      throw new IkkeTilgangTilDeltakerException();
+    public boolean harSkrivetilgangTilKandidat(NavIdent navIdent, Fnr fnr) {
+        return abacAdapter.harLeseTilgang(navIdent.asString(), fnr.asString());
     }
-  }
+
+    @Override
+    public Map<Fnr, Boolean> skriveTilganger(NavIdent navIdent, Set<Fnr> fnrListe) {
+        return fnrListe.stream()
+                .map(fnr -> Map.entry(fnr, harSkrivetilgangTilKandidat(navIdent, fnr)))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
 }

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/abac/TilgangskontrollServiceImpl.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/abac/TilgangskontrollServiceImpl.java
@@ -3,12 +3,12 @@ package no.nav.tag.tiltaksgjennomforing.autorisasjon.abac;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
 import no.nav.tag.tiltaksgjennomforing.autorisasjon.abac.adapter.AbacAdapter;
 import no.nav.tag.tiltaksgjennomforing.avtale.Fnr;
-import no.nav.tag.tiltaksgjennomforing.avtale.NavIdent;
-import org.springframework.stereotype.Service;
+import no.nav.tag.tiltaksgjennomforing.avtale.InternBruker;
 
 @Service
 @RequiredArgsConstructor
@@ -16,14 +16,13 @@ public class TilgangskontrollServiceImpl implements TilgangskontrollService {
 
     private final AbacAdapter abacAdapter;
 
-    public boolean harSkrivetilgangTilKandidat(NavIdent navIdent, Fnr fnr) {
-        return abacAdapter.harLeseTilgang(navIdent.asString(), fnr.asString());
+    public boolean harSkrivetilgangTilKandidat(InternBruker internBruker, Fnr fnr) {
+        return abacAdapter.harLeseTilgang(internBruker.getNavIdent().asString(), fnr.asString());
     }
 
-    @Override
-    public Map<Fnr, Boolean> skriveTilganger(NavIdent navIdent, Set<Fnr> fnrListe) {
+    public Map<Fnr, Boolean> skriveTilganger(InternBruker internBruker, Set<Fnr> fnrListe) {
         return fnrListe.stream()
-                .map(fnr -> Map.entry(fnr, harSkrivetilgangTilKandidat(navIdent, fnr)))
+                .map(fnr -> Map.entry(fnr, harSkrivetilgangTilKandidat(internBruker, fnr)))
                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
     }
 }

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleController.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleController.java
@@ -121,12 +121,14 @@ public class AvtaleController {
         }
 
         start = Instant.now();
+        var fnrSet = avtaler.stream().map(AvtaleMinimal::getDeltakerFnr).map(Fnr::new).collect(Collectors.toSet());
+        var deltakereBeslutterHarTilgangTil = beslutter.harTilgangTilFnr(fnrSet).stream().map(Fnr::asString).collect(Collectors.toSet());
+
         List<AvtaleMinimal> avtalerMedTilgang = avtaler.stream()
                 .skip(skip)
                 .limit(limit)
-                .filter(avtaleMinimal -> beslutter.harTilgangTilFnr(
-                        new Fnr(avtaleMinimal.getDeltakerFnr()))).collect(Collectors.toList()
-                );
+                .filter(avtaleMinimal -> deltakereBeslutterHarTilgangTil.contains(avtaleMinimal.getDeltakerFnr()))
+                .toList();
         end = Instant.now();
         Duration abacFiltreringTid = Duration.between(start, end);
         if(abacFiltreringTid.getSeconds() > 1) {

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/Beslutter.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/Beslutter.java
@@ -23,11 +23,19 @@ public class Beslutter extends Avtalepart<NavIdent> {
     private Norg2Client norg2Client;
     private TilgangskontrollService tilgangskontrollService;
 
-    public Beslutter(NavIdent identifikator, TilgangskontrollService tilgangskontrollService, AxsysService axsysService, Norg2Client norg2Client) {
+    private UUID azureOid;
+
+    public Beslutter(NavIdent identifikator, UUID azureOid, TilgangskontrollService tilgangskontrollService, AxsysService axsysService, Norg2Client norg2Client) {
         super(identifikator);
+        this.azureOid = azureOid;
         this.tilgangskontrollService = tilgangskontrollService;
         this.axsysService = axsysService;
         this.norg2Client = norg2Client;
+    }
+
+    @Deprecated
+    public Beslutter(NavIdent identifikator, TilgangskontrollService tilgangskontrollService, AxsysService axsysService, Norg2Client norg2Client) {
+        this(identifikator, null, tilgangskontrollService, axsysService, norg2Client);
     }
 
     public void godkjennTilskuddsperiode(Avtale avtale, String enhet) {
@@ -74,6 +82,13 @@ public class Beslutter extends Avtalepart<NavIdent> {
 
     public boolean harTilgangTilFnr(Fnr fnr) {
         return tilgangskontrollService.harSkrivetilgangTilKandidat(getIdentifikator(), fnr);
+    }
+
+    public Set<Fnr> harTilgangTilFnr(Set<Fnr> fnrSet) {
+        return tilgangskontrollService.skriveTilganger(getIdentifikator(), fnrSet).entrySet().stream()
+                .filter(Map.Entry::getValue)
+                .map(Map.Entry::getKey)
+                .collect(Collectors.toSet());
     }
 
     @Override

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/Beslutter.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/Beslutter.java
@@ -18,7 +18,7 @@ import no.nav.tag.tiltaksgjennomforing.featuretoggles.enhet.AxsysService;
 import no.nav.tag.tiltaksgjennomforing.featuretoggles.enhet.NavEnhet;
 
 @Slf4j
-public class Beslutter extends Avtalepart<NavIdent> {
+public class Beslutter extends Avtalepart<NavIdent> implements InternBruker {
     private AxsysService axsysService;
     private Norg2Client norg2Client;
     private TilgangskontrollService tilgangskontrollService;
@@ -77,15 +77,15 @@ public class Beslutter extends Avtalepart<NavIdent> {
 
     @Override
     public boolean harTilgangTilAvtale(Avtale avtale) {
-        return tilgangskontrollService.harSkrivetilgangTilKandidat(getIdentifikator(), avtale.getDeltakerFnr());
+        return tilgangskontrollService.harSkrivetilgangTilKandidat(this, avtale.getDeltakerFnr());
     }
 
     public boolean harTilgangTilFnr(Fnr fnr) {
-        return tilgangskontrollService.harSkrivetilgangTilKandidat(getIdentifikator(), fnr);
+        return tilgangskontrollService.harSkrivetilgangTilKandidat(this, fnr);
     }
 
     public Set<Fnr> harTilgangTilFnr(Set<Fnr> fnrSet) {
-        return tilgangskontrollService.skriveTilganger(getIdentifikator(), fnrSet).entrySet().stream()
+        return tilgangskontrollService.skriveTilganger(this, fnrSet).entrySet().stream()
                 .filter(Map.Entry::getValue)
                 .map(Map.Entry::getKey)
                 .collect(Collectors.toSet());
@@ -236,5 +236,15 @@ public class Beslutter extends Avtalepart<NavIdent> {
     @Override
     public InnloggetBruker innloggetBruker() {
         return new InnloggetBeslutter(getIdentifikator());
+    }
+
+    @Override
+    public UUID getAzureOid() {
+        return azureOid;
+    }
+
+    @Override
+    public NavIdent getNavIdent() {
+        return getIdentifikator();
     }
 }

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/InternBruker.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/InternBruker.java
@@ -1,0 +1,8 @@
+package no.nav.tag.tiltaksgjennomforing.avtale;
+
+import java.util.UUID;
+
+public interface InternBruker {
+    UUID getAzureOid();
+    NavIdent getNavIdent();
+}

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/Veileder.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/Veileder.java
@@ -28,9 +28,11 @@ public class Veileder extends Avtalepart<NavIdent> {
     private final Norg2Client norg2Client;
     private final Set<NavEnhet> navEnheter;
     private final VeilarbArenaClient veilarbArenaClient;
+    private final UUID azureOid;
 
     public Veileder(
             NavIdent identifikator,
+            UUID azureOid,
             TilgangskontrollService tilgangskontrollService,
             PersondataService persondataService,
             Norg2Client norg2Client,
@@ -41,6 +43,7 @@ public class Veileder extends Avtalepart<NavIdent> {
     ) {
 
         super(identifikator);
+        this.azureOid = azureOid;
         this.tilgangskontrollService = tilgangskontrollService;
         this.persondataService = persondataService;
         this.norg2Client = norg2Client;
@@ -48,6 +51,20 @@ public class Veileder extends Avtalepart<NavIdent> {
         this.slettemerkeProperties = slettemerkeProperties;
         this.harAdGruppeForBeslutter = harAdGruppeForBeslutter;
         this.veilarbArenaClient = veilarbArenaClient;
+    }
+
+    @Deprecated
+    public Veileder(
+            NavIdent identifikator,
+            TilgangskontrollService tilgangskontrollService,
+            PersondataService persondataService,
+            Norg2Client norg2Client,
+            Set<NavEnhet> navEnheter,
+            SlettemerkeProperties slettemerkeProperties,
+            boolean harAdGruppeForBeslutter,
+            VeilarbArenaClient veilarbArenaClient
+    ) {
+        this(identifikator, null, tilgangskontrollService, persondataService, norg2Client, navEnheter, slettemerkeProperties, harAdGruppeForBeslutter, veilarbArenaClient);
     }
 
     @Override

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/Veileder.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/Veileder.java
@@ -19,7 +19,7 @@ import java.util.*;
 import static no.nav.tag.tiltaksgjennomforing.persondata.PersondataService.hentNavnFraPdlRespons;
 
 @Slf4j
-public class Veileder extends Avtalepart<NavIdent> {
+public class Veileder extends Avtalepart<NavIdent> implements InternBruker {
     private final TilgangskontrollService tilgangskontrollService;
 
     private final PersondataService persondataService;
@@ -69,7 +69,7 @@ public class Veileder extends Avtalepart<NavIdent> {
 
     @Override
     public boolean harTilgangTilAvtale(Avtale avtale) {
-        return tilgangskontrollService.harSkrivetilgangTilKandidat(getIdentifikator(), avtale.getDeltakerFnr());
+        return tilgangskontrollService.harSkrivetilgangTilKandidat(this, avtale.getDeltakerFnr());
     }
 
     @Override
@@ -265,21 +265,21 @@ public class Veileder extends Avtalepart<NavIdent> {
     }
 
     public Avtale opprettAvtale(OpprettAvtale opprettAvtale) {
-        this.sjekkTilgangskontroll(getIdentifikator(), opprettAvtale.getDeltakerFnr());
+        this.sjekkTilgangskontroll(opprettAvtale.getDeltakerFnr());
         Avtale avtale = Avtale.veilederOppretterAvtale(opprettAvtale, getIdentifikator());
         leggTilEnheter(avtale);
         return avtale;
     }
 
     public Avtale opprettMentorAvtale(OpprettMentorAvtale opprettMentorAvtale) {
-        this.sjekkTilgangskontroll(getIdentifikator(), opprettMentorAvtale.getDeltakerFnr());
+        this.sjekkTilgangskontroll(opprettMentorAvtale.getDeltakerFnr());
         Avtale avtale = Avtale.veilederOppretterAvtale(opprettMentorAvtale, getIdentifikator());
         leggTilEnheter(avtale);
         return avtale;
     }
 
-    public void sjekkTilgangskontroll(NavIdent identifikator, Fnr deltakerFnr) {
-        if(!tilgangskontrollService.harSkrivetilgangTilKandidat(identifikator, deltakerFnr)) {
+    private void sjekkTilgangskontroll(Fnr deltakerFnr) {
+        if(!tilgangskontrollService.harSkrivetilgangTilKandidat(this, deltakerFnr)) {
             throw new IkkeTilgangTilDeltakerException();
         }
     }
@@ -448,4 +448,11 @@ public class Veileder extends Avtalepart<NavIdent> {
         );
     }
 
+    @Override public UUID getAzureOid() {
+        return azureOid;
+    }
+
+    @Override public NavIdent getNavIdent() {
+        return getIdentifikator();
+    }
 }

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/InnloggetBrukerTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/InnloggetBrukerTest.java
@@ -64,12 +64,12 @@ public class InnloggetBrukerTest {
                 veilarbArenaClient
         );
         when(tilgangskontrollService.harSkrivetilgangTilKandidat(
-                veileder.getIdentifikator(),
+                veileder,
                 avtale.getDeltakerFnr())
         ).thenReturn(true);
 
         assertThat(veileder.harTilgang(avtale)).isTrue();
-        verify(tilgangskontrollService).harSkrivetilgangTilKandidat(veileder.getIdentifikator(), avtale.getDeltakerFnr());
+        verify(tilgangskontrollService).harSkrivetilgangTilKandidat(veileder, avtale.getDeltakerFnr());
     }
 
     @Test
@@ -85,7 +85,7 @@ public class InnloggetBrukerTest {
                 veilarbArenaClient
         );
         when(tilgangskontrollService.harSkrivetilgangTilKandidat(
-                veileder.getIdentifikator(),
+                veileder,
                 avtale.getDeltakerFnr()
         )).thenReturn(false);
 
@@ -104,12 +104,12 @@ public class InnloggetBrukerTest {
                 false, veilarbArenaClient
         );
         when(tilgangskontrollService.harSkrivetilgangTilKandidat(
-                veileder.getIdentifikator(),
+                veileder,
                 avtale.getDeltakerFnr())
         ).thenReturn(true);
 
         assertThat(veileder.harTilgang(avtale)).isTrue();
-        verify(tilgangskontrollService).harSkrivetilgangTilKandidat(veileder.getIdentifikator(), avtale.getDeltakerFnr());
+        verify(tilgangskontrollService).harSkrivetilgangTilKandidat(veileder, avtale.getDeltakerFnr());
     }
 
     @Test
@@ -125,7 +125,7 @@ public class InnloggetBrukerTest {
                 veilarbArenaClient
         );
         when(tilgangskontrollService.harSkrivetilgangTilKandidat(
-                veileder.getIdentifikator(),
+                veileder,
                 avtale.getDeltakerFnr())
         ).thenReturn(false);
 

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleControllerTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleControllerTest.java
@@ -83,7 +83,7 @@ public class AvtaleControllerTest {
                 veilarbArenaClient
         );
         værInnloggetSom(veileder);
-        when(tilgangskontrollService.harSkrivetilgangTilKandidat(eq(veileder.getIdentifikator()), any(Fnr.class))).thenReturn(true);
+        when(tilgangskontrollService.harSkrivetilgangTilKandidat(eq(veileder), any(Fnr.class))).thenReturn(true);
         when(avtaleRepository.findById(avtale.getId())).thenReturn(Optional.of(avtale));
         Avtale hentetAvtale = avtaleController.hent(avtale.getId(), Avtalerolle.VEILEDER);
         assertThat(hentetAvtale).isEqualTo(avtale);
@@ -142,7 +142,7 @@ public class AvtaleControllerTest {
                 avtaleRepository.findAllByVeilederNavIdent(veilederNavIdent)
         ).thenReturn(asList(avtaleForVeilederSomSøkesEtter, avtaleForAnnenVeilder));
         when(tilgangskontrollService.harSkrivetilgangTilKandidat(
-                eq(identTilInnloggetVeileder),
+                eq(veileder),
                 any(Fnr.class)
         )).thenReturn(true);
         AvtalePredicate avtalePredicate = new AvtalePredicate();
@@ -179,7 +179,7 @@ public class AvtaleControllerTest {
                 avtaleRepository.findAllByVeilederNavIdent(veilederNavIdent)
         ).thenReturn(List.of(avtaleForVeilederSomSøkesEtter));
         when(tilgangskontrollService.harSkrivetilgangTilKandidat(
-                eq(identTilInnloggetVeileder),
+                eq(veileder),
                 any(Fnr.class)
         )).thenReturn(false);
         Iterable<Avtale> avtaler = avtaleController.hentAlleAvtalerInnloggetBrukerHarTilgangTil(
@@ -212,7 +212,7 @@ public class AvtaleControllerTest {
                 avtaleRepository.findAllByVeilederNavIdent(identTilInnloggetVeileder)
         ).thenReturn(asList(avtaleForInnloggetVeileder, avtaleForAnnenVeilder));
         when(tilgangskontrollService.harSkrivetilgangTilKandidat(
-                eq(identTilInnloggetVeileder),
+                eq(veileder),
                 any(Fnr.class)
         )).thenReturn(true);
 
@@ -249,7 +249,7 @@ public class AvtaleControllerTest {
         when(
                 avtaleRepository.findAllFordelteOrUfordeltByEnhet(navEnhet)
         ).thenReturn(asList(nyAvtaleMedGeografiskEnhet, nyAvtaleMedOppfølgningsEnhet));
-        when(tilgangskontrollService.harSkrivetilgangTilKandidat(eq(navIdent), any(Fnr.class))).thenReturn(true);
+        when(tilgangskontrollService.harSkrivetilgangTilKandidat(eq(veileder), any(Fnr.class))).thenReturn(true);
 
         List<Avtale> avtaler = avtaleController.hentAlleAvtalerInnloggetBrukerHarTilgangTil(
                 new AvtalePredicate().setNavEnhet(navEnhet),
@@ -283,7 +283,7 @@ public class AvtaleControllerTest {
         enArbeidstreningsAvtale.setAvtaleNr(TestData.ET_AVTALENR);
 
         when(avtaleRepository.findAllByAvtaleNr(TestData.ET_AVTALENR)).thenReturn(asList(enArbeidstreningsAvtale));
-        when(tilgangskontrollService.harSkrivetilgangTilKandidat(eq(navIdent), any(Fnr.class))).thenReturn(true);
+        when(tilgangskontrollService.harSkrivetilgangTilKandidat(eq(veileder), any(Fnr.class))).thenReturn(true);
 
         List<Avtale> avtaler = avtaleController.hentAlleAvtalerInnloggetBrukerHarTilgangTil(
                 new AvtalePredicate().setAvtaleNr(TestData.ET_AVTALENR),
@@ -361,18 +361,17 @@ public class AvtaleControllerTest {
                 avtale.getBedriftNr(),
                 Tiltakstype.ARBEIDSTRENING
         );
-        værInnloggetSom(
-                new Veileder(
-                        navIdent,
-                        tilgangskontrollService,
-                        persondataService,
-                        norg2Client,
-                        Set.of(navEnhet),
-                        new SlettemerkeProperties(),
-                        false,
-                        veilarbArenaClient
-                )
+        var veileder = new Veileder(
+                navIdent,
+                tilgangskontrollService,
+                persondataService,
+                norg2Client,
+                Set.of(navEnhet),
+                new SlettemerkeProperties(),
+                false,
+                veilarbArenaClient
         );
+        værInnloggetSom(veileder);
         when(avtaleRepository.save(any(Avtale.class))).thenReturn(avtale);
         when(
                 eregService.hentVirksomhet(avtale.getBedriftNr())).thenReturn(
@@ -381,7 +380,7 @@ public class AvtaleControllerTest {
                                 avtale.getGjeldendeInnhold().getBedriftNavn()
                         )
         );
-        when(tilgangskontrollService.harSkrivetilgangTilKandidat(eq(navIdent), any())).thenReturn(true);
+        when(tilgangskontrollService.harSkrivetilgangTilKandidat(eq(veileder), any())).thenReturn(true);
         when(persondataService.hentPersondata(fnr)).thenReturn(pdlRespons);
         when(norg2Client.hentGeografiskEnhet(pdlRespons.getData().getHentGeografiskTilknytning().getGtBydel()))
                 .thenReturn(
@@ -434,7 +433,7 @@ public class AvtaleControllerTest {
         );
         værInnloggetSom(veileder);
         when(tilgangskontrollService.harSkrivetilgangTilKandidat(
-                any(NavIdent.class),
+                any(Veileder.class),
                 any(Fnr.class)
         )).thenReturn(true);
         when(avtaleRepository.findById(avtale.getId())).thenReturn(Optional.of(avtale));
@@ -505,7 +504,7 @@ public class AvtaleControllerTest {
         værInnloggetSom(enNavAnsatt);
         Fnr deltakerFnr = new Fnr("11111100000");
         when(
-                tilgangskontrollService.harSkrivetilgangTilKandidat(enNavAnsatt.getIdentifikator(), deltakerFnr)
+                tilgangskontrollService.harSkrivetilgangTilKandidat(enNavAnsatt, deltakerFnr)
         ).thenReturn(false);
         assertThatThrownBy(
                 () -> avtaleController.opprettAvtaleSomVeileder(
@@ -531,7 +530,7 @@ public class AvtaleControllerTest {
         værInnloggetSom(enNavAnsatt);
         Fnr deltakerFnr = new Fnr("11111100000");
         when(
-                tilgangskontrollService.harSkrivetilgangTilKandidat(enNavAnsatt.getIdentifikator(), deltakerFnr)
+                tilgangskontrollService.harSkrivetilgangTilKandidat(enNavAnsatt, deltakerFnr)
         ).thenReturn(true);
         PdlRespons pdlRespons = TestData.enPdlrespons(true);
         when(persondataServiceIMetode.hentPersondata(deltakerFnr)).thenReturn(pdlRespons);
@@ -615,7 +614,7 @@ public class AvtaleControllerTest {
         when(kontoregisterService.hentKontonummer(anyString())).thenReturn("990983666");
         when(
                 tilgangskontrollService.harSkrivetilgangTilKandidat(
-                        eq(identTilInnloggetVeileder),
+                        eq(veileder),
                         any(Fnr.class)
                 )
         ).thenReturn(true);
@@ -641,7 +640,7 @@ public class AvtaleControllerTest {
         );
         værInnloggetSom(veileder);
         when(tilgangskontrollService.harSkrivetilgangTilKandidat(
-                        eq(identTilInnloggetVeileder),
+                        eq(veileder),
                         any(Fnr.class)
                 )).thenReturn(false);
         when(avtaleRepository.findById(avtale.getId())).thenReturn(Optional.of(avtale));
@@ -668,7 +667,7 @@ public class AvtaleControllerTest {
         værInnloggetSom(veileder);
         when(kontoregisterService.hentKontonummer(anyString())).thenThrow(KontoregisterFeilException.class);
         when(tilgangskontrollService.harSkrivetilgangTilKandidat(
-                eq(identTilInnloggetVeileder),
+                eq(veileder),
                 any(Fnr.class)
         )).thenReturn(true);
         when(avtaleRepository.findById(avtale.getId())).thenReturn(Optional.of(avtale));

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleTest.java
@@ -934,10 +934,6 @@ public class AvtaleTest {
 
         // Gi veileder tilgang til deltaker
         TilgangskontrollService tilgangskontrollService = mock(TilgangskontrollService.class);
-        when(tilgangskontrollService.harSkrivetilgangTilKandidat(
-                eq(avtale.getVeilederNavIdent()),
-                any(Fnr.class)
-        )).thenReturn(true);
 
         TilskuddsperiodeConfig tilskuddsperiodeConfig = new TilskuddsperiodeConfig();
 
@@ -951,6 +947,10 @@ public class AvtaleTest {
                 false,
                 mock(VeilarbArenaClient.class)
         );
+        when(tilgangskontrollService.harSkrivetilgangTilKandidat(
+                eq(veileder),
+                any(Fnr.class)
+        )).thenReturn(true);
         veileder.endreAvtale(
                 Instant.now(),
                 TestData.endringPåAlleArbeidstreningFelter(),
@@ -973,7 +973,6 @@ public class AvtaleTest {
 
         // Gi veileder tilgang til deltaker
         TilgangskontrollService tilgangskontrollService = mock(TilgangskontrollService.class);
-        when(tilgangskontrollService.harSkrivetilgangTilKandidat(eq(avtale.getVeilederNavIdent()), any(Fnr.class))).thenReturn(true);
 
         TilskuddsperiodeConfig tilskuddsperiodeConfig = new TilskuddsperiodeConfig();
 
@@ -987,6 +986,8 @@ public class AvtaleTest {
                 false,
                 mock(VeilarbArenaClient.class)
         );
+
+        when(tilgangskontrollService.harSkrivetilgangTilKandidat(eq(veileder), any(Fnr.class))).thenReturn(true);
 
         deltaker.godkjennAvtale(Instant.now(), avtale);
         arbeidsgiver.godkjennAvtale(Instant.now(), avtale);

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/BeslutterTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/BeslutterTest.java
@@ -1,6 +1,5 @@
 package no.nav.tag.tiltaksgjennomforing.avtale;
 
-
 import static no.nav.tag.tiltaksgjennomforing.AssertFeilkode.assertFeilkode;
 import static no.nav.tag.tiltaksgjennomforing.avtale.TestData.avtalerMedTilskuddsperioder;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -24,8 +23,8 @@ import no.nav.tag.tiltaksgjennomforing.exceptions.NavEnhetIkkeFunnetException;
 import no.nav.tag.tiltaksgjennomforing.featuretoggles.enhet.AxsysService;
 import no.nav.tag.tiltaksgjennomforing.featuretoggles.enhet.NavEnhet;
 import no.nav.tag.tiltaksgjennomforing.persondata.PersondataService;
-import org.junit.jupiter.api.Test;
 
+import org.junit.jupiter.api.Test;
 
 class BeslutterTest {
 
@@ -197,8 +196,6 @@ class BeslutterTest {
 
         // Gi veileder tilgang til deltaker
         TilgangskontrollService tilgangskontrollService = mock(TilgangskontrollService.class);
-        when(tilgangskontrollService.harSkrivetilgangTilKandidat(eq(avtale.getVeilederNavIdent()), any(Fnr.class)))
-                .thenReturn(true);
 
         Veileder veileder = new Veileder(
                 avtale.getVeilederNavIdent(),
@@ -209,6 +206,9 @@ class BeslutterTest {
                 mock(SlettemerkeProperties.class),
                 false,
                 mock(VeilarbArenaClient.class));
+
+        when(tilgangskontrollService.harSkrivetilgangTilKandidat(eq(veileder), any(Fnr.class)))
+                .thenReturn(true);
 
         avtale.endreAvtale(
                 Instant.now(),

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/VeilederTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/VeilederTest.java
@@ -131,9 +131,6 @@ public class VeilederTest {
 
         // Gi veileder tilgang til deltaker
         TilgangskontrollService tilgangskontrollService = mock(TilgangskontrollService.class);
-        when(tilgangskontrollService.harSkrivetilgangTilKandidat(eq(avtale.getVeilederNavIdent()), any(Fnr.class)))
-                .thenReturn(true);
-
         Veileder veileder = new Veileder(
                 avtale.getVeilederNavIdent(),
                 tilgangskontrollService,
@@ -144,6 +141,8 @@ public class VeilederTest {
 
                 false,
                 mock(VeilarbArenaClient.class));
+        when(tilgangskontrollService.harSkrivetilgangTilKandidat(eq(veileder), any(Fnr.class)))
+                .thenReturn(true);
 
         avtale.endreAvtale(
                 Instant.now(),
@@ -282,8 +281,18 @@ public class VeilederTest {
         final PdlRespons pdlRespons = TestData.enPdlrespons(false);
         final VeilarbArenaClient veilarbArenaClient = mock(VeilarbArenaClient.class);
 
+        Veileder veileder = new Veileder(
+                navIdent,
+                tilgangskontrollService,
+                persondataService,
+                norg2Client,
+                Set.of(navEnhet),
+                new SlettemerkeProperties(),
+                false,
+                veilarbArenaClient
+        );
 
-        when(tilgangskontrollService.harSkrivetilgangTilKandidat(eq(navIdent), any())).thenReturn(true);
+        when(tilgangskontrollService.harSkrivetilgangTilKandidat(eq(veileder), any())).thenReturn(true);
         when(persondataService.hentPersondata(fnr)).thenReturn(pdlRespons);
         when(persondataService.erKode6(pdlRespons)).thenCallRealMethod();
         when(norg2Client.hentGeografiskEnhet(pdlRespons.getData().getHentGeografiskTilknytning().getGtBydel()))
@@ -298,16 +307,6 @@ public class VeilederTest {
                         TestData.ENHET_GEOGRAFISK.getVerdi()
                 ));
 
-        Veileder veileder = new Veileder(
-                navIdent,
-                tilgangskontrollService,
-                persondataService,
-                norg2Client,
-                Set.of(navEnhet),
-                new SlettemerkeProperties(),
-                false,
-                veilarbArenaClient
-        );
         Avtale avtale = veileder.opprettAvtale(opprettAvtale);
 
         assertThat(avtale.getVeilederNavIdent()).isEqualTo(TestData.enNavIdent());
@@ -345,7 +344,7 @@ public class VeilederTest {
                 veilarbArenaClient
         );
 
-        when(tilgangskontrollService.harSkrivetilgangTilKandidat(eq(navIdent), any())).thenReturn(true);
+        when(tilgangskontrollService.harSkrivetilgangTilKandidat(eq(veileder), any())).thenReturn(true);
         when(persondataService.hentPersondata(fnr)).thenReturn(pdlRespons);
         when(veilarbArenaClient.hentOppfølgingsEnhet(fnr.asString())).thenReturn(navEnhet.getVerdi());
         when(norg2Client.hentGeografiskEnhet(pdlRespons.getData().getHentGeografiskTilknytning().getGtBydel()))
@@ -366,9 +365,6 @@ public class VeilederTest {
         NavIdent navIdent = new NavIdent("Z123456");
 
         TilgangskontrollService tilgangskontrollService = mock(TilgangskontrollService.class);
-        when(tilgangskontrollService.harSkrivetilgangTilKandidat(eq(navIdent), eq(avtale.getDeltakerFnr())))
-                .thenReturn(true);
-
         SlettemerkeProperties slettemerkeProperties = new SlettemerkeProperties();
         slettemerkeProperties.setIdent(List.of(navIdent));
         Veileder veileder = new Veileder(
@@ -381,6 +377,10 @@ public class VeilederTest {
                 false,
                 mock(VeilarbArenaClient.class)
         );
+
+        when(tilgangskontrollService.harSkrivetilgangTilKandidat(eq(veileder), eq(avtale.getDeltakerFnr())))
+                .thenReturn(true);
+
         veileder.slettemerk(avtale);
         assertThat(avtale.isSlettemerket()).isTrue();
     }
@@ -392,7 +392,6 @@ public class VeilederTest {
         NavIdent navIdent = new NavIdent("X123456");
 
         TilgangskontrollService tilgangskontrollService = mock(TilgangskontrollService.class);
-        when(tilgangskontrollService.harSkrivetilgangTilKandidat(eq(navIdent), eq(avtale.getDeltakerFnr()))).thenReturn(true);
 
         SlettemerkeProperties slettemerkeProperties = new SlettemerkeProperties();
         slettemerkeProperties.setIdent(List.of(new NavIdent("Z123456")));
@@ -406,6 +405,7 @@ public class VeilederTest {
                 false,
                 mock(VeilarbArenaClient.class)
         );
+        when(tilgangskontrollService.harSkrivetilgangTilKandidat(eq(veileder), eq(avtale.getDeltakerFnr()))).thenReturn(true);
         assertThatThrownBy(() -> veileder.slettemerk(avtale)).isExactlyInstanceOf(IkkeAdminTilgangException.class);
     }
 

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/infrastruktur/caching/CachingConfigMockTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/infrastruktur/caching/CachingConfigMockTest.java
@@ -150,7 +150,7 @@ public class CachingConfigMockTest {
         mockAbacAdapter = AopTestUtils.getTargetObject(abacAdapter);
 
         lenient().when(mockTilgangskontrollService.harSkrivetilgangTilKandidat(
-                eq(avtale.getVeilederNavIdent()),
+                any(),
                 eq(avtale.getDeltakerFnr())
         )).thenReturn(true, true, true);
 

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/infrastruktur/caching/CachingConfigTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/infrastruktur/caching/CachingConfigTest.java
@@ -196,11 +196,6 @@ public class CachingConfigTest {
 
         final TilgangskontrollService mockTilgangskontrollService = mock(TilgangskontrollService.class);
 
-        lenient().when(mockTilgangskontrollService.harSkrivetilgangTilKandidat(
-                eq(avtale.getVeilederNavIdent()),
-                eq(avtale.getDeltakerFnr())
-        )).thenReturn(true, true, true);
-
         Veileder veileder = new Veileder(
                 avtale.getVeilederNavIdent(),
                 mockTilgangskontrollService,
@@ -211,6 +206,11 @@ public class CachingConfigTest {
                 false,
                 veilarbArenaClient
         );
+
+        lenient().when(mockTilgangskontrollService.harSkrivetilgangTilKandidat(
+                eq(veileder),
+                eq(avtale.getDeltakerFnr())
+        )).thenReturn(true, true, true);
 
         veileder.endreAvtale(
                 Instant.now(),


### PR DESCRIPTION
Vi ønsker å ta i bruk poao-tilgang på sikt, men der ABAC
bruker en Nav-ident som nøkkel, vil poao-tilgang bruke
azure-id'en til brukeren som nøkkel.

I en overgangsfase behøver vi begge deler for å sjekke
i både abac og poao-tilgang. Derfor bør vi endre koden
slik at tilgangskontrollservice tar imot en bruker i stedet
for kun en ident.