### PR TITLE
Ikke cache feil fra Abac

### DIFF
--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/IntegrasjonerMockServer.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/IntegrasjonerMockServer.java
@@ -19,6 +19,10 @@ public class IntegrasjonerMockServer implements DisposableBean {
         server.start();
     }
 
+    public WireMockServer getServer() {
+        return server;
+    }
+
     @Override
     public void destroy() {
         log.info("Stopper mockserver.");

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/abac/adapter/AbacAdapterTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/abac/adapter/AbacAdapterTest.java
@@ -1,15 +1,20 @@
 package no.nav.tag.tiltaksgjennomforing.autorisasjon.abac.adapter;
 
+import com.github.tomakehurst.wiremock.WireMockServer;
+import no.nav.tag.tiltaksgjennomforing.IntegrasjonerMockServer;
 import no.nav.tag.tiltaksgjennomforing.Miljø;
 import no.nav.tag.tiltaksgjennomforing.avtale.Fnr;
 import no.nav.tag.tiltaksgjennomforing.avtale.NavIdent;
+import no.nav.tag.tiltaksgjennomforing.infrastruktur.cache.EhCacheConfig;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cache.ehcache.EhCacheCacheManager;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -17,18 +22,32 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @ActiveProfiles({ Miljø.LOCAL, "wiremock" })
 @DirtiesContext
 public class AbacAdapterTest {
+    private final AbacAdapter abacAdapter;
+    private final EhCacheCacheManager cacheManager;
+    private final WireMockServer mockServer;
 
-    @Autowired
-    private AbacAdapter abacAdapter;
+    public AbacAdapterTest(
+            @Autowired AbacAdapter abacAdapter,
+            @Autowired IntegrasjonerMockServer mockServerService,
+            @Autowired EhCacheCacheManager ehCacheCacheManager) {
+        this.abacAdapter = abacAdapter;
+        this.cacheManager = ehCacheCacheManager;
+        this.mockServer = mockServerService.getServer();
+    }
+
+    @BeforeEach
+    public void setup() {
+        cacheManager.getCache(EhCacheConfig.ABAC_CACHE).clear();
+    }
 
     @Test
     public void skal_teste_at_Abac_ikke_gi_lese_tilgang_på_På_Gitt_Bruker_Og_Veileder() {
         NavIdent veilederIdent = new NavIdent("F142226");
         Fnr deltakerFnr = new Fnr("01118023456");
 
-        boolean verdic = abacAdapter.harSkriveTilgang(veilederIdent.asString(), deltakerFnr.asString());
+        boolean utfall = abacAdapter.harSkriveTilgang(veilederIdent.asString(), deltakerFnr.asString());
 
-        assertFalse(verdic);
+        assertFalse(utfall);
     }
 
     @Test
@@ -36,8 +55,8 @@ public class AbacAdapterTest {
         NavIdent veilederIdent = new NavIdent("F142226");
         Fnr deltakerFnr = new Fnr("11111111111");
 
-        boolean verdic = abacAdapter.harSkriveTilgang(veilederIdent.asString(), deltakerFnr.asString());
-        assertThat(verdic).isFalse();
+        boolean utfall = abacAdapter.harSkriveTilgang(veilederIdent.asString(), deltakerFnr.asString());
+        assertFalse(utfall);
     }
 
     @Test
@@ -45,8 +64,8 @@ public class AbacAdapterTest {
         NavIdent veilederIdent = new NavIdent("F142226");
         Fnr deltakerFnr = new Fnr("07098142678");
 
-        boolean verdic = abacAdapter.harSkriveTilgang(veilederIdent.asString(), deltakerFnr.asString());
-        assertTrue(verdic);
+        boolean utfall = abacAdapter.harSkriveTilgang(veilederIdent.asString(), deltakerFnr.asString());
+        assertTrue(utfall);
     }
 
     @Test
@@ -65,4 +84,44 @@ public class AbacAdapterTest {
 
     }
 
+    @Test
+    public void bekreft_antall_ganger_endepunkter_blir_kalt_ved_abac() {
+        NavIdent veilederIdent = new NavIdent("F142226");
+
+        Fnr første_deltakerFnr = new Fnr("07098142678");
+        Fnr andre_deltakerFnr = new Fnr("01118023456");
+        mockServer.resetAll();
+
+        boolean tilgang_navId_F142226_og_fnr_07098142678 = abacAdapter.harSkriveTilgang(veilederIdent.asString(), første_deltakerFnr.asString());
+        boolean tilgang_navId_F142226_og_fnr_07098142678_response2 = abacAdapter.harSkriveTilgang(veilederIdent.asString(), første_deltakerFnr.asString());
+
+        mockServer.verify(exactly(1), postRequestedFor(urlEqualTo("/abac")));
+        mockServer.resetAll();
+
+        boolean tilgang_navId_F142226_og_fnr_11111111111 = abacAdapter.harSkriveTilgang(veilederIdent.asString(), andre_deltakerFnr.asString());
+        boolean tilgang_navId_F142226_og_fnr_11111111111_response2 = abacAdapter.harSkriveTilgang(veilederIdent.asString(), andre_deltakerFnr.asString());
+
+        mockServer.verify(exactly(1), postRequestedFor(urlEqualTo("/abac")));
+
+        assertTrue(tilgang_navId_F142226_og_fnr_07098142678);
+        assertTrue(tilgang_navId_F142226_og_fnr_07098142678_response2);
+
+        assertFalse(tilgang_navId_F142226_og_fnr_11111111111);
+        assertFalse(tilgang_navId_F142226_og_fnr_11111111111_response2);
+    }
+
+    @Test
+    public void ikke_cache_ved_feil_fra_abac() {
+        NavIdent veilederIdent = new NavIdent("F142226");
+        Fnr deltakerFnr = new Fnr("11111111111");
+        mockServer.resetAll();
+
+        boolean tilgang_navId_F142226_og_fnr_07098142678 = abacAdapter.harSkriveTilgang(veilederIdent.asString(), deltakerFnr.asString());
+        boolean tilgang_navId_F142226_og_fnr_07098142678_response2 = abacAdapter.harSkriveTilgang(veilederIdent.asString(), deltakerFnr.asString());
+
+        mockServer.verify(exactly(2), postRequestedFor(urlEqualTo("/abac")));
+
+        assertFalse(tilgang_navId_F142226_og_fnr_07098142678);
+        assertFalse(tilgang_navId_F142226_og_fnr_07098142678_response2);
+    }
 }

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/infrastruktur/caching/CachingConfigMockTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/infrastruktur/caching/CachingConfigMockTest.java
@@ -41,7 +41,6 @@ public class CachingConfigMockTest {
     private PersondataService mockPersondataService;
     private Norg2Client mockNorg2Client;
     private VeilarbArenaClient mockVeilarbArenaClient;
-    private AbacAdapter mockAbacAdapter;
 
     @Autowired
     private TilgangskontrollService tilgangskontrollService;
@@ -51,8 +50,6 @@ public class CachingConfigMockTest {
     private Norg2Client norg2Client;
     @Autowired
     private VeilarbArenaClient veilarbArenaClient;
-    @Autowired
-    AbacAdapter abacAdapter;
 
     private Avtale avtale = TestData.enMidlertidigLonnstilskuddsjobbAvtale();
     private final PdlRespons FØRSTE_PDL_RESPONSE = TestData.enPdlrespons(false);
@@ -91,8 +88,6 @@ public class CachingConfigMockTest {
             Kvalifiseringsgruppe.VARIG_TILPASSET_INNSATS,
             "0904"
     );
-    private final boolean FØRSTE_ABAC_VERDIC_FOR_F142226_07098142678 = true;
-    private final boolean ANDRE_ABAC_VERDIC_FOR_F142226_11111111111 = false;
 
 
     @EnableCaching
@@ -147,7 +142,6 @@ public class CachingConfigMockTest {
         mockPersondataService = AopTestUtils.getTargetObject(persondataService);
         mockNorg2Client = AopTestUtils.getTargetObject(norg2Client);
         mockVeilarbArenaClient = AopTestUtils.getTargetObject(veilarbArenaClient);
-        mockAbacAdapter = AopTestUtils.getTargetObject(abacAdapter);
 
         lenient().when(mockTilgangskontrollService.harSkrivetilgangTilKandidat(
                 any(),
@@ -163,14 +157,6 @@ public class CachingConfigMockTest {
         when(mockVeilarbArenaClient.HentOppfølgingsenhetFraCacheEllerArena(avtale.getDeltakerFnr().asString())).thenReturn(
                 FØRSTE_OPPFØLGNING_ENHET_ARENA,
                 ANDRE_OPPFØLGNING_ENHET_ARENA
-        );
-        when(mockAbacAdapter.harSkriveTilgang("F142226", "07098142678")).thenReturn(
-                FØRSTE_ABAC_VERDIC_FOR_F142226_07098142678,
-                FØRSTE_ABAC_VERDIC_FOR_F142226_07098142678
-        );
-        when(mockAbacAdapter.harSkriveTilgang("F142226", "11111111111")).thenReturn(
-                ANDRE_ABAC_VERDIC_FOR_F142226_11111111111,
-                ANDRE_ABAC_VERDIC_FOR_F142226_11111111111
         );
     }
 
@@ -211,31 +197,6 @@ public class CachingConfigMockTest {
 
         /** Blir kalt 2 ganger. Andre iterasjon så treffer vi cache response istedenfor endepunkt */
         verify(mockNorg2Client, times(1)).hentGeoEnhetFraCacheEllerNorg2(geoEnhet);
-    }
-
-    @Test
-    public void bekreft_antall_ganger_Cacheable_endepunkter_blir_kalt_ved_abac() {
-        NavIdent veilederIdent = new NavIdent("F142226");
-
-        Fnr første_deltakerFnr = new Fnr("07098142678");
-        Fnr andre_deltakerFnr = new Fnr("11111111111");
-
-        boolean tilgang_navId_F142226_og_fnr_07098142678 = abacAdapter.harSkriveTilgang(veilederIdent.asString(), første_deltakerFnr.asString());
-        boolean tilgang_navId_F142226_og_fnr_07098142678_response2 = abacAdapter.harSkriveTilgang(veilederIdent.asString(), første_deltakerFnr.asString());
-
-        verify(mockAbacAdapter, times(1)).harSkriveTilgang(veilederIdent.asString(), første_deltakerFnr.asString());
-
-
-        boolean tilgang_navId_F142226_og_fnr_11111111111 = abacAdapter.harSkriveTilgang(veilederIdent.asString(), andre_deltakerFnr.asString());
-        boolean tilgang_navId_F142226_og_fnr_11111111111_response2 = abacAdapter.harSkriveTilgang(veilederIdent.asString(), andre_deltakerFnr.asString());
-
-       verify(mockAbacAdapter, times(1)).harSkriveTilgang(veilederIdent.asString(), andre_deltakerFnr.asString());
-
-        Assertions.assertEquals(FØRSTE_ABAC_VERDIC_FOR_F142226_07098142678, tilgang_navId_F142226_og_fnr_07098142678);
-        Assertions.assertEquals(FØRSTE_ABAC_VERDIC_FOR_F142226_07098142678, tilgang_navId_F142226_og_fnr_07098142678_response2);
-
-        Assertions.assertEquals(ANDRE_ABAC_VERDIC_FOR_F142226_11111111111, tilgang_navId_F142226_og_fnr_11111111111);
-        Assertions.assertEquals(ANDRE_ABAC_VERDIC_FOR_F142226_11111111111, tilgang_navId_F142226_og_fnr_11111111111_response2);
     }
 
     @Test

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/infrastruktur/caching/CachingConfigTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/infrastruktur/caching/CachingConfigTest.java
@@ -43,20 +43,17 @@ public class CachingConfigTest {
     private final VeilarbArenaClient veilarbArenaClient;
     private final Norg2Client norg2Client;
     private final PersondataService persondataService;
-    private final AbacAdapter abacAdapter;
 
     public CachingConfigTest(
             @Autowired CacheManager cacheManager,
             @Autowired VeilarbArenaClient veilarbArenaClient,
             @Autowired Norg2Client norg2Client,
-            @Autowired PersondataService persondataService,
-            @Autowired AbacAdapter abacAdapter
+            @Autowired PersondataService persondataService
     ){
         this.cacheManager = cacheManager;
         this.veilarbArenaClient = veilarbArenaClient;
         this.norg2Client = norg2Client;
         this.persondataService = persondataService;
-        this.abacAdapter = abacAdapter;
     }
 
     private  <T,K> T getCacheValue(String cacheName, K cacheKey, Class<T> clazz) {
@@ -150,39 +147,6 @@ public class CachingConfigTest {
                 persondataService.hentNavnFraPdlRespons(pdlRespons).getEtternavn(),
                 persondataService.hentNavnFraPdlRespons(pdlCache).getEtternavn()
         );
-    }
-
-    @Test
-    public void sjekk_at_caching_fanger_opp_data_fra_abac_cache() {
-        NavIdent veilederIdent = new NavIdent("F142226");
-        Fnr deltakerFnr = new Fnr("07098142678");
-
-        NavIdent veilederIdent2 = new NavIdent("F142226");
-        Fnr deltakerFnr2 = new Fnr("11111111111");
-
-        Fnr brukerFnr = new Fnr("00000000000");
-
-        boolean tilgang_navId_F142226_og_fnr_07098142678 = abacAdapter.harSkriveTilgang(veilederIdent.asString(), deltakerFnr.asString());
-        boolean tilgang_navId_F142226_og_fnr_11111111111 = abacAdapter.harSkriveTilgang(veilederIdent2.asString(), deltakerFnr2.asString());
-
-        Assertions.assertTrue(getCacheValue(ABAC_CACHE, veilederIdent.asString() + deltakerFnr.asString(), boolean.class));
-        Assertions.assertEquals(
-                tilgang_navId_F142226_og_fnr_07098142678,
-                getCacheValue(ABAC_CACHE, veilederIdent.asString() + deltakerFnr.asString(), boolean.class)
-        );
-        Assertions.assertFalse(getCacheValue(ABAC_CACHE, veilederIdent2.asString() + deltakerFnr2.asString(), boolean.class));
-        Assertions.assertEquals(
-                tilgang_navId_F142226_og_fnr_11111111111,
-                getCacheValue(ABAC_CACHE, veilederIdent2.asString() + deltakerFnr2.asString(), boolean.class)
-        );
-        Assertions.assertNotEquals(
-                getCacheValue(ABAC_CACHE, veilederIdent.asString() + deltakerFnr.asString(), boolean.class),
-                (getCacheValue(ABAC_CACHE, veilederIdent2.asString() + deltakerFnr2.asString(), boolean.class))
-        );
-
-        Assertions.assertThrows(Exception.class, () -> {
-            getCacheValue(ABAC_CACHE, veilederIdent.asString() + brukerFnr.asString(), boolean.class);
-        });
     }
 
     @Test


### PR DESCRIPTION
Dersom kall til abac feiler (feks timeout), vil vi fange opp feilen, logge og deretter lagre at bruker ikke har tilgang i cachen!

Denne endringen sørger for at feil fra Abac fortsatt teller som "ikke tilgang", men vi lagrer kun i cache dersom kallet til abac er vellykket.