### PR TITLE
Prøver unngå split i perioder så mye som mulig ved forlenging av avtaler

### DIFF
--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/Avtale.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/Avtale.java
@@ -829,6 +829,12 @@ public class Avtale extends AbstractAggregateRoot<Avtale> {
                 List<TilskuddPeriode> nyeTilskuddperioder = beregnTilskuddsperioder(sisteTilskuddsperiode.getStartDato(), nySluttDato);
                 fikseLøpenumre(nyeTilskuddperioder, sisteTilskuddsperiode.getLøpenummer());
                 tilskuddPeriode.addAll(nyeTilskuddperioder);
+            } else if (sisteTilskuddsperiode.getStatus() == TilskuddPeriodeStatus.GODKJENT && (!sisteTilskuddsperiode.erRefusjonGodkjent() && !sisteTilskuddsperiode.erUtbetalt())) {
+                annullerTilskuddsperiode(sisteTilskuddsperiode);
+                List<TilskuddPeriode> nyeTilskuddperioder = beregnTilskuddsperioder(sisteTilskuddsperiode.getStartDato(), nySluttDato);
+                fikseLøpenumre(nyeTilskuddperioder, sisteTilskuddsperiode.getLøpenummer() + 1);
+                tilskuddPeriode.addAll(nyeTilskuddperioder);
+                // Tjohoo. Her må vi anullere den siste og lage ny for hele perioden.
             } else {
                 // Regner ut nye perioder fra gammel avtaleslutt til ny avtaleslutt
                 List<TilskuddPeriode> nyeTilskuddperioder = beregnTilskuddsperioder(gammelSluttDato.plusDays(1), nySluttDato);

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/TilskuddPeriode.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/TilskuddPeriode.java
@@ -148,11 +148,11 @@ public class TilskuddPeriode implements Comparable<TilskuddPeriode> {
     }
 
     public boolean erUtbetalt() {
-        return refusjonStatus == RefusjonStatus.UTBETALT;
+        return refusjonStatus == RefusjonStatus.UTBETALT || refusjonStatus == RefusjonStatus.KORRIGERT;
     }
 
     public boolean erRefusjonGodkjent() {
-        return refusjonStatus == RefusjonStatus.SENDT_KRAV;
+        return refusjonStatus == RefusjonStatus.SENDT_KRAV || refusjonStatus == RefusjonStatus.GODKJENT_MINUSBELØP || refusjonStatus == RefusjonStatus.GODKJENT_NULLBELØP;
     }
 
 }

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/LastInnTestData.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/LastInnTestData.java
@@ -46,6 +46,7 @@ public class LastInnTestData implements ApplicationListener<ApplicationReadyEven
         avtaleRepository.save(TestData.enSommerjobbAvtaleGodkjentAvBeslutter());
         avtaleRepository.save(TestData.enSommerjobbAvtaleGodkjentAvArbeidsgiver());
         Now.resetClock();
+        avtaleRepository.save(TestData.enMidlertidigLonnstilskuddAvtaleMedSpesieltTilpassetInnsatsGodkjentAvVeileder());
         avtaleRepository.save(TestData.enMentorAvtaleMedMedAltUtfylt());
         avtaleRepository.save(TestData.enArbeidstreningAvtaleOpprettetAvArbeidsgiverOgErUfordelt());
         avtaleRepository.save(TestData.enArbeidstreningAvtaleOpprettetAvArbeidsgiverOgErUfordeltMedGeografiskEnhet());

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleArenaMigreringTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleArenaMigreringTest.java
@@ -12,7 +12,7 @@ public class AvtaleArenaMigreringTest {
     @Test
     public void lonnstilskudd_tilskuddsperioder_skal_ha_status_ubehandlet_hvis_ikke_ryddeavtale() {
         Now.fixedDate(LocalDate.of(2023, 02, 15));
-        Avtale avtale = TestData.enLønnstilskuddsAvtaleMedStartOgSluttGodkjentAvAlleParter(LocalDate.of(2022, 05, 01), LocalDate.of(2023, 04,30));
+        Avtale avtale = TestData.enMidlertidigLønnstilskuddsAvtaleMedStartOgSluttGodkjentAvAlleParter(LocalDate.of(2022, 05, 01), LocalDate.of(2023, 04,30));
         assertThat(avtale.getTilskuddPeriode()).isNotEmpty();
 
         avtale.getTilskuddPeriode().forEach(tilskuddPeriode -> {
@@ -24,7 +24,7 @@ public class AvtaleArenaMigreringTest {
     @Test
     public void lonnstilskudd_skal_generere_tilskuddsperioder_med_behandlet_status_om_ryddeavtale() {
         Now.fixedDate(LocalDate.of(2023, 02, 15));
-        Avtale avtale = TestData.enLønnstilskuddsRyddeAvtaleMedStartOgSluttGodkjentAvAlleParter(LocalDate.of(2022, 05, 01), LocalDate.of(2023, 04,30));
+        Avtale avtale = TestData.enMidlertidigLønnstilskuddsRyddeAvtaleMedStartOgSluttGodkjentAvAlleParter(LocalDate.of(2022, 05, 01), LocalDate.of(2023, 04,30));
         assertThat(avtale.getTilskuddPeriode()).isNotEmpty();
 
         avtale.getTilskuddPeriode().forEach(tilskuddPeriode -> {

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleRepositoryTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleRepositoryTest.java
@@ -229,10 +229,10 @@ public class AvtaleRepositoryTest {
 
     @Test
     public void finnGodkjenteAvtalerMedTilskuddsperiodestatusOgNavEnheter__skal_ikke_kunne_hente_avtale_med_tiltakstype_arbeidstrening_3() {
-        Avtale avtale = enLønnstilskuddsAvtaleMedStartOgSluttGodkjentAvAlleParter(Now.localDate().plusDays(1), Now.localDate().plusMonths(3).plusDays(1));
-        Avtale avtale2 = enLønnstilskuddsAvtaleMedStartOgSluttGodkjentAvAlleParter(Now.localDate().plusDays(5), Now.localDate().plusMonths(3).plusDays(5));
-        Avtale avtale3 = enLønnstilskuddsAvtaleMedStartOgSluttGodkjentAvAlleParter(Now.localDate().plusDays(10), Now.localDate().plusMonths(3).plusDays(10));
-        Avtale avtale4 = enLønnstilskuddsAvtaleMedStartOgSluttGodkjentAvAlleParter(Now.localDate().plusDays(15), Now.localDate().plusMonths(3).plusDays(15));
+        Avtale avtale = enMidlertidigLønnstilskuddsAvtaleMedStartOgSluttGodkjentAvAlleParter(Now.localDate().plusDays(1), Now.localDate().plusMonths(3).plusDays(1));
+        Avtale avtale2 = enMidlertidigLønnstilskuddsAvtaleMedStartOgSluttGodkjentAvAlleParter(Now.localDate().plusDays(5), Now.localDate().plusMonths(3).plusDays(5));
+        Avtale avtale3 = enMidlertidigLønnstilskuddsAvtaleMedStartOgSluttGodkjentAvAlleParter(Now.localDate().plusDays(10), Now.localDate().plusMonths(3).plusDays(10));
+        Avtale avtale4 = enMidlertidigLønnstilskuddsAvtaleMedStartOgSluttGodkjentAvAlleParter(Now.localDate().plusDays(15), Now.localDate().plusMonths(3).plusDays(15));
         avtale.getGjeldendeInnhold().setDeltakerFornavn("Arne");
         avtale2.getGjeldendeInnhold().setDeltakerFornavn("Bjarne");
         avtale3.getGjeldendeInnhold().setDeltakerFornavn("Carl");

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleTest.java
@@ -869,13 +869,13 @@ public class AvtaleTest {
 
     @Test
     public void forleng_24_mnd_midl_lts() {
-        Avtale avtale = TestData.enLonnstilskuddAvtaleGodkjentAvVeileder();
+        Avtale avtale = TestData.enMidlertidigLonnstilskuddAvtaleMedSpesieltTilpassetInnsatsGodkjentAvVeileder();
         avtale.forlengAvtale(avtale.getGjeldendeInnhold().getStartDato().plusMonths(24).minusDays(1), TestData.enNavIdent());
     }
 
     @Test
     public void forleng_over_24_mnd_midl_lts() {
-        Avtale avtale = TestData.enLonnstilskuddAvtaleGodkjentAvVeileder();
+        Avtale avtale = TestData.enMidlertidigLonnstilskuddAvtaleMedSpesieltTilpassetInnsatsGodkjentAvVeileder();
         assertFeilkode(Feilkode.VARIGHET_FOR_LANG_MIDLERTIDIG_LONNSTILSKUDD_24_MND, () -> avtale.forlengAvtale(avtale.getGjeldendeInnhold().getStartDato().plusMonths(24), TestData.enNavIdent()));
     }
 
@@ -884,7 +884,7 @@ public class AvtaleTest {
         Now.fixedDate(LocalDate.of(2021, 11, 25));
         LocalDate startDato = LocalDate.of(2021, 11, 30);
         LocalDate sluttDato = LocalDate.of(2022, 11, 25);
-        Avtale avtale = TestData.enLønnstilskuddsAvtaleMedStartOgSluttGodkjentAvAlleParter(startDato, sluttDato);
+        Avtale avtale = TestData.enMidlertidigLønnstilskuddsAvtaleMedStartOgSluttGodkjentAvAlleParter(startDato, sluttDato);
         Now.resetClock();
         LocalDate nySluttDato = avtale.getGjeldendeInnhold().getSluttDato().plusMonths(1);
         avtale.forlengAvtale(nySluttDato, TestData.enNavIdent());
@@ -896,7 +896,7 @@ public class AvtaleTest {
         Now.fixedDate(LocalDate.of(2023, 03, 15));
         LocalDate startDato = LocalDate.of(2022, 03, 01);
         LocalDate sluttDato = LocalDate.of(2023, 02, 28);
-        Avtale avtale = TestData.enLønnstilskuddsAvtaleMedStartOgSluttGodkjentAvAlleParter(startDato, sluttDato);
+        Avtale avtale = TestData.enMidlertidigLønnstilskuddsAvtaleMedStartOgSluttGodkjentAvAlleParter(startDato, sluttDato);
         // Alle perioder er godkjent
         avtale.getTilskuddPeriode().forEach(t -> {
             t.godkjenn(TestData.enNavIdent2(), "1234");
@@ -912,7 +912,7 @@ public class AvtaleTest {
         Now.fixedDate(LocalDate.of(2023, 03, 15));
         LocalDate startDato = LocalDate.of(2022, 03, 01);
         LocalDate sluttDato = LocalDate.of(2023, 02, 28);
-        Avtale avtale = TestData.enLønnstilskuddsAvtaleMedStartOgSluttGodkjentAvAlleParter(startDato, sluttDato);
+        Avtale avtale = TestData.enMidlertidigLønnstilskuddsAvtaleMedStartOgSluttGodkjentAvAlleParter(startDato, sluttDato);
         LocalDate nySluttDato = sluttDato.plusMonths(6);
         avtale.forlengAvtale(nySluttDato, TestData.enNavIdent());
         assertThat(avtale.getGjeldendeInnhold().getSluttDato()).isEqualTo(nySluttDato);

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/GjeldendeTilskuddsperiodeTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/GjeldendeTilskuddsperiodeTest.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.Test;
 import java.time.LocalDate;
 import java.util.EnumSet;
 
-import static no.nav.tag.tiltaksgjennomforing.avtale.TestData.enLønnstilskuddsAvtaleMedStartOgSluttGodkjentAvAlleParter;
+import static no.nav.tag.tiltaksgjennomforing.avtale.TestData.enMidlertidigLønnstilskuddsAvtaleMedStartOgSluttGodkjentAvAlleParter;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class GjeldendeTilskuddsperiodeTest {
@@ -50,7 +50,7 @@ public class GjeldendeTilskuddsperiodeTest {
     public void en_periode() {
         LocalDate avtaleStart = Now.localDate();
         LocalDate avtaleSlutt = Now.localDate();
-        Avtale avtale = enLønnstilskuddsAvtaleMedStartOgSluttGodkjentAvAlleParter(avtaleStart, avtaleSlutt);
+        Avtale avtale = enMidlertidigLønnstilskuddsAvtaleMedStartOgSluttGodkjentAvAlleParter(avtaleStart, avtaleSlutt);
         assertThat(avtale.tilskuddsperiode(0)).isEqualTo(avtale.gjeldendeTilskuddsperiode());
     }
 
@@ -59,7 +59,7 @@ public class GjeldendeTilskuddsperiodeTest {
     public void frem_i_tid() {
         LocalDate avtaleStart = Now.localDate().plusDays(15);
         LocalDate avtaleSlutt = Now.localDate().plusMonths(8);
-        Avtale avtale = enLønnstilskuddsAvtaleMedStartOgSluttGodkjentAvAlleParter(avtaleStart, avtaleSlutt);
+        Avtale avtale = enMidlertidigLønnstilskuddsAvtaleMedStartOgSluttGodkjentAvAlleParter(avtaleStart, avtaleSlutt);
         assertThat(avtale.tilskuddsperiode(0)).isEqualTo(avtale.gjeldendeTilskuddsperiode());
     }
 
@@ -82,7 +82,7 @@ public class GjeldendeTilskuddsperiodeTest {
     public void første_avslått__neste_kan_ikke_behandles() {
         LocalDate avtaleStart = Now.localDate();
         LocalDate avtaleSlutt = Now.localDate().plusMonths(8);
-        Avtale avtale = enLønnstilskuddsAvtaleMedStartOgSluttGodkjentAvAlleParter(avtaleStart, avtaleSlutt);
+        Avtale avtale = enMidlertidigLønnstilskuddsAvtaleMedStartOgSluttGodkjentAvAlleParter(avtaleStart, avtaleSlutt);
         avtale.avslåTilskuddsperiode(TestData.enNavIdent2(), EnumSet.of(Avslagsårsak.ANNET), "Forklaring");
         assertThat(avtale.tilskuddsperiode(0)).isEqualTo(avtale.gjeldendeTilskuddsperiode());
     }
@@ -94,7 +94,7 @@ public class GjeldendeTilskuddsperiodeTest {
         Now.fixedDate(LocalDate.of(2021, 11, 30));
         LocalDate avtaleStart = Now.localDate();
         LocalDate avtaleSlutt = Now.localDate().plusMonths(6);
-        Avtale avtale = enLønnstilskuddsAvtaleMedStartOgSluttGodkjentAvAlleParter(avtaleStart, avtaleSlutt);
+        Avtale avtale = enMidlertidigLønnstilskuddsAvtaleMedStartOgSluttGodkjentAvAlleParter(avtaleStart, avtaleSlutt);
         assertThat(avtale.gjeldendeTilskuddsperiode().getStartDato()).isEqualTo(avtaleStart);
         avtale.godkjennTilskuddsperiode(TestData.enNavIdent2(), avtale.getEnhetGeografisk());
         assertThat(avtale.gjeldendeTilskuddsperiode().getStartDato()).isEqualTo(avtaleStart);
@@ -107,7 +107,7 @@ public class GjeldendeTilskuddsperiodeTest {
         Now.fixedDate(LocalDate.of(2021, 11, 30));
         LocalDate avtaleStart = Now.localDate();
         LocalDate avtaleSlutt = Now.localDate().plusMonths(6);
-        Avtale avtale = enLønnstilskuddsAvtaleMedStartOgSluttGodkjentAvAlleParter(avtaleStart, avtaleSlutt);
+        Avtale avtale = enMidlertidigLønnstilskuddsAvtaleMedStartOgSluttGodkjentAvAlleParter(avtaleStart, avtaleSlutt);
 
         assertThat(avtale.gjeldendeTilskuddsperiode().getStartDato()).isEqualTo(avtaleStart);
         avtale.godkjennTilskuddsperiode(TestData.enNavIdent2(), avtale.getEnhetGeografisk());

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/RegnUtTilskuddsperioderForAvtaleTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/RegnUtTilskuddsperioderForAvtaleTest.java
@@ -355,7 +355,7 @@ public class RegnUtTilskuddsperioderForAvtaleTest {
     @Test
     public void sjekk_at_nye_perioder_ved_forlengelse_starter_etter_utbetalte_perioder() {
         Now.fixedDate(LocalDate.of(2021, 1, 1));
-        Avtale avtale = TestData.enLønnstilskuddsAvtaleMedStartOgSluttGodkjentAvAlleParter(LocalDate.of(2021, 1, 1), LocalDate.of(2021, 4, 1));
+        Avtale avtale = TestData.enMidlertidigLønnstilskuddsAvtaleMedStartOgSluttGodkjentAvAlleParter(LocalDate.of(2021, 1, 1), LocalDate.of(2021, 4, 1));
 
         avtale.tilskuddsperiode(0).setRefusjonStatus(RefusjonStatus.UTBETALT);
         avtale.tilskuddsperiode(1).setRefusjonStatus(RefusjonStatus.UTBETALT);
@@ -370,19 +370,6 @@ public class RegnUtTilskuddsperioderForAvtaleTest {
 
         harRiktigeEgenskaper(avtale);
         Now.resetClock();
-    }
-
-    @Test
-    public void sjekk_at_godkjent_perioder_beholdes_ved_endring_som_ikke_påvirker_økonomi() {
-        Avtale avtale = TestData.enLonnstilskuddAvtaleGodkjentAvVeileder();
-        avtale.tilskuddsperiode(0).setStatus(TilskuddPeriodeStatus.GODKJENT);
-        UUID idPåGodkjentTilskuddsperiode = avtale.tilskuddsperiode(0).getId();
-
-        avtale.forlengAvtale(avtale.getGjeldendeInnhold().getSluttDato().plusDays(1), TestData.enNavIdent());
-
-        assertThat(avtale.tilskuddsperiode(0).getStatus()).isEqualTo(TilskuddPeriodeStatus.GODKJENT);
-        assertThat(avtale.tilskuddsperiode(0).getId()).isEqualTo(idPåGodkjentTilskuddsperiode);
-        harRiktigeEgenskaper(avtale);
     }
 
     @Test
@@ -427,23 +414,23 @@ public class RegnUtTilskuddsperioderForAvtaleTest {
     }
 
     @Test
-    public void sjekk_at_godkjent_periode_ikke_annulleres_ved_forlengelse() {
+    public void sjekk_at_godkjent_periode_annulleres_ved_forlengelse() {
         Now.fixedDate(LocalDate.of(2021, 1, 1));
         LocalDate avtaleFørsteDag = LocalDate.of(2021, 1, 1);
-        Avtale avtale = TestData.enLønnstilskuddsAvtaleMedStartOgSluttGodkjentAvAlleParter(avtaleFørsteDag, avtaleFørsteDag);
+        Avtale avtale = TestData.enMidlertidigLønnstilskuddsAvtaleMedStartOgSluttGodkjentAvAlleParter(avtaleFørsteDag, avtaleFørsteDag);
 
         avtale.tilskuddsperiode(0).setStatus(TilskuddPeriodeStatus.GODKJENT);
         UUID idPåGodkjentTilskuddsperiode = avtale.tilskuddsperiode(0).getId();
 
         avtale.forlengAvtale(avtaleFørsteDag.plusDays(1), TestData.enNavIdent());
 
-        assertThat(avtale.tilskuddsperiode(0).getStatus()).isEqualTo(TilskuddPeriodeStatus.GODKJENT);
+        assertThat(avtale.tilskuddsperiode(0).getStatus()).isEqualTo(TilskuddPeriodeStatus.ANNULLERT);
         assertThat(avtale.tilskuddsperiode(0).getId()).isEqualTo(idPåGodkjentTilskuddsperiode);
         assertThat(avtale.tilskuddsperiode(0).getStartDato()).isEqualTo(avtaleFørsteDag);
         assertThat(avtale.tilskuddsperiode(0).getSluttDato()).isEqualTo(avtaleFørsteDag);
 
         assertThat(avtale.tilskuddsperiode(1).getStatus()).isEqualTo(TilskuddPeriodeStatus.UBEHANDLET);
-        assertThat(avtale.tilskuddsperiode(1).getStartDato()).isEqualTo(avtaleFørsteDag.plusDays(1));
+        assertThat(avtale.tilskuddsperiode(1).getStartDato()).isEqualTo(avtaleFørsteDag);
         assertThat(avtale.tilskuddsperiode(1).getSluttDato()).isEqualTo(avtaleFørsteDag.plusDays(1));
 
         harRiktigeEgenskaper(avtale);
@@ -455,7 +442,7 @@ public class RegnUtTilskuddsperioderForAvtaleTest {
         Now.fixedDate(LocalDate.of(2020, 6, 28));
         LocalDate avtaleStart = LocalDate.of(2021, 1, 1);
         LocalDate avtaleSlutt = LocalDate.of(2021, 8, 1);
-        Avtale avtale = TestData.enLønnstilskuddsAvtaleMedStartOgSluttGodkjentAvAlleParter(avtaleStart, avtaleSlutt);
+        Avtale avtale = TestData.enMidlertidigLønnstilskuddsAvtaleMedStartOgSluttGodkjentAvAlleParter(avtaleStart, avtaleSlutt);
 
 
         avtale.tilskuddsperiode(0).setStatus(TilskuddPeriodeStatus.GODKJENT);
@@ -487,7 +474,7 @@ public class RegnUtTilskuddsperioderForAvtaleTest {
         Now.fixedDate(LocalDate.of(2021, 1, 01));
         LocalDate avtaleStart = LocalDate.of(2021, 1, 1);
         LocalDate avtaleSlutt = LocalDate.of(2021, 6, 2);
-        Avtale avtale = TestData.enLønnstilskuddsAvtaleMedStartOgSluttGodkjentAvAlleParter(avtaleStart, avtaleSlutt);
+        Avtale avtale = TestData.enMidlertidigLønnstilskuddsAvtaleMedStartOgSluttGodkjentAvAlleParter(avtaleStart, avtaleSlutt);
 
         avtale.getTilskuddPeriode().forEach(tilskuddPeriode -> {
             LocalDate fra = tilskuddPeriode.getStartDato();
@@ -507,7 +494,7 @@ public class RegnUtTilskuddsperioderForAvtaleTest {
         Now.fixedDate(LocalDate.of(2021, 1, 1));
         LocalDate avtaleStart = LocalDate.of(2021, 1, 20);
         LocalDate avtaleSlutt = LocalDate.of(2022, 3, 2);
-        Avtale avtale = TestData.enLønnstilskuddsAvtaleMedStartOgSluttGodkjentAvAlleParter(avtaleStart, avtaleSlutt);
+        Avtale avtale = TestData.enMidlertidigLønnstilskuddsAvtaleMedStartOgSluttGodkjentAvAlleParter(avtaleStart, avtaleSlutt);
 
         avtale.getTilskuddPeriode().forEach(tilskuddPeriode -> {
             // start- og sluttdato er alltid i samme måned
@@ -555,7 +542,7 @@ public class RegnUtTilskuddsperioderForAvtaleTest {
 
     private void harRiktigeLøpenumre(Collection<TilskuddPeriode> tilskuddPerioder) {
         int løpenummer = 1;
-        for (TilskuddPeriode tilskuddPeriode : tilskuddPerioder.stream().filter(tp -> tp.getStatus() != TilskuddPeriodeStatus.ANNULLERT).collect(Collectors.toList())) {
+        for (TilskuddPeriode tilskuddPeriode : tilskuddPerioder) {
             assertThat(tilskuddPeriode.getLøpenummer()).isEqualTo(løpenummer++);
         }
     }

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/TestData.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/TestData.java
@@ -173,29 +173,7 @@ public class TestData {
         return avtale;
     }
 
-    public static Avtale enLønnstilskuddsAvtaleMedStartOgSlutt(LocalDate startDato, LocalDate sluttDato) {
-        Avtale avtale = TestData.enMidlertidigLonnstilskuddAvtaleMedAltUtfylt();
-        setOppfølgingOgGeografiskPåAvtale(avtale);
-        EndreAvtale endring = TestData.endringPåAlleLønnstilskuddFelter();
-        endring.setStartDato(startDato);
-        endring.setSluttDato(sluttDato);
-        avtale.endreAvtale(Now.instant(), endring, Avtalerolle.VEILEDER, avtalerMedTilskuddsperioder);
-        return avtale;
-    }
-
-    public static Avtale enLønnstilskuddsAvtaleMedStartOgSluttEtterregistrering(LocalDate startDato, LocalDate sluttDato) {
-        Avtale avtale = TestData.enMidlertidigLonnstilskuddAvtaleMedAltUtfylt();
-        setOppfølgingOgGeografiskPåAvtale(avtale);
-        avtale.setKvalifiseringsgruppe(Kvalifiseringsgruppe.VARIG_TILPASSET_INNSATS);
-        EndreAvtale endring = TestData.endringPåAlleLønnstilskuddFelter();
-        avtale.setGodkjentForEtterregistrering(true);
-        endring.setStartDato(startDato);
-        endring.setSluttDato(sluttDato);
-        avtale.endreAvtale(Now.instant(), endring, Avtalerolle.VEILEDER, avtalerMedTilskuddsperioder);
-        return avtale;
-    }
-
-    public static Avtale enLønnstilskuddsAvtaleMedStartOgSluttGodkjentAvAlleParter(LocalDate startDato, LocalDate sluttDato) {
+    public static Avtale enMidlertidigLønnstilskuddsAvtaleMedStartOgSluttGodkjentAvAlleParter(LocalDate startDato, LocalDate sluttDato) {
         Avtale avtale = TestData.enMidlertidigLonnstilskuddAvtaleMedAltUtfylt();
         setOppfølgingOgGeografiskPåAvtale(avtale);
         avtale.setKvalifiseringsgruppe(Kvalifiseringsgruppe.VARIG_TILPASSET_INNSATS);
@@ -210,7 +188,7 @@ public class TestData {
         return avtale;
     }
 
-    public static Avtale enLønnstilskuddsRyddeAvtaleMedStartOgSluttGodkjentAvAlleParter(LocalDate startDato, LocalDate sluttDato) {
+    public static Avtale enMidlertidigLønnstilskuddsRyddeAvtaleMedStartOgSluttGodkjentAvAlleParter(LocalDate startDato, LocalDate sluttDato) {
         Avtale avtale = TestData.enMidlertidigLonnstilskuddAvtaleMedAltUtfylt();
         avtale.setArenaRyddeAvtale(new ArenaRyddeAvtale());
         setOppfølgingOgGeografiskPåAvtale(avtale);
@@ -263,7 +241,6 @@ public class TestData {
         avtale.getGjeldendeInnhold().setDeltakerFornavn("Lilly");
         avtale.getGjeldendeInnhold().setDeltakerEtternavn("Lønning");
         avtale.getGjeldendeInnhold().setArbeidsgiverKontonummer("22222222222");
-        avtale.getGjeldendeInnhold().setLonnstilskuddProsent(60);
         avtale.getGjeldendeInnhold().setManedslonn(20000);
         avtale.getGjeldendeInnhold().setFeriepengesats(BigDecimal.valueOf(0.12));
         avtale.getGjeldendeInnhold().setArbeidsgiveravgift(BigDecimal.valueOf(0.141));
@@ -273,9 +250,40 @@ public class TestData {
         return avtale;
     }
 
+    public static Avtale enMidlertidigLonnstilskuddAvtaleMedSpesieltTilpassetInnsatsOgAltUtfylt(Tiltakstype tiltakstype) {
+        NavIdent veilderNavIdent = new NavIdent("Z123456");
+        Avtale avtale = Avtale.veilederOppretterAvtale(lagOpprettAvtale(tiltakstype), veilderNavIdent);
+        setOppfølgingPåAvtale(avtale);
+        avtale.setKvalifiseringsgruppe(Kvalifiseringsgruppe.SPESIELT_TILPASSET_INNSATS);
+        avtale.endreAvtale(avtale.getSistEndret(), endringPåAlleLønnstilskuddFelter(), Avtalerolle.VEILEDER, EnumSet.of(avtale.getTiltakstype()));
+        avtale.setTiltakstype(tiltakstype);
+        avtale.getGjeldendeInnhold().setDeltakerFornavn("Lilly");
+        avtale.getGjeldendeInnhold().setDeltakerEtternavn("Lønning");
+        avtale.getGjeldendeInnhold().setArbeidsgiverKontonummer("22222222222");
+        avtale.getGjeldendeInnhold().setManedslonn(20000);
+        avtale.getGjeldendeInnhold().setFeriepengesats(BigDecimal.valueOf(0.12));
+        avtale.getGjeldendeInnhold().setArbeidsgiveravgift(BigDecimal.valueOf(0.141));
+        avtale.getGjeldendeInnhold().setVersjon(1);
+        avtale.getGjeldendeInnhold().setJournalpostId(null);
+        avtale.getGjeldendeInnhold().setMaal(List.of());
+        return avtale;
+    }
+
+
     public static Avtale enLonnstilskuddAvtaleGodkjentAvVeileder() {
         Avtale avtale = enMidlertidigLonnstilskuddAvtaleMedAltUtfylt();
-        avtale.setKvalifiseringsgruppe(Kvalifiseringsgruppe.VARIG_TILPASSET_INNSATS);
+        avtale.getGjeldendeInnhold().setGodkjentAvArbeidsgiver(Now.localDateTime());
+        avtale.getGjeldendeInnhold().setGodkjentAvDeltaker(Now.localDateTime());
+        avtale.getGjeldendeInnhold().setGodkjentAvVeileder(Now.localDateTime());
+        avtale.getGjeldendeInnhold().setAvtaleInngått(Now.localDateTime());
+        avtale.getGjeldendeInnhold().setGodkjentAvNavIdent(TestData.enNavIdent());
+        avtale.getGjeldendeInnhold().setIkrafttredelsestidspunkt(Now.localDateTime());
+        avtale.getGjeldendeInnhold().setJournalpostId("1");
+        return avtale;
+    }
+
+    public static Avtale enMidlertidigLonnstilskuddAvtaleMedSpesieltTilpassetInnsatsGodkjentAvVeileder() {
+        Avtale avtale = enMidlertidigLonnstilskuddAvtaleMedSpesieltTilpassetInnsatsOgAltUtfylt(Tiltakstype.MIDLERTIDIG_LONNSTILSKUDD);
         avtale.getGjeldendeInnhold().setGodkjentAvArbeidsgiver(Now.localDateTime());
         avtale.getGjeldendeInnhold().setGodkjentAvDeltaker(Now.localDateTime());
         avtale.getGjeldendeInnhold().setGodkjentAvVeileder(Now.localDateTime());

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/journalfoering/InternalAvtaleControllerTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/journalfoering/InternalAvtaleControllerTest.java
@@ -110,7 +110,7 @@ public class InternalAvtaleControllerTest {
     }
 
     private static List<Avtale> enAvtaleMedTilskudsPerioderSomSkalJournalføres() {
-        Avtale avtale4 = TestData.enLønnstilskuddsAvtaleMedStartOgSluttGodkjentAvAlleParter(Now.localDate(), Now.localDate());
+        Avtale avtale4 = TestData.enMidlertidigLønnstilskuddsAvtaleMedStartOgSluttGodkjentAvAlleParter(Now.localDate(), Now.localDate());
         avtale4.getGjeldendeInnhold().setGodkjentAvVeileder(Now.localDateTime());
         avtale4.setId(AVTALE_ID_3);
         return Arrays.asList(avtale4);

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/tilskuddsperiode/TilskuddsperiodeResendingTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/tilskuddsperiode/TilskuddsperiodeResendingTest.java
@@ -57,7 +57,7 @@ public class TilskuddsperiodeResendingTest {
         Now.fixedDate(LocalDate.of(2023, 03, 1));
         LocalDate avtaleStart = LocalDate.of(2022, 10, 20);
         LocalDate avtaleSlutt = LocalDate.of(2024, 3, 2);
-        Avtale avtale = TestData.enLønnstilskuddsAvtaleMedStartOgSluttGodkjentAvAlleParter(avtaleStart, avtaleSlutt);
+        Avtale avtale = TestData.enMidlertidigLønnstilskuddsAvtaleMedStartOgSluttGodkjentAvAlleParter(avtaleStart, avtaleSlutt);
         // Godkjenner første gang. Denne skal ikke ha noen resendingsnummer
         avtale.godkjennTilskuddsperiode(TestData.enNavIdent2(), "4321");
         avtale.nyeTilskuddsperioderEtterMigreringFraArena(LocalDate.of(2022, 10, 20), false);


### PR DESCRIPTION
Ved forlengelse prøver vi nå å få en periode for å unngå split. Er perioden godkjent av beslutter men ikke sendt inn av arbeidsgiver så blir det annullert sånn at det kan lages en periode for hele måneden.

Har og oppdatert noe i testdata for å få reelle prosentsatser i tilskuddsperioder i testdatan.