### PR TITLE
Skjuler data i listevisning lenger ut i stakken. I dto til frontend

### DIFF
--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/Arbeidsgiver.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/Arbeidsgiver.java
@@ -176,9 +176,12 @@ public class Arbeidsgiver extends Avtalepart<Fnr> {
                 avtaler = Page.empty();
             }
         }
-        return avtaler
-                .map(Arbeidsgiver::fjernAvbruttGrunn)
-                .map(Arbeidsgiver::fjernAnnullertGrunn);
+        return avtaler;
+    }
+
+    @Override
+    AvtaleMinimalListevisning skjulData(AvtaleMinimalListevisning avtaleMinimalListevisning) {
+        return avtaleMinimalListevisning;
     }
 
     public List<Avtale> hentAvtalerForMinsideArbeidsgiver(AvtaleRepository avtaleRepository, BedriftNr bedriftNr) {
@@ -234,6 +237,5 @@ public class Arbeidsgiver extends Avtalepart<Fnr> {
         fjernKvalifiseringsgruppe(avtale);
         return avtale;
     }
-
 
 }

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleController.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleController.java
@@ -128,9 +128,6 @@ public class AvtaleController {
             @RequestParam(value = "page", required = false, defaultValue = "0") Integer page,
             @RequestParam(value = "size", required = false, defaultValue = "10") Integer size
     ) {
-        log.error("Kalte ny endepunkt for søk (get)");
-        throw new NotImplementedException("Ikke ferdig enda");
-        /*
         Avtalepart avtalepart = innloggingService.hentAvtalepart(innloggetPart);
 
         FilterSok filterSok = filterSokRepository.findFilterSokBySokId(filterSokId).orElse(null);
@@ -166,7 +163,6 @@ public class AvtaleController {
                     entry("sokId", "")
             );
         }
-        */
     }
 
     @ApiBeskrivelse("Hent liste over avtaler om arbeidsmarkedstiltak")
@@ -179,9 +175,7 @@ public class AvtaleController {
             @RequestParam(value = "page", required = false, defaultValue = "0") Integer page,
             @RequestParam(value = "size", required = false, defaultValue = "10") Integer size
     ) {
-        log.error("Kalte ny endepunkt for søk (post)");
-        throw new NotImplementedException("Ikke ferdig enda");
-        /*Avtalepart avtalepart = innloggingService.hentAvtalepart(innloggetPart);
+        Avtalepart avtalepart = innloggingService.hentAvtalepart(innloggetPart);
         Pageable pageable = PageRequest.of(Math.abs(page), Math.abs(size), Sort.by(getSortingOrderForPageable(sorteringskolonne)));
         Map<String, Object> avtaler = avtalepart.hentAlleAvtalerMedLesetilgang(
                 avtaleRepository,
@@ -209,7 +203,7 @@ public class AvtaleController {
             filterSokRepository.save(filterSok);
             stringObjectHashMap.put("sokId", filterSok.getSokId());
         }
-        return stringObjectHashMap;*/
+        return stringObjectHashMap;
     }
 
     @ApiBeskrivelse("Hent liste over avtaler om arbeidsmarkedstiltak")

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/Avtalepart.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/Avtalepart.java
@@ -36,6 +36,8 @@ public abstract class Avtalepart<T extends Identifikator> {
 
     abstract Page<Avtale> hentAlleAvtalerMedMuligTilgang(AvtaleRepository avtaleRepository, AvtalePredicate queryParametre, Pageable pageable);
 
+    abstract AvtaleMinimalListevisning skjulData(AvtaleMinimalListevisning avtaleMinimalListevisning);
+
     public Map<String, Object> hentAlleAvtalerMedLesetilgang(AvtaleRepository avtaleRepository, AvtalePredicate queryParametre, String sorteringskolonne, Pageable pageable) {
         Page<Avtale> avtaler = hentAlleAvtalerMedMuligTilgang(avtaleRepository, queryParametre, pageable);
 
@@ -45,6 +47,10 @@ public abstract class Avtalepart<T extends Identifikator> {
                 .toList();
 
         List<AvtaleMinimalListevisning> listMinimal = avtalerMedTilgang.stream().map(AvtaleMinimalListevisning::fromAvtale).toList();
+
+        // Fjern data her og ikke i entity
+        listMinimal = listMinimal.stream().map(avtaleMinimal -> skjulData(avtaleMinimal)).toList();
+
 
         return Map.ofEntries(
                 entry("avtaler", listMinimal),

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/Beslutter.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/Beslutter.java
@@ -75,6 +75,11 @@ public class Beslutter extends Avtalepart<NavIdent> implements InternBruker {
         return avtaleRepository.findAllByAvtaleNr(queryParametre.getAvtaleNr(), pageable);
     }
 
+    @Override
+    AvtaleMinimalListevisning skjulData(AvtaleMinimalListevisning avtaleMinimalListevisning) {
+        return avtaleMinimalListevisning;
+    }
+
     private Integer getPlussdato() {
         return ((int) ChronoUnit.DAYS.between(LocalDate.now(), LocalDate.now().plusMonths(3)));
     }

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/Deltaker.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/Deltaker.java
@@ -27,10 +27,13 @@ public class Deltaker extends Avtalepart<Fnr> {
 
     @Override
     Page<Avtale> hentAlleAvtalerMedMuligTilgang(AvtaleRepository avtaleRepository, AvtalePredicate queryParametre, Pageable pageable) {
-
         Page<Avtale> avtaler = avtaleRepository.findAllByDeltakerFnr(getIdentifikator(), pageable);
-        Page<Avtale> filtrereAvtalerKanske = avtaler.map(this::skjulMentorFødselsnummer);
-        return filtrereAvtalerKanske;
+        return avtaler;
+    }
+
+    @Override
+    AvtaleMinimalListevisning skjulData(AvtaleMinimalListevisning avtaleMinimalListevisning) {
+        return avtaleMinimalListevisning;
     }
 
     private Avtale skjulMentorFødselsnummer(Avtale avtale){

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/Mentor.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/Mentor.java
@@ -38,19 +38,7 @@ public class Mentor extends Avtalepart<Fnr> {
         avtaleMinimalListevisning.setDeltakerFnr(null);
         return avtaleMinimalListevisning;
     }
-
-    private Avtale gjemInnholdOmMentorIkkeHarSignertErklæring(Avtale avtale){
-        if(!avtale.erGodkjentTaushetserklæringAvMentor()) {
-            AvtaleInnhold innhold = AvtaleInnhold.nyttTomtInnhold(avtale.getTiltakstype());
-            innhold.setBedriftNavn(avtale.getGjeldendeInnhold().getBedriftNavn());
-            innhold.setAvtale(avtale);
-            avtale.setGjeldendeInnhold(innhold);
-            avtale.setDeltakerFnr(null);
-            avtale.setVeilederNavIdent(null);
-        }
-        return avtale;
-    }
-
+    
     @Override
     public void godkjennForAvtalepart(Avtale avtale) {
         avtale.godkjennForMentor(getIdentifikator());

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/Mentor.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/Mentor.java
@@ -30,10 +30,13 @@ public class Mentor extends Avtalepart<Fnr> {
     @Override
     Page<Avtale> hentAlleAvtalerMedMuligTilgang(AvtaleRepository avtaleRepository, AvtalePredicate queryParametre, Pageable pageable) {
         Page<Avtale> avtaler = avtaleRepository.findAllByMentorFnr(getIdentifikator(), pageable);
-        Page<Avtale> avtalerMedMuligTilgang = avtaler
-                .map(this::gjemInnholdOmMentorIkkeHarSignertErklæring)
-                .map(this::skjulDeltakerFødselsnummer);
-        return avtalerMedMuligTilgang;
+        return avtaler;
+    }
+
+    @Override
+    AvtaleMinimalListevisning skjulData(AvtaleMinimalListevisning avtaleMinimalListevisning) {
+        avtaleMinimalListevisning.setDeltakerFnr(null);
+        return avtaleMinimalListevisning;
     }
 
     private Avtale gjemInnholdOmMentorIkkeHarSignertErklæring(Avtale avtale){

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/Veileder.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/Veileder.java
@@ -168,6 +168,11 @@ public class Veileder extends Avtalepart<NavIdent> implements InternBruker {
         }
     }
 
+    @Override
+    AvtaleMinimalListevisning skjulData(AvtaleMinimalListevisning avtaleMinimalListevisning) {
+        return avtaleMinimalListevisning;
+    }
+
     public void annullerAvtale(Instant sistEndret, String annullerGrunn, Avtale avtale) {
         avtale.sjekkSistEndret(sistEndret);
         avtale.annuller(this, annullerGrunn);

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/DeltakerTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/DeltakerTest.java
@@ -12,6 +12,7 @@ import org.springframework.data.domain.Pageable;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import static no.nav.tag.tiltaksgjennomforing.AssertFeilkode.assertFeilkode;
@@ -30,19 +31,6 @@ public class DeltakerTest {
         Avtale avtale = TestData.enAvtaleMedAltUtfylt();
         Deltaker deltaker = TestData.enDeltaker(avtale);
         assertThatThrownBy(() -> deltaker.opphevGodkjenninger(avtale)).isInstanceOf(KanIkkeOppheveException.class);
-    }
-
-    @Test
-    public void mentor_Avtaler__skjul_mentor_fnr_for_deltaker() {
-        Pageable pageable = PageRequest.of(0, 100);
-        Avtale avtale = TestData.enMentorAvtaleSignert();
-        Deltaker deltaker = TestData.enDeltaker(avtale);
-        AvtalePredicate avtalePredicate = new AvtalePredicate();
-        when(avtaleRepository.findAllByDeltakerFnr(any(), eq(pageable))).thenReturn(new PageImpl<Avtale>(List.of(avtale)));
-        Page<Avtale> avtaler = deltaker.hentAlleAvtalerMedMuligTilgang(avtaleRepository, avtalePredicate, pageable);
-        assertThat(avtaler.getContent().get(0).getMentorFnr()).isNull();
-        assertThat(avtaler.getContent().get(0).getGjeldendeInnhold().getMentorTimelonn()).isNull();
-
     }
 
     @Test

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/MentorTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/MentorTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.when;
 
 import java.time.Instant;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import no.nav.tag.tiltaksgjennomforing.exceptions.Feilkode;
@@ -36,13 +37,11 @@ public class MentorTest {
 
         // NÅR
         when(avtaleRepository.findAllByMentorFnr(any(), eq(pageable))).thenReturn(new PageImpl<Avtale>(List.of(avtaleUsignert, avtaleSignert)));
-        Page<Avtale> avtaler = mentor.hentAlleAvtalerMedMuligTilgang(avtaleRepository, avtalePredicate, pageable);
-
-        assertThat(avtaler.getTotalElements()).isEqualTo(2);
-        assertThat(avtaler.getContent().get(0)).isEqualTo(avtaleUsignert);
-        assertThat(avtaler.getContent().get(1)).isEqualTo(avtaleSignert);
-        assertThat(avtaler.getContent().get(0).getDeltakerFnr()).isNull();
-        assertThat(avtaler.getContent().get(1).getDeltakerFnr()).isNull();
+        Map<String, Object> avtalerMinimalPage = mentor.hentAlleAvtalerMedLesetilgang(avtaleRepository, avtalePredicate, null, pageable);
+        List<AvtaleMinimalListevisning> avtalerMinimal = (List<AvtaleMinimalListevisning>) avtalerMinimalPage.get("avtaler");
+        assertThat(avtalerMinimal.size()).isEqualTo(2);
+        assertThat(avtalerMinimal.get(0).getDeltakerFnr()).isNull();
+        assertThat(avtalerMinimal.get(1).getDeltakerFnr()).isNull();
      }
 
     @Test
@@ -89,16 +88,12 @@ public class MentorTest {
         AvtalePredicate avtalePredicate = new AvtalePredicate();
         // NÅR
         when(avtaleRepository.findAllByMentorFnr(any(), eq(pageable))).thenReturn(new PageImpl<Avtale>(List.of(avtale)));
-        Page<Avtale> avtaler = mentor.hentAlleAvtalerMedMuligTilgang(avtaleRepository, avtalePredicate, pageable);
+        Map<String, Object> avtalerMinimalPage = mentor.hentAlleAvtalerMedLesetilgang(avtaleRepository, avtalePredicate, null, pageable);
+        List<AvtaleMinimalListevisning> avtalerMinimal = (List<AvtaleMinimalListevisning>) avtalerMinimalPage.get("avtaler");
 
-        assertThat(avtaler).isNotEmpty();
-        assertThat(avtaler.getContent().get(0).getDeltakerFnr()).isNull();
-        assertThat(avtaler.getContent().get(0).getVeilederNavIdent()).isNull();
-        assertThat(avtaler.getContent().get(0).getGjeldendeInnhold().getDeltakerFornavn()).isNull();
-        assertThat(avtaler.getContent().get(0).getGjeldendeInnhold().getDeltakerEtternavn()).isNull();
-        assertThat(avtaler.getContent().get(0).getGjeldendeInnhold().getVeilederTlf()).isNull();
-        assertThat(avtaler.getContent().get(0).getGjeldendeInnhold().getArbeidsgiverKontonummer()).isNull();
-        assertThat(avtaler.getContent().get(0).getBedriftNr()).isNotNull();
+        assertThat(avtalerMinimal).isNotEmpty();
+        assertThat(avtalerMinimal.get(0).getDeltakerFnr()).isNull();
+        assertThat(avtalerMinimal.get(0).getBedriftNavn()).isNotNull();
     }
 
     @Test


### PR DESCRIPTION
Tidligere "skjulte" vi data i listevisning (søk) ved å sette data i Entities til "null". Dette hade noen uventede side effects. Som at data ble slettet fra databasen.

Skjuler nå data i "DTO" som brukes til frontend.