### PR TITLE
Sortering på lavest og høyest på sorteringKolonne

### DIFF
--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleController.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleController.java
@@ -53,7 +53,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 import static java.util.Map.entry;
-import static no.nav.tag.tiltaksgjennomforing.avtale.AvtaleSorterer.getSortingOrderForPageable;
+import static no.nav.tag.tiltaksgjennomforing.avtale.AvtaleSorterer.getSortingOrderForPageableVeileder;
 import static no.nav.tag.tiltaksgjennomforing.utils.Utils.lagUri;
 
 @Protected
@@ -155,7 +155,7 @@ public class AvtaleController {
             @RequestParam(value = "size", required = false, defaultValue = "10") Integer size
     ) {
         Avtalepart avtalepart = innloggingService.hentAvtalepart(innloggetPart);
-        Pageable pageable = PageRequest.of(Math.abs(page), Math.abs(size), Sort.by(getSortingOrderForPageable(sorteringskolonne)));
+        Pageable pageable = PageRequest.of(Math.abs(page), Math.abs(size), Sort.by(getSortingOrderForPageableVeileder(sorteringskolonne)));
         Map<String, Object> avtaler = avtalepart.hentAlleAvtalerMedLesetilgang(
                 avtaleRepository,
                 queryParametre,
@@ -174,7 +174,8 @@ public class AvtaleController {
             @CookieValue("innlogget-part") Avtalerolle innloggetPart,
             @RequestParam(value = "sorteringskolonne", required = false, defaultValue = Avtale.Fields.sistEndret) String sorteringskolonne,
             @RequestParam(value = "page", required = false, defaultValue = "0") Integer page,
-            @RequestParam(value = "size", required = false, defaultValue = "10") Integer size
+            @RequestParam(value = "size", required = false, defaultValue = "10") Integer size,
+            @RequestParam(value = "sorteringOrder", required = false, defaultValue = "ASC") String sorteringOrder
     ) {
         Avtalepart avtalepart = innloggingService.hentAvtalepart(innloggetPart);
 
@@ -185,7 +186,11 @@ public class AvtaleController {
             filterSokRepository.save(filterSok);
             AvtalePredicate avtalePredicate = filterSok.getAvtalePredicate();
 
-            Pageable pageable = PageRequest.of(Math.abs(page), Math.abs(size), Sort.by(getSortingOrderForPageable(sorteringskolonne)));
+            Pageable pageable = PageRequest.of(
+                    Math.abs(page),
+                    Math.abs(size),
+                    Sort.by(getSortingOrderForPageableVeileder(sorteringskolonne, sorteringOrder))
+            );
             Map<String, Object> avtaler = avtalepart.hentAlleAvtalerMedLesetilgang(
                     avtaleRepository,
                     avtalePredicate,
@@ -197,6 +202,7 @@ public class AvtaleController {
             stringObjectHashMap.put("sokeParametere", avtalePredicate);
             stringObjectHashMap.put("sokId", filterSok.getSokId());
             stringObjectHashMap.put("sorteringskolonne", sorteringskolonne);
+            stringObjectHashMap.put("sorteringOrder", sorteringOrder);
             return stringObjectHashMap;
 
         } else {
@@ -208,6 +214,7 @@ public class AvtaleController {
                     entry("totalPages", 0),
                     entry("sokeParametere", new AvtalePredicate()),
                     entry("sorteringskolonne", "sistEndret"),
+                    entry("sorteringOrder", "ASC"),
                     entry("sokId", "")
             );
         }
@@ -221,10 +228,11 @@ public class AvtaleController {
             @CookieValue("innlogget-part") Avtalerolle innloggetPart,
             @RequestParam(value = "sorteringskolonne", required = false, defaultValue = Avtale.Fields.sistEndret) String sorteringskolonne,
             @RequestParam(value = "page", required = false, defaultValue = "0") Integer page,
-            @RequestParam(value = "size", required = false, defaultValue = "10") Integer size
+            @RequestParam(value = "size", required = false, defaultValue = "10") Integer size,
+            @RequestParam(value = "sorteringOrder", required = false, defaultValue = "ASC") String sorteringOrder
     ) {
         Avtalepart avtalepart = innloggingService.hentAvtalepart(innloggetPart);
-        Pageable pageable = PageRequest.of(Math.abs(page), Math.abs(size), Sort.by(getSortingOrderForPageable(sorteringskolonne)));
+        Pageable pageable = PageRequest.of(Math.abs(page), Math.abs(size), Sort.by(getSortingOrderForPageableVeileder(sorteringskolonne, sorteringOrder)));
         Map<String, Object> avtaler = avtalepart.hentAlleAvtalerMedLesetilgang(
                 avtaleRepository,
                 queryParametre,
@@ -235,6 +243,7 @@ public class AvtaleController {
         HashMap<String, Object> stringObjectHashMap = new HashMap<>(avtaler);
         stringObjectHashMap.put("sokeParametere", queryParametre);
         stringObjectHashMap.put("sorteringskolonne", sorteringskolonne);
+        stringObjectHashMap.put("sorteringOrder", sorteringOrder);
 
 
         FilterSok filterSokiDb = filterSokRepository.findFilterSokBySokId(queryParametre.generateHash()).orElse(null);

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleSorterer.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleSorterer.java
@@ -13,7 +13,8 @@ public class AvtaleSorterer {
             case AvtaleInnhold.Fields.deltakerEtternavn -> Comparator.comparing(avtale -> lowercaseEllerNull(avtale.getGjeldendeInnhold().getDeltakerEtternavn()), Comparator.nullsLast(Comparator.naturalOrder()));
             case AvtaleInnhold.Fields.deltakerFornavn -> Comparator.comparing(avtale -> lowercaseEllerNull(avtale.getGjeldendeInnhold().getDeltakerFornavn()), Comparator.nullsLast(Comparator.naturalOrder()));
             case "status" -> Comparator.comparing(Avtale::status);
-            case "startDato" -> Comparator.comparing(avtale -> (avtale.gjeldendeTilskuddsperiode() != null ? avtale.gjeldendeTilskuddsperiode().getStartDato() : avtale.getGjeldendeInnhold().getStartDato()), Comparator.nullsLast(Comparator.naturalOrder()));
+            case "startDato" ->
+                    Comparator.comparing(avtale -> (avtale.gjeldendeTilskuddsperiode() != null ? avtale.gjeldendeTilskuddsperiode().getStartDato() : avtale.getGjeldendeInnhold().getStartDato()), Comparator.nullsLast(Comparator.naturalOrder()));
             default -> Comparator.comparing(Avtale::getSistEndret, Comparator.reverseOrder());
         };
     }
@@ -22,20 +23,27 @@ public class AvtaleSorterer {
         return x != null ? x.toLowerCase() : null;
     }
 
-    static Sort.Order getSortingOrderForPageable(String sortingOrder) {
-        return switch (sortingOrder) {
-            case "deltakerFornavn" -> Sort.Order.asc("gjeldendeInnhold.deltakerFornavn");
-            case "opprettetTidspunkt" -> Sort.Order.desc("opprettetTidspunkt");
-            case "bedriftNavn" -> Sort.Order.asc("gjeldendeInnhold.bedriftNavn");
-            case "startDato" -> Sort.Order.asc("gjeldendeInnhold.startDato");
-            case "tiltakstype" -> Sort.Order.asc("tiltakstype");
-            default -> Sort.Order.desc("sistEndret");
-        };
+    static Sort.Order getSortingOrderForPageableVeileder(String sorteringskolonne) {
+        return getSortingOrderForPageableVeileder(sorteringskolonne, "ASC");
     }
 
-   static protected Sort.Order getSortingOrderForPageable(String order, String direction) {
-       SortingDirection sortingDirection = SortingDirection.valueOf(direction.toUpperCase());
-       return switch (sortingDirection) {
+    static Sort.Order getSortingOrderForPageableVeileder(String sorteringskolonne, String sorteringsRetning) {
+        var feldtnavn = switch (sorteringskolonne) {
+            case "deltakerFornavn" -> "gjeldendeInnhold.deltakerFornavn";
+            case "opprettetTidspunkt" -> "opprettetTidspunkt";
+            case "bedriftNavn" -> "gjeldendeInnhold.bedriftNavn";
+            case "startDato" -> "gjeldendeInnhold.startDato";
+            case "sluttDato" -> "gjeldendeInnhold.sluttDato";
+            case "tiltakstype" -> "tiltakstype";
+            case "veilederNavIdent" -> "veilederNavIdent";
+            default -> "sistEndret";
+        };
+        return new Sort.Order(Sort.Direction.fromString(sorteringsRetning), feldtnavn);
+    }
+
+    static protected Sort.Order getSortingOrderForPageableBeslutter(String order, String direction) {
+        SortingDirection sortingDirection = SortingDirection.valueOf(direction.toUpperCase());
+        return switch (sortingDirection) {
             case ASC -> getSortingOrderForPageableASC(SortingOrder.valueOf(order.toUpperCase()));
             case DESC -> getSortingOrderForPageableDESC(SortingOrder.valueOf(order.toUpperCase()));
         };

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/Beslutter.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/Beslutter.java
@@ -92,7 +92,7 @@ public class Beslutter extends Avtalepart<NavIdent> implements InternBruker {
             Integer size,
             String sorteringOrder
     ) {
-        Sort by = Sort.by(AvtaleSorterer.getSortingOrderForPageable(sorteringskolonne, sorteringOrder));
+        Sort by = Sort.by(AvtaleSorterer.getSortingOrderForPageableBeslutter(sorteringskolonne, sorteringOrder));
         Pageable paging = PageRequest.of(page, size, by);
 
         Set<String> navEnheter = hentNavEnheter();


### PR DESCRIPTION
Lagt til så man kan sortere på lavest og høyest på de ulike sorteringskolonnene.
- [x] sortering av veilederNavIdent for veileder
- [x] sortering for sluttDato for veileder

[https://github.com/navikt/tiltaksgjennomforing/pull/1184](https://github.com/navikt/tiltaksgjennomforing/pull/1184)