### PR TITLE
fix. Fjerne spec.team fram nais yaml

### DIFF
--- a/nais/dev-fss.yaml
+++ b/nais/dev-fss.yaml
@@ -22,7 +22,6 @@ spec:
   kafka:
     pool: nav-dev
   image: {{image}}
-  team: arbeidsgiver
   port: 8080
   liveness:
     path: /tiltaksgjennomforing-api/internal/healthcheck

--- a/nais/dev-gcp-labs.yaml
+++ b/nais/dev-gcp-labs.yaml
@@ -10,7 +10,6 @@ spec:
     - name: MILJO
       value: dev-gcp-labs
   image: {{image}}
-  team: arbeidsgiver
   port: 8080
   replicas:
     min: 1

--- a/nais/prod-fss.yaml
+++ b/nais/prod-fss.yaml
@@ -25,7 +25,6 @@ spec:
   kafka:
     pool: nav-prod
   image: {{image}}
-  team: arbeidsgiver
   port: 8080
   liveness:
     path: /tiltaksgjennomforing-api/internal/healthcheck


### PR DESCRIPTION
Error: Status: failure: nais.io/v1alpha1, Kind=Application, Namespace=arbeidsgiver, Name=tiltaksgjennomforing-api: updating resource: strict decoding error: | unknown field spec.team
| The field might be misspelled, incorrectly indented, or unsupported. Fields are case sensitive. | Please verify your resource against the reference documentation at https://doc.nais.io/nais-application/application/ (total of 1 errors)