### PR TITLE
fix. Degradere logging til warn

### DIFF
--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/Veileder.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/Veileder.java
@@ -314,7 +314,7 @@ public class Veileder extends Avtalepart<NavIdent> implements InternBruker {
     }
 
     private void oppdatereOppfølgingEnhetsnavnVedEndreAvtale(Avtale avtale) {
-        final Norg2OppfølgingResponse response = norg2Client.hentOppfølgingsEnhetsnavnFraCacheNorg2(
+        final Norg2OppfølgingResponse response = norg2Client.hentOppfølgingsEnhetFraCacheNorg2(
                 avtale.getEnhetOppfolging()
         );
         if (response == null) return;

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/enhet/EnhetController.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/enhet/EnhetController.java
@@ -19,7 +19,7 @@ public class EnhetController {
     
     @GetMapping("/{enhetsnummer}")
     public ResponseEntity<HentEnhetResponse> hent(@PathVariable("enhetsnummer") String enhetsnummer) {
-        Norg2OppfølgingResponse response = norg2Client.hentOppfølgingsEnhet(enhetsnummer);
+        Norg2OppfølgingResponse response = norg2Client.hentOppfølgingsEnhetFraCacheNorg2(enhetsnummer);
         
         if (response == null || response.getStatus() == Norg2EnhetStatus.NEDLAGT) {
             return new ResponseEntity<>(HttpStatus.NOT_FOUND);

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/enhet/Norg2Client.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/enhet/Norg2Client.java
@@ -3,7 +3,6 @@ package no.nav.tag.tiltaksgjennomforing.enhet;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import no.nav.tag.tiltaksgjennomforing.infrastruktur.cache.EhCacheConfig;
-import org.apache.commons.compress.harmony.pack200.NewAttribute;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Component;
 import org.springframework.validation.annotation.Validated;
@@ -23,7 +22,7 @@ public class Norg2Client {
     private final RestTemplate restTemplate;
 
     @Cacheable(EhCacheConfig.NORGNAVN_CACHE)
-    public Norg2OppfølgingResponse hentOppfølgingsEnhetsnavnFraCacheNorg2(String enhet) {
+    public Norg2OppfølgingResponse hentOppfølgingsEnhetFraCacheNorg2(String enhet) {
         return this.hentOppfølgingsEnhet(enhet);
     }
 
@@ -34,29 +33,28 @@ public class Norg2Client {
 
 
     public Norg2GeoResponse hentGeografiskEnhet(String geoOmråde) {
-        Norg2GeoResponse norg2GeoResponse;
         try {
-            norg2GeoResponse = restTemplate.getForObject(norg2GeografiskProperties.getUrl() + geoOmråde, Norg2GeoResponse.class);
+            Norg2GeoResponse norg2GeoResponse = restTemplate.getForObject(norg2GeografiskProperties.getUrl() + geoOmråde, Norg2GeoResponse.class);
             if (norg2GeoResponse.getEnhetNr() == null) {
                 log.warn("Fant ikke enhet med geoOmråde {}", geoOmråde);
             }
+            return norg2GeoResponse;
         } catch (Exception e) {
             log.error("Feil v/oppslag på geoOmråde {}", geoOmråde);
             throw e;
         }
-        return norg2GeoResponse;
     }
 
     public Norg2OppfølgingResponse hentOppfølgingsEnhet(@Pattern(regexp = "^\\d{4}$", message = "Ugyldig enhetsnummer") String enhetsnummer) {
-        Norg2OppfølgingResponse norg2OppfølgingResponse = null;
         try {
-            norg2OppfølgingResponse = restTemplate.getForObject(norg2OppfølgingProperties.getUrl() + enhetsnummer, Norg2OppfølgingResponse.class);
+            Norg2OppfølgingResponse norg2OppfølgingResponse = restTemplate.getForObject(norg2OppfølgingProperties.getUrl() + enhetsnummer, Norg2OppfølgingResponse.class);
             if (Objects.requireNonNull(norg2OppfølgingResponse).getNavn() == null) {
                 log.warn("Fant ingen enhet: {}", enhetsnummer);
             }
+            return norg2OppfølgingResponse;
         } catch (Exception e) {
-            log.error("Feil v/oppslag på enhet {}", enhetsnummer, e);
+            log.warn("Feil v/oppslag på enhet {}", enhetsnummer, e);
+            return null;
         }
-        return norg2OppfølgingResponse;
     }
 }

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/infrastruktur/caching/CachingConfigMockTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/infrastruktur/caching/CachingConfigMockTest.java
@@ -150,7 +150,7 @@ public class CachingConfigMockTest {
         )).thenReturn(true, true, true);
 
         when(mockPersondataService.hentPersondataFraPdl(avtale.getDeltakerFnr())).thenReturn(FØRSTE_PDL_RESPONSE, ANDRE_PDL_RESPONSE);
-        when(mockNorg2Client.hentOppfølgingsEnhetsnavnFraCacheNorg2(any())).thenReturn(
+        when(mockNorg2Client.hentOppfølgingsEnhetFraCacheNorg2(any())).thenReturn(
                 FØRSTE_NORG2_OPPFØLGNING_RESPONSE,
                 ANDRE_NORG2_OPPFØLGNING_RESPONSE
         );
@@ -163,10 +163,10 @@ public class CachingConfigMockTest {
 
     @Test
     public void bekreft_antall_ganger_Cacheable_endepunkter_blir_kalt_ved_norg2Client_oppfølgingsEnhetsnavn() {
-        Norg2OppfølgingResponse norg2OppfølgingResponse = norg2Client.hentOppfølgingsEnhetsnavnFraCacheNorg2(
+        Norg2OppfølgingResponse norg2OppfølgingResponse = norg2Client.hentOppfølgingsEnhetFraCacheNorg2(
                 avtale.getEnhetOppfolging()
         );
-        Norg2OppfølgingResponse norg2OppfølgingResponse2 = norg2Client.hentOppfølgingsEnhetsnavnFraCacheNorg2(
+        Norg2OppfølgingResponse norg2OppfølgingResponse2 = norg2Client.hentOppfølgingsEnhetFraCacheNorg2(
                 avtale.getEnhetOppfolging()
         );
 
@@ -179,7 +179,7 @@ public class CachingConfigMockTest {
         Assertions.assertEquals(FØRSTE_NORG2_OPPFØLGNING_RESPONSE.getNavn(), norg2OppfølgingResponse2.getNavn());
 
         /** Blir kalt 2 ganger. Andre iterasjon så treffer vi cache response istedenfor endepunkt */
-        verify(mockNorg2Client, times(1)).hentOppfølgingsEnhetsnavnFraCacheNorg2(avtale.getEnhetOppfolging());
+        verify(mockNorg2Client, times(1)).hentOppfølgingsEnhetFraCacheNorg2(avtale.getEnhetOppfolging());
     }
 
     @Test
@@ -288,7 +288,7 @@ public class CachingConfigMockTest {
         );
 
         /** Blir kalt 2 ganger. Andre iterasjon så treffer vi cache response istedenfor endepunkt */
-        verify(mockNorg2Client, times(1)).hentOppfølgingsEnhetsnavnFraCacheNorg2(avtale.getEnhetOppfolging());
+        verify(mockNorg2Client, times(1)).hentOppfølgingsEnhetFraCacheNorg2(avtale.getEnhetOppfolging());
         verify(mockNorg2Client, times(1)).hentGeoEnhetFraCacheEllerNorg2(geoEnhet);
         verify(mockPersondataService, times(1)).hentPersondataFraPdl(avtale.getDeltakerFnr());
         verify(mockVeilarbArenaClient, times(1)).HentOppfølgingsenhetFraCacheEllerArena(avtale.getDeltakerFnr().asString());

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/infrastruktur/caching/CachingConfigTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/infrastruktur/caching/CachingConfigTest.java
@@ -89,7 +89,7 @@ public class CachingConfigTest {
 
         TestData.setOppfolgingNavEnhet(avtale, oppfolgingNavEnhet);
 
-        Norg2OppfølgingResponse norg2OppfølgingResponse = norg2Client.hentOppfølgingsEnhetsnavnFraCacheNorg2(
+        Norg2OppfølgingResponse norg2OppfølgingResponse = norg2Client.hentOppfølgingsEnhetFraCacheNorg2(
                 avtale.getEnhetOppfolging()
         );
         Norg2OppfølgingResponse norgnavnCacheForEnhet = getCacheValue(


### PR DESCRIPTION
Degrader logging for henting av enhet i Norg2 til warn. Dette blir nå validert i frontend og håndtert der.