### PR TITLE
øker til hver andre time på dvh statusendring jobb

### DIFF
--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/datavarehus/DvhStatusendringJobb.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/datavarehus/DvhStatusendringJobb.java
@@ -14,6 +14,7 @@ import org.springframework.stereotype.Component;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 
 @Profile("!local")
 @Component
@@ -25,7 +26,7 @@ public class DvhStatusendringJobb {
     private final AvtaleRepository avtaleRepository;
     private final LeaderPodCheck leaderPodCheck;
 
-    @Scheduled(fixedDelayString = "${tiltaksgjennomforing.dvh-melding.fixed-delay}")
+    @Scheduled(fixedDelayString = "${tiltaksgjennomforing.dvh-melding.fixed-delay}", timeUnit = TimeUnit.MINUTES)
     public void sjekkOmStatusendring() {
 
         if (!leaderPodCheck.isLeaderPod()) {

--- a/src/main/resources/config/application.yaml
+++ b/src/main/resources/config/application.yaml
@@ -56,7 +56,7 @@ tiltaksgjennomforing:
     uri: https://ag-notifikasjon-produsent-api.dev.intern.nav.no/api/graphql
     lenke: https://arbeidsgiver.nav.no/tiltaksgjennomforing/avtale/
   dvh-melding:
-    fixed-delay: 600000
+    fixed-delay: 120
   avtale-hendelse-melding:
     fixed-delay: 120
   tilskuddsperioder:

--- a/src/test/resources/config/application-dockercompose.yml
+++ b/src/test/resources/config/application-dockercompose.yml
@@ -65,7 +65,7 @@ tiltaksgjennomforing:
     uri: http://localhost:9000/template/tiltak-avtale/create-pdf
   dvh-melding:
     gruppe-tilgang: 1a1d2745-952f-4a0f-839f-9530145b1d4a
-    fixed-delay: 20000
+    fixed-delay: 10
   avtale-hendelse-melding:
     fixed-delay: 120
   tilskuddsperioder:

--- a/src/test/resources/config/application-local.yaml
+++ b/src/test/resources/config/application-local.yaml
@@ -107,7 +107,7 @@ tiltaksgjennomforing:
     enabled: false
   dvh-melding:
     gruppe-tilgang: 1a1d2745-952f-4a0f-839f-9530145b1d4a
-    fixed-delay: 20000
+    fixed-delay: 10
   tilskuddsperioder:
     tiltakstyper: SOMMERJOBB, MIDLERTIDIG_LONNSTILSKUDD, VARIG_LONNSTILSKUDD
   salesforcekontorer:


### PR DESCRIPTION
Øker frekvensen på den skedulerte jobben for å se etter statusendring på meldinger til datavarehus fra 10 minutter til 2 timer.
Dette trengs trolig ikke kjøres oftere enn 1 gang om dagen, statusendringer som ikke fanges opp av domeneeventer, så langt jeg kan skjønne, skjer kun ved datoendringer.