### PR TITLE
Nytt post-versjon av endepunkt

### DIFF
--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/AlleredePaaTiltakRequest.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/AlleredePaaTiltakRequest.java
@@ -1,0 +1,14 @@
+package no.nav.tag.tiltaksgjennomforing.avtale;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record AlleredePaaTiltakRequest(
+        @JsonProperty(required = true)
+        Fnr deltakerFnr,
+        @JsonProperty(required = true)
+        Tiltakstype tiltakstype,
+        String startDato,
+        String sluttDato,
+        String avtaleId
+) {
+}

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleController.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleController.java
@@ -434,7 +434,29 @@ public class AvtaleController {
                 sluttDato != null ? LocalDate.parse(sluttDato) : null,
                 avtaleRepository
         );
-        return new ResponseEntity<List<AlleredeRegistrertAvtale>>(avtaler, HttpStatus.OK);
+        return ResponseEntity.ok(avtaler);
+    }
+
+    /**
+     * VEILEDER-OPERASJONER
+     **/
+    @ApiBeskrivelse("Hent liste over registrerte avtaler for bruker")
+    @PostMapping("/deltaker-allerede-paa-tiltak")
+    @Transactional
+    public ResponseEntity<List<AlleredeRegistrertAvtale>> sjekkOmDeltakerAlleredeErRegistrertPaaTiltak(
+            @RequestBody AlleredePaaTiltakRequest alleredePaaTiltakRequest
+
+    ) {
+        Veileder veileder = innloggingService.hentVeileder();
+        List<AlleredeRegistrertAvtale> avtaler = veileder.hentAvtaleDeltakerAlleredeErRegistrertPaa(
+                alleredePaaTiltakRequest.deltakerFnr(),
+                alleredePaaTiltakRequest.tiltakstype(),
+                alleredePaaTiltakRequest.avtaleId() != null ? UUID.fromString(alleredePaaTiltakRequest.avtaleId()) : null,
+                alleredePaaTiltakRequest.startDato() != null ? LocalDate.parse(alleredePaaTiltakRequest.startDato()) : null,
+                alleredePaaTiltakRequest.sluttDato() != null ? LocalDate.parse(alleredePaaTiltakRequest.sluttDato()) : null,
+                avtaleRepository
+        );
+        return ResponseEntity.ok(avtaler);
     }
 
     @PostMapping


### PR DESCRIPTION
For å unngå fødselsnr i URLer oppretter
vi et nytt post-endepunkt som skal erstatte
get-endepunktet for å sjekke om en deltaker
er på tiltak.