### PR TITLE
Vis periode(dato fra og til) for godkjent tilskuddsperiode i hendelseslogg når beslutter godkjenner 

### DIFF
--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/varsel/Varsel.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/varsel/Varsel.java
@@ -54,18 +54,20 @@ public class Varsel extends AbstractAggregateRoot<Varsel> {
         return switch (hendelseType) {
             case TILSKUDDSPERIODE_AVSLATT -> tilskuddsperiodeAvslåttTekst(avtale, hendelseType.getTekst());
             case TILSKUDDSPERIODE_GODKJENT ->{
-                if(avtale.gjeldendeTilskuddsperiode().getStartDato() != null
+                if(avtale.gjeldendeTilskuddsperiode() != null
+                        && avtale.gjeldendeTilskuddsperiode().getStartDato() != null
                         && avtale.gjeldendeTilskuddsperiode().getSluttDato() != null) {
-                    yield hendelseType.getTekst() + " (" + avtale.gjeldendeTilskuddsperiode().getStartDato() + " til " + avtale.gjeldendeTilskuddsperiode().getSluttDato() + ")";
+                    DateTimeFormatter norskDatoformat = DateTimeFormatter.ofPattern("dd.MM.yyyy");
+                    yield hendelseType.getTekst() + "\n(" + avtale.gjeldendeTilskuddsperiode().getStartDato().format(norskDatoformat) + " til " + avtale.gjeldendeTilskuddsperiode().getSluttDato().format(norskDatoformat) + ")";
                 }else{
                     yield hendelseType.getTekst();
                 }
             }
             case AVTALE_FORKORTET ->
-                    "Avtale forkortet til " + avtale.getGjeldendeInnhold().getSluttDato().format(DateTimeFormatter.ofPattern("dd.MM.YYYY"));
+                    "Avtale forkortet til " + avtale.getGjeldendeInnhold().getSluttDato().format(DateTimeFormatter.ofPattern("dd.MM.yyyy"));
             case AVTALE_FORLENGET ->
-                    "Avtale forlenget til " + avtale.getGjeldendeInnhold().getSluttDato().format(DateTimeFormatter.ofPattern("dd.MM.YYYY"));
-            default -> hendelseType.getTekst(); // TODO: Lag en for godkjent tilskuddsperiode av beslutter + legg periode det gjelder her!
+                    "Avtale forlenget til " + avtale.getGjeldendeInnhold().getSluttDato().format(DateTimeFormatter.ofPattern("dd.MM.yyyy"));
+            default -> hendelseType.getTekst();
         };
     }
 

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/varsel/Varsel.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/varsel/Varsel.java
@@ -53,11 +53,19 @@ public class Varsel extends AbstractAggregateRoot<Varsel> {
     private static String lagVarselTekst(Avtale avtale, HendelseType hendelseType) {
         return switch (hendelseType) {
             case TILSKUDDSPERIODE_AVSLATT -> tilskuddsperiodeAvslåttTekst(avtale, hendelseType.getTekst());
+            case TILSKUDDSPERIODE_GODKJENT ->{
+                if(avtale.gjeldendeTilskuddsperiode().getStartDato() != null
+                        && avtale.gjeldendeTilskuddsperiode().getSluttDato() != null) {
+                    yield hendelseType.getTekst() + " (" + avtale.gjeldendeTilskuddsperiode().getStartDato() + " til " + avtale.gjeldendeTilskuddsperiode().getSluttDato() + ")";
+                }else{
+                    yield hendelseType.getTekst();
+                }
+            }
             case AVTALE_FORKORTET ->
                     "Avtale forkortet til " + avtale.getGjeldendeInnhold().getSluttDato().format(DateTimeFormatter.ofPattern("dd.MM.YYYY"));
             case AVTALE_FORLENGET ->
                     "Avtale forlenget til " + avtale.getGjeldendeInnhold().getSluttDato().format(DateTimeFormatter.ofPattern("dd.MM.YYYY"));
-            default -> hendelseType.getTekst();
+            default -> hendelseType.getTekst(); // TODO: Lag en for godkjent tilskuddsperiode av beslutter + legg periode det gjelder her!
         };
     }
 

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/varsel/VarselFactoryTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/varsel/VarselFactoryTest.java
@@ -1,14 +1,31 @@
 package no.nav.tag.tiltaksgjennomforing.varsel;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
 
-import no.nav.tag.tiltaksgjennomforing.avtale.Avtalerolle;
-import no.nav.tag.tiltaksgjennomforing.avtale.HendelseType;
-import no.nav.tag.tiltaksgjennomforing.avtale.TestData;
+import no.nav.tag.tiltaksgjennomforing.avtale.*;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 class VarselFactoryTest {
 
+  @Test
+  public void skal_returnere_tilskuddsperiode_verdi_i_teksten_naar_beslutter_godkjenner_periode(){
+    Avtale avtale = TestData.enMidlertidigLonnstilskuddAvtaleMedSpesieltTilpassetInnsatsGodkjentAvVeileder();
+    VarselFactory factory = new VarselFactory(avtale, Avtalerolle.BESLUTTER, TestData.enNavIdent() , HendelseType.TILSKUDDSPERIODE_GODKJENT);
+    assertEquals("Tilskuddsperiode har blitt godkjent av beslutter (" + avtale.gjeldendeTilskuddsperiode().getStartDato() + " til " + avtale.gjeldendeTilskuddsperiode().getSluttDato() + ")",factory.veileder().getTekst());
+  }
+
+  @Test
+  public void skal_returnere_tilskuddsperiode_uten_periode_i_tekstenom_om_start_og_slutt_periode_ikke_er_satt(){
+    Avtale avtale = Mockito.mock(Avtale.class);
+    TilskuddPeriode tilskuddPeriode = Mockito.mock(TilskuddPeriode.class);
+    when(tilskuddPeriode.getStartDato()).thenReturn(null);
+    when(tilskuddPeriode.getSluttDato()).thenReturn(null);
+    when(avtale.gjeldendeTilskuddsperiode()).thenReturn(tilskuddPeriode);
+    VarselFactory factory = new VarselFactory(avtale, Avtalerolle.BESLUTTER, TestData.enNavIdent() , HendelseType.TILSKUDDSPERIODE_GODKJENT);
+    assertEquals("Tilskuddsperiode har blitt godkjent av beslutter",factory.veileder().getTekst());
+  }
   @Test
   public void skal_returnere_4_parter_Mentor_Deltaker_Arbeidsgiver_Veileder_Ventor_I_VarselListe(){
     VarselFactory factory = new VarselFactory(TestData.enMentorAvtaleUsignert(), Avtalerolle.MENTOR, TestData.enNavIdent() , HendelseType.OPPRETTET);

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/varsel/VarselFactoryTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/varsel/VarselFactoryTest.java
@@ -7,13 +7,16 @@ import no.nav.tag.tiltaksgjennomforing.avtale.*;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
+import java.time.format.DateTimeFormatter;
+
 class VarselFactoryTest {
 
   @Test
   public void skal_returnere_tilskuddsperiode_verdi_i_teksten_naar_beslutter_godkjenner_periode(){
     Avtale avtale = TestData.enMidlertidigLonnstilskuddAvtaleMedSpesieltTilpassetInnsatsGodkjentAvVeileder();
     VarselFactory factory = new VarselFactory(avtale, Avtalerolle.BESLUTTER, TestData.enNavIdent() , HendelseType.TILSKUDDSPERIODE_GODKJENT);
-    assertEquals("Tilskuddsperiode har blitt godkjent av beslutter (" + avtale.gjeldendeTilskuddsperiode().getStartDato() + " til " + avtale.gjeldendeTilskuddsperiode().getSluttDato() + ")",factory.veileder().getTekst());
+    DateTimeFormatter norskDatoformat = DateTimeFormatter.ofPattern("dd.MM.yyyy");
+    assertEquals("Tilskuddsperiode har blitt godkjent av beslutter\n(" + avtale.gjeldendeTilskuddsperiode().getStartDato().format(norskDatoformat) + " til " + avtale.gjeldendeTilskuddsperiode().getSluttDato().format(norskDatoformat) + ")",factory.veileder().getTekst());
   }
 
   @Test
@@ -23,6 +26,13 @@ class VarselFactoryTest {
     when(tilskuddPeriode.getStartDato()).thenReturn(null);
     when(tilskuddPeriode.getSluttDato()).thenReturn(null);
     when(avtale.gjeldendeTilskuddsperiode()).thenReturn(tilskuddPeriode);
+    VarselFactory factory = new VarselFactory(avtale, Avtalerolle.BESLUTTER, TestData.enNavIdent() , HendelseType.TILSKUDDSPERIODE_GODKJENT);
+    assertEquals("Tilskuddsperiode har blitt godkjent av beslutter",factory.veileder().getTekst());
+  }
+  @Test
+  public void skal_returnere_tilskuddsperiode_er_null(){
+    Avtale avtale = Mockito.mock(Avtale.class);
+    when(avtale.gjeldendeTilskuddsperiode()).thenReturn(null);
     VarselFactory factory = new VarselFactory(avtale, Avtalerolle.BESLUTTER, TestData.enNavIdent() , HendelseType.TILSKUDDSPERIODE_GODKJENT);
     assertEquals("Tilskuddsperiode har blitt godkjent av beslutter",factory.veileder().getTekst());
   }


### PR DESCRIPTION
Vis periode (dato fra og til) det gjelder i varselloggen når beslutter godkjenner tilskuddsperiode. Det var forvirrende tidligere da veileder/beslutter ikke kunne se hvilken periode det gjelder i hendelsesloggen.