### PR TITLE
Stoppe godkjenning av tilskudd for neste år

### DIFF
--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/TilskuddPeriode.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/TilskuddPeriode.java
@@ -109,8 +109,22 @@ public class TilskuddPeriode implements Comparable<TilskuddPeriode> {
         }
     }
 
+    private static LocalDate tidligstI2025(LocalDate dato) {
+        return dato.isBefore(TilskuddPeriode.START_2025) ? TilskuddPeriode.START_2025 : dato;
+    }
+    private boolean startDatoErI2025() {
+        return startDato.isAfter(START_2025.minusDays(1));
+    }
+
+    private static final LocalDate START_2025 = LocalDate.of(2025, 1, 1);
+
     @JsonProperty
     private LocalDate kanBesluttesFom() {
+        // Ikke tillat godkjenning av tilskuddsperioder etter 2025 før budsjettet er vedtatt
+        // TODO: Må oppdateres før årsskifte 2024/2025
+        if (startDatoErI2025()) {
+            return tidligstI2025(startDato.minusMonths(3));
+        }
         if (løpenummer == 1) {
             return LocalDate.MIN;
         }

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/TilskuddPeriodeTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/TilskuddPeriodeTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.LocalDate;
 import java.util.EnumSet;
+
 import no.nav.tag.tiltaksgjennomforing.exceptions.Feilkode;
 import no.nav.tag.tiltaksgjennomforing.utils.Now;
 import org.junit.jupiter.api.Disabled;
@@ -67,6 +68,67 @@ class TilskuddPeriodeTest {
         TilskuddPeriode tilskuddPeriode = TestData.enTilskuddPeriode();
         tilskuddPeriode.setRefusjonStatus(RefusjonStatus.UTBETALT);
         assertThat(tilskuddPeriode.erUtbetalt()).isTrue();
+    }
+
+    static final Integer NESTE_AAR = 2025;
+    static final Integer NAAVAERENDE_AAR = NESTE_AAR - 1;
+
+    @Test
+    void kan_ikke_beslutte_for_neste_aar() {
+        // Første tilskuddsperiode kan alltid godkjennes tidligere enn 3 mnd før startdato,
+        // men det er ikke ønskelig å åpne for dette for tilskuddsperioder som starter "neste år" grunnet
+        // uavklart budsjett.
+        Now.fixedDate(LocalDate.of(NAAVAERENDE_AAR, 1, 1));
+        TilskuddPeriode tilskuddPeriode = TestData.enTilskuddPeriode();
+        tilskuddPeriode.setStatus(TilskuddPeriodeStatus.UBEHANDLET);
+
+        tilskuddPeriode.setStartDato(LocalDate.of(NAAVAERENDE_AAR - 1, 1, 1));
+        assertThat(tilskuddPeriode.kanBehandles()).isTrue();
+
+        tilskuddPeriode.setStartDato(LocalDate.of(NAAVAERENDE_AAR, 12, 31));
+        assertThat(tilskuddPeriode.kanBehandles()).isTrue();
+
+        tilskuddPeriode.setStartDato(LocalDate.of(NESTE_AAR, 1, 1));
+        assertThat(tilskuddPeriode.kanBehandles()).isFalse();
+
+        tilskuddPeriode.setStartDato(LocalDate.of(NESTE_AAR, 6, 1));
+        assertThat(tilskuddPeriode.kanBehandles()).isFalse();
+
+        tilskuddPeriode.setStartDato(LocalDate.of(NESTE_AAR + 1, 6, 1));
+        assertThat(tilskuddPeriode.kanBehandles()).isFalse();
+
+        Now.resetClock();
+    }
+
+    @Test
+    void kan_ikke_godkjenne_for_neste_aar() {
+        // Alle tilskuddsperioder etter første kan godkjennes tidligere enn 3 mnd før startdato,
+        // men det er ikke ønskelig å åpne for dette for tilskuddsperioder som starter "neste år" grunnet
+        // uavklart budsjett.
+        Now.fixedDate(LocalDate.of(NAAVAERENDE_AAR, 9, 1));
+        TilskuddPeriode tilskuddPeriode = TestData.enTilskuddPeriode();
+        tilskuddPeriode.setStatus(TilskuddPeriodeStatus.UBEHANDLET);
+        tilskuddPeriode.setLøpenummer(2);
+
+        tilskuddPeriode.setStartDato(LocalDate.of(NAAVAERENDE_AAR - 1, 1, 1));
+        assertThat(tilskuddPeriode.kanBehandles()).isTrue();
+
+        tilskuddPeriode.setStartDato(LocalDate.of(NAAVAERENDE_AAR, 11, 30));
+        assertThat(tilskuddPeriode.kanBehandles()).isTrue();
+
+        tilskuddPeriode.setStartDato(LocalDate.of(NAAVAERENDE_AAR, 12, 31));
+        assertThat(tilskuddPeriode.kanBehandles()).isFalse();
+
+        tilskuddPeriode.setStartDato(LocalDate.of(NESTE_AAR, 1, 1));
+        assertThat(tilskuddPeriode.kanBehandles()).isFalse();
+
+        tilskuddPeriode.setStartDato(LocalDate.of(NESTE_AAR, 6, 1));
+        assertThat(tilskuddPeriode.kanBehandles()).isFalse();
+
+        tilskuddPeriode.setStartDato(LocalDate.of(NESTE_AAR + 1, 6, 1));
+        assertThat(tilskuddPeriode.kanBehandles()).isFalse();
+
+        Now.resetClock();
     }
 
     @Test


### PR DESCRIPTION
Dersom en beslutter forsøker å godkjenne tilskuddsperioder for neste år burde dette stoppes inntil budsjett er avklart.