### PR TITLE
fix. Oppgrader altinn-rettigheter-proxy-klient

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -142,7 +142,7 @@
         <dependency>
             <groupId>no.nav.arbeidsgiver</groupId>
             <artifactId>altinn-rettigheter-proxy-klient</artifactId>
-            <version>2.0.1</version>
+            <version>4.0.0</version>
         </dependency>
 
         <dependency>

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/ArbeidsgiverTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/ArbeidsgiverTest.java
@@ -54,14 +54,15 @@ public class ArbeidsgiverTest {
         Arbeidsgiver arbeidsgiver = new Arbeidsgiver(
                 TestData.etFodselsnummer(),
                 Set.of(
-                        new AltinnReportee(
-                                "",
-                                "",
-                                null,
-                                TestData.etBedriftNr().asString(),
-                                null,
-                                null
-                        )
+                    new AltinnReportee(
+                        "",
+                        "",
+                        null,
+                        TestData.etBedriftNr().asString(),
+                        null,
+                        null,
+                        null
+                    )
                 ),
                 Map.of(TestData.etBedriftNr(), Set.of(Tiltakstype.ARBEIDSTRENING)),
                 persondataService,

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/TestData.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/TestData.java
@@ -674,7 +674,7 @@ public class TestData {
     public static Arbeidsgiver enArbeidsgiver(Avtale avtale) {
         return new Arbeidsgiver(
                 TestData.etFodselsnummer(),
-                Set.of(new AltinnReportee("Bedriftnavn", "", null, avtale.getBedriftNr().asString(), "", ""))
+                Set.of(new AltinnReportee("Bedriftnavn", "", null, avtale.getBedriftNr().asString(), "", "", null))
                 , Map.of(avtale.getBedriftNr(),
                 List.of(Tiltakstype.values())),
                 null,
@@ -861,7 +861,7 @@ public class TestData {
 
     public static InnloggetArbeidsgiver innloggetArbeidsgiver(Avtalepart<Fnr> avtalepartMedFnr, BedriftNr bedriftNr) {
         Map<BedriftNr, Collection<Tiltakstype>> tilganger = Map.of(bedriftNr, Set.of(Tiltakstype.values()));
-        AltinnReportee altinnOrganisasjon = new AltinnReportee("Bedriften AS", "Business", bedriftNr.asString(), "BEDR", "Active", null);
+        AltinnReportee altinnOrganisasjon = new AltinnReportee("Bedriften AS", "Business", bedriftNr.asString(), "BEDR", "Active", null, null);
         return new InnloggetArbeidsgiver(avtalepartMedFnr.getIdentifikator(), Set.of(altinnOrganisasjon), tilganger);
     }
 

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/featuretoggles/ByOrgnummerStrategyTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/featuretoggles/ByOrgnummerStrategyTest.java
@@ -28,7 +28,7 @@ public class ByOrgnummerStrategyTest {
     public void skal_være_enablet_hvis_bruker_tilhører_organisasjon() {
         Fnr fnr = new Fnr("12345678901");
         Set<AltinnReportee> orgSet = new HashSet<>();
-        orgSet.add(new AltinnReportee("", "AS", null, "999999999", "", ""));
+        orgSet.add(new AltinnReportee("", "AS", null, "999999999", "", "", null));
 
         when(altinnTilgangsstyringService.hentAltinnOrganisasjoner(eq(fnr), any())).thenReturn(orgSet);
         assertThat(new ByOrgnummerStrategy(altinnTilgangsstyringService).isEnabled(Map.of(ByOrgnummerStrategy.UNLEASH_PARAMETER_ORGNUMRE, "999999999"), unleashContext)).isTrue();
@@ -38,7 +38,7 @@ public class ByOrgnummerStrategyTest {
     public void skal_være_disablet_hvis_bruker_ikke_tilhører_organisasjon() {
         Fnr fnr = new Fnr("12345678901");
         Set<AltinnReportee> orgSet = new HashSet<>();
-        orgSet.add(new AltinnReportee("", "AS", null, "999999998", "", ""));
+        orgSet.add(new AltinnReportee("", "AS", null, "999999998", "", "", null));
 
         when(altinnTilgangsstyringService.hentAltinnOrganisasjoner(fnr, () -> "")).thenReturn(orgSet);
         assertThat(new ByOrgnummerStrategy(altinnTilgangsstyringService).isEnabled(Map.of(ByOrgnummerStrategy.UNLEASH_PARAMETER_ORGNUMRE, "999999999"), unleashContext)).isFalse();
@@ -48,7 +48,7 @@ public class ByOrgnummerStrategyTest {
     public void navIdent_skal_returnere_false() {
         UnleashContext unleashContext = UnleashContext.builder().userId("J154200").build();
         Set<AltinnReportee> orgSet = new HashSet<>();
-        orgSet.add(new AltinnReportee("", "AS", null, "999999998", "", ""));
+        orgSet.add(new AltinnReportee("", "AS", null, "999999998", "", "", null));
         assertThat(new ByOrgnummerStrategy(altinnTilgangsstyringService).isEnabled(Map.of(ByOrgnummerStrategy.UNLEASH_PARAMETER_ORGNUMRE, "999999999"), unleashContext)).isFalse();
         verify(altinnTilgangsstyringService, never()).hentAltinnOrganisasjoner(any(), any());
     }
@@ -57,7 +57,7 @@ public class ByOrgnummerStrategyTest {
     public void byOrgnummmer_strategy_håndterer_flere_orgnummer() {
         Fnr fnr = new Fnr("12345678901");
         Set<AltinnReportee> orgSet = new HashSet<>();
-        orgSet.add(new AltinnReportee("", "AS", null, "999999999", "", ""));
+        orgSet.add(new AltinnReportee("", "AS", null, "999999999", "", "", null));
 
         when(altinnTilgangsstyringService.hentAltinnOrganisasjoner(eq(fnr), any())).thenReturn(orgSet);
         assertThat(new ByOrgnummerStrategy(altinnTilgangsstyringService).isEnabled(Map.of(ByOrgnummerStrategy.UNLEASH_PARAMETER_ORGNUMRE, "910825526,999999999"), unleashContext)).isTrue();
@@ -67,7 +67,7 @@ public class ByOrgnummerStrategyTest {
     public void skal_være_disablet_hvis_feil_ved_oppslag_i_altinn() {
         Fnr fnr = new Fnr("12345678901");
         Set<AltinnReportee> orgSet = new HashSet<>();
-        orgSet.add(new AltinnReportee("", "AS", null, "999999998", "", ""));
+        orgSet.add(new AltinnReportee("", "AS", null, "999999998", "", "", null));
 
         when(altinnTilgangsstyringService.hentAltinnOrganisasjoner(fnr, () -> "")).thenThrow(RuntimeException.class);
         assertThat(new ByOrgnummerStrategy(altinnTilgangsstyringService).isEnabled(Map.of(ByOrgnummerStrategy.UNLEASH_PARAMETER_ORGNUMRE, "999999999"), unleashContext)).isFalse();


### PR DESCRIPTION
altinn-rettigheter-proxy-klient 2.0.1 hadde en avhengighet til com.github.kittinunf.fuel 2.2.1 som har blitt avpublisert.