### PR TITLE
Legg til tabell for satser

### DIFF
--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/satser/Sats.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/satser/Sats.java
@@ -1,0 +1,89 @@
+package no.nav.tag.tiltaksgjennomforing.satser;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.NavigableMap;
+import java.util.TreeMap;
+
+public class Sats {
+    private final String typeNavn;
+    private final NavigableMap<LocalDate, Double> satsePerioder;
+
+    Sats(String typenavn, List<Satser> satser) {
+        this.typeNavn = typenavn;
+        this.satsePerioder = lagPeriodesett(satser);
+    }
+
+    public Double hentGjeldendeSats(LocalDate dato) {
+        return satsePerioder.floorEntry(dato).getValue();
+    }
+
+    @Override
+    public String toString() {
+        var string = new StringBuilder("Sats: " + typeNavn + "\n");
+        var satseperiodeEntryset = new ArrayList<>(this.satsePerioder.entrySet());
+        for (int i = 0; i < satseperiodeEntryset.size() - 1; i++) {
+            string.append(satseperiodeEntryset.get(i).getKey());
+            string.append("\t");
+            string.append(satseperiodeEntryset.get(i + 1).getKey().minusDays(1));
+            string.append(":\t");
+            string.append(satseperiodeEntryset.get(i).getValue());
+            string.append("\n");
+        }
+        if (!satseperiodeEntryset.isEmpty()) {
+            var sistePeriode = satseperiodeEntryset.getLast();
+            string.append(sistePeriode.getKey());
+            string.append("\t");
+            string.append(LocalDate.MAX);
+            string.append(":\t");
+            string.append(sistePeriode.getValue());
+            string.append("\n");
+        }
+        return string.toString();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        Sats sats = (Sats) o;
+        return typeNavn.equals(sats.typeNavn) && satsePerioder.equals(sats.satsePerioder);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = typeNavn.hashCode();
+        result = 31 * result + satsePerioder.hashCode();
+        return result;
+    }
+
+    static NavigableMap<LocalDate, Double> lagPeriodesett(List<Satser> satser) {
+        NavigableMap<LocalDate, Double> m = new TreeMap<>();
+
+        m.put(LocalDate.MIN, null);
+
+        // Må unngå å opprette Sats basert på data med overlapp
+        for (int i = 0; i < satser.size(); i++) {
+            var sut = satser.get(i);
+            for (int j = i + 1; j < satser.size(); j++) {
+                if (satser.get(j).overlapper(sut)) {
+                    throw new IllegalStateException("Kan ikke lage periodesett med overlappende perioder!");
+                }
+            }
+        }
+
+        satser.stream()
+                .sorted(Comparator.comparing(Satser::getGyldigFraOgMed))
+                .forEach(sats -> {
+                    m.put(sats.getGyldigFraOgMed(), sats.getSatsVerdi());
+                    if (sats.getGyldigTilOgMed() != null) {
+                        m.put(sats.getGyldigTilOgMed().plusDays(1), null);
+                    }
+                });
+
+        return m;
+    }
+}

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/satser/SatsPeriodeData.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/satser/SatsPeriodeData.java
@@ -1,0 +1,10 @@
+package no.nav.tag.tiltaksgjennomforing.satser;
+
+import java.time.LocalDate;
+
+public record SatsPeriodeData(
+        Double satsVerdi,
+        LocalDate gyldigFra,
+        LocalDate gyldigTil
+) {
+}

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/satser/SatsService.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/satser/SatsService.java
@@ -1,0 +1,39 @@
+package no.nav.tag.tiltaksgjennomforing.satser;
+
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Set;
+
+import static java.lang.String.format;
+
+@Service
+public class SatsService {
+    private final SatserRepository satserRepository;
+
+    SatsService(SatserRepository satserRepository) {
+        this.satserRepository = satserRepository;
+    }
+
+    public Set<String> hentSatsetyper() {
+        return this.satserRepository.finnSatsetyper();
+    }
+
+    public Sats hentSats(String satsType) {
+        List<Satser> satser = satserRepository.findAllBySatsType(satsType);
+        return new Sats(satsType, satser);
+    }
+
+    public void opprettNySats(String satsType, SatsPeriodeData satsPeriodeData) {
+        var eksisterendeSatser = satserRepository.findAllBySatsType(satsType);
+        var nySats = Satser.of(satsType, satsPeriodeData);
+        eksisterendeSatser.forEach(eksisterendeSats -> {
+            if (eksisterendeSats.overlapper(nySats)) {
+                throw new IllegalArgumentException(
+                        format("Ny sats (%s) overlapper eksisterende sats (%s)", satsPeriodeData, eksisterendeSats)
+                );
+            }
+        });
+        satserRepository.save(nySats);
+    }
+}

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/satser/Satser.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/satser/Satser.java
@@ -1,0 +1,68 @@
+package no.nav.tag.tiltaksgjennomforing.satser;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.validation.constraints.NotNull;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.UUID;
+
+import static java.lang.String.format;
+
+@Entity
+class Satser {
+    @Id
+    private UUID id = UUID.randomUUID();
+    @NotNull
+    private String satsType;
+    @NotNull
+    private Double satsVerdi;
+    @NotNull
+    private LocalDate gyldigFraOgMed;
+    private LocalDate gyldigTilOgMed;
+    @NotNull
+    private Instant opprettetTidspunkt = Instant.now();
+
+    public Satser() {
+    }
+
+    public Satser(@NotNull String satsType, @NotNull Double satsVerdi, @NotNull LocalDate gyldigFraOgMed, LocalDate gyldigTilOgMed) {
+        this.satsType = satsType;
+        this.satsVerdi = satsVerdi;
+        this.gyldigFraOgMed = gyldigFraOgMed;
+        this.gyldigTilOgMed = gyldigTilOgMed;
+    }
+
+    public static Satser of(String satsType, SatsPeriodeData satsPeriodeData) {
+        return new Satser(satsType, satsPeriodeData.satsVerdi(), satsPeriodeData.gyldigFra(), satsPeriodeData.gyldigTil());
+    }
+
+    public @NotNull String getSatsType() {
+        return satsType;
+    }
+
+    public @NotNull Double getSatsVerdi() {
+        return satsVerdi;
+    }
+
+    public @NotNull LocalDate getGyldigFraOgMed() {
+        return gyldigFraOgMed;
+    }
+
+    public LocalDate getGyldigTilOgMed() {
+        return gyldigTilOgMed;
+    }
+
+    public boolean overlapper(Satser that) {
+        var thisGyldigTilOgMed = this.gyldigTilOgMed == null ? LocalDate.MAX : this.gyldigTilOgMed;
+        var thatGyldigTilOgMed = that.gyldigTilOgMed == null ? LocalDate.MAX : that.gyldigTilOgMed;
+        return this.gyldigFraOgMed.isBefore(thatGyldigTilOgMed) && that.gyldigFraOgMed.isBefore(thisGyldigTilOgMed);
+    }
+
+    @Override
+    public String toString() {
+        return format("Satser(id=%s, type=%s, verdi=%s, fra=%s, til=%s)",
+                id, satsType, satsVerdi, gyldigFraOgMed, gyldigTilOgMed);
+    }
+}

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/satser/SatserController.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/satser/SatserController.java
@@ -1,0 +1,42 @@
+package no.nav.tag.tiltaksgjennomforing.satser;
+
+import no.nav.security.token.support.core.api.ProtectedWithClaims;
+import no.nav.security.token.support.core.api.Unprotected;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Set;
+
+@RestController
+@RequestMapping("/satser")
+class SatserController {
+    private final SatsService satsService;
+
+    SatserController(SatsService satsService) {
+        this.satsService = satsService;
+    }
+
+    @Unprotected
+    @GetMapping("/sats/{satsType}")
+    Sats hentSatser(@PathVariable("satsType") String satsType) {
+        return satsService.hentSats(satsType.toLowerCase());
+    }
+
+    @ProtectedWithClaims(issuer = "aad")
+    @PostMapping("/sats/{satsType}")
+    ResponseEntity<Void> settInnSats(@PathVariable("satsType") String satsType, @RequestBody SatsPeriodeData satsPeriodeData) {
+        satsService.opprettNySats(satsType.toLowerCase(), satsPeriodeData);
+        return ResponseEntity.status(201).body(null);
+    }
+
+    @Unprotected
+    @GetMapping("/typer")
+    public Set<String> satseTyper() {
+        return satsService.hentSatsetyper();
+    }
+}

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/satser/SatserRepository.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/satser/SatserRepository.java
@@ -1,0 +1,14 @@
+package no.nav.tag.tiltaksgjennomforing.satser;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+import java.util.Set;
+
+interface SatserRepository extends JpaRepository<Satser, Integer> {
+    List<Satser> findAllBySatsType(String satsType);
+
+    @Query("select distinct(satsType) from Satser")
+    Set<String> finnSatsetyper();
+}

--- a/src/main/resources/db/migration/V107__satsetabellen.sql
+++ b/src/main/resources/db/migration/V107__satsetabellen.sql
@@ -1,0 +1,14 @@
+begin;
+
+create table satser (
+    id uuid primary key,
+    sats_type varchar(255) not null,
+    sats_verdi numeric not null,
+    gyldig_fra_og_med date not null,
+    gyldig_til_og_med date,
+    opprettet_tidspunkt timestamp with time zone not null default now()
+);
+
+create index satser_satstype_idx on satser(sats_type);
+
+commit;

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleApiTestUtil.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleApiTestUtil.java
@@ -21,7 +21,7 @@ import java.util.stream.Stream;
 
 import static java.lang.String.format;
 
-class AvtaleApiTestUtil {
+public class AvtaleApiTestUtil {
 
     private static String tokenRequest(String url) {
         try {
@@ -40,7 +40,7 @@ class AvtaleApiTestUtil {
         return tokenRequest(format("https://tiltak-fakelogin.ekstern.dev.nav.no/token?pid=%s&aud=fake-tokenx&iss=tokenx&acr=Level4", fnr.asString()));
     }
 
-    static String lagTokenForNavIdent(NavIdent navIdent) {
+    public static String lagTokenForNavIdent(NavIdent navIdent) {
         return tokenRequest(format("https://tiltak-fakelogin.ekstern.dev.nav.no/token?NAVident=%s&aud=fake-aad&iss=aad&acr=Level4", navIdent.asString()));
     }
 

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/satser/SatsTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/satser/SatsTest.java
@@ -1,0 +1,82 @@
+package no.nav.tag.tiltaksgjennomforing.satser;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class SatsTest {
+
+    @Test
+    void henterUtBelopTest() {
+        var sats = new Sats("VTAO", List.of(
+                new Satser(
+                        "VTAO",
+                        6000.0,
+                        LocalDate.of(2021, 1, 1),
+                        LocalDate.of(2021, 12, 31)),
+                new Satser(
+                        "VTAO",
+                        6500.0,
+                        LocalDate.of(2022, 1, 1),
+                        LocalDate.of(2022, 12, 31)),
+                new Satser(
+                        "VTAO",
+                        8000.0,
+                        LocalDate.of(2024, 1, 1),
+                        null
+                )));
+        assertEquals(
+                6500.0,
+                sats.hentGjeldendeSats(LocalDate.of(2022, 4, 1)),
+                "Henter riktig sats innenfor perioden");
+        assertEquals(
+                6500.0,
+                sats.hentGjeldendeSats(LocalDate.of(2022, 1, 1)),
+                "Henter riktig sats på starten av perioden");
+        assertEquals(
+                6500.0,
+                sats.hentGjeldendeSats(LocalDate.of(2022, 12, 31)),
+                "Henter sats for enden av perioden");
+        assertEquals(
+                8000.0,
+                sats.hentGjeldendeSats(LocalDate.of(4000, 12, 31)),
+                "Henter sats for åpen periode");
+        assertNull(
+                sats.hentGjeldendeSats(LocalDate.of(1000, 12, 31)),
+                "Henter sats før kjente perioder"
+        );
+        assertNull(
+                sats.hentGjeldendeSats(LocalDate.of(2023, 12, 31)),
+                "Kan ikke hente sats for en periode som ikke fins"
+        );
+    }
+
+    @Test
+    void feilerVedDuplisertPeriodeTest() {
+        // Når man oppretter en overlappende periode vil sats-klassen
+        // feile under opprettelse.
+        assertThrows(IllegalStateException.class,
+                () -> new Sats("VTAO", List.of(
+                        new Satser(
+                                "VTAO",
+                                6000.0,
+                                LocalDate.of(2021, 1, 1),
+                                LocalDate.of(2021, 12, 31)),
+                        new Satser(
+                                "VTAO",
+                                6500.0,
+                                LocalDate.of(2022, 1, 1),
+                                LocalDate.of(2022, 12, 31)),
+                        // Dupliser satsperioden ovenfor, som fører til ugyldig tilstand
+                        new Satser(
+                                "VTAO",
+                                700.0,
+                                LocalDate.of(2022, 1, 1),
+                                LocalDate.of(2022, 12, 31)
+                        ))),
+                "Feiler ved henting av sats fordi to overlappende perioder eksisterer");
+    }
+}

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/satser/SatserAPITest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/satser/SatserAPITest.java
@@ -1,0 +1,177 @@
+package no.nav.tag.tiltaksgjennomforing.satser;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import no.nav.tag.tiltaksgjennomforing.Miljø;
+import no.nav.tag.tiltaksgjennomforing.avtale.NavIdent;
+import no.nav.tag.tiltaksgjennomforing.utils.Now;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Set;
+
+import static no.nav.tag.tiltaksgjennomforing.avtale.AvtaleApiTestUtil.lagTokenForNavIdent;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ActiveProfiles(Miljø.TEST)
+@SpringBootTest
+@AutoConfigureMockMvc
+public class SatserAPITest {
+    @Autowired
+    SatserController satserController;
+    @Autowired
+    SatserRepository satserRepository;
+    @Autowired
+    private MockMvc mockMvc;
+
+    private final ObjectMapper objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
+
+    @AfterEach
+    void tearDown() {
+        satserRepository.deleteAll();
+        Now.resetClock();
+    }
+
+    @Test
+    public void settInnVTAOSatsTest() throws Exception {
+        settInnSats(new SatsPeriodeData(
+                6000.0,
+                LocalDate.parse("2021-01-01"),
+                LocalDate.parse("2021-12-31")
+        ));
+
+        settInnSats(new SatsPeriodeData(
+                6500.0,
+                LocalDate.parse("2022-01-01"),
+                LocalDate.parse("2022-12-31")
+        ));
+
+        var resultat = satserController.hentSatser("VTAO");
+        assertEquals(
+                new Sats("vtao", List.of(
+                        new Satser(
+                                "VTAO",
+                                6000.0,
+                                LocalDate.of(2021, 1, 1),
+                                LocalDate.of(2021, 12, 31)),
+                        new Satser(
+                                "VTAO",
+                                6500.0,
+                                LocalDate.of(2022, 1, 1),
+                                LocalDate.of(2022, 12, 31))
+                )),
+                resultat);
+    }
+
+    private void settInnSats(SatsPeriodeData vtao) throws Exception {
+        postForNavIdent(
+                "/satser/sats/vtao",
+                objectMapper.writeValueAsString(vtao),
+                "X123456"
+        ).andExpect(status().is(201));
+    }
+
+    @Test
+    public void settInnOverlappendeVTAOSatsFeilerTest() {
+        var opprinneligSats = new SatsPeriodeData(
+                6000.0,
+                LocalDate.parse("2021-01-01"),
+                LocalDate.parse("2021-12-31")
+        );
+
+        satserController.settInnSats("VTAO", opprinneligSats);
+
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> satserController.settInnSats("VTAO", new SatsPeriodeData(
+                        6500.0,
+                        LocalDate.parse("2020-12-31"),
+                        LocalDate.parse("2022-01-01")
+                )), "Sett inn samme periode på ny");
+
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> satserController.settInnSats("VTAO", new SatsPeriodeData(
+                        6500.0,
+                        LocalDate.parse("2021-03-31"),
+                        LocalDate.parse("2021-11-30")
+                )), "Sett inn periode som 'innerlapper' perioden");
+
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> satserController.settInnSats("VTAO", new SatsPeriodeData(
+                        6500.0,
+                        LocalDate.parse("2021-10-01"),
+                        LocalDate.parse("2022-12-31")
+                )), "Sett inn periode som overlapper mot enden av perioden");
+
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> satserController.settInnSats("VTAO", new SatsPeriodeData(
+                        6500.0,
+                        LocalDate.parse("2021-10-01"),
+                        null
+                )), "Sett inn periode som overlapper mot med åpen sluttdato");
+
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> satserController.settInnSats("VTAO", new SatsPeriodeData(
+                        6500.0,
+                        LocalDate.parse("2020-11-01"),
+                        LocalDate.parse("2021-03-31")
+                )), "Sett inn periode som overlapper mot starten av perioden");
+
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> satserController.settInnSats("VTAO", new SatsPeriodeData(
+                        6500.0,
+                        LocalDate.parse("2020-12-31"),
+                        LocalDate.parse("2022-01-01")
+                )), "Sett inn en periode som 'OVERlapper' en annen (dekker perioden)");
+    }
+
+    @Test
+    void hentGjeldendeSatserTest() throws Exception {
+        satserController.settInnSats("VTAO", new SatsPeriodeData(
+                6500.0,
+                LocalDate.parse("2020-12-31"),
+                LocalDate.parse("2022-01-01")));
+        satserController.settInnSats("5G", new SatsPeriodeData(
+                6500.0,
+                LocalDate.parse("2020-12-31"),
+                LocalDate.parse("2022-01-01")));
+
+        getResultat("/satser/typer").andExpectAll(
+                status().is(200),
+                content().json(objectMapper.writeValueAsString(Set.of("vtao", "5g")))
+        );
+    }
+
+    private ResultActions getResultat(String url) throws Exception {
+        return mockMvc.perform(get(url));
+    }
+
+    private ResultActions postForNavIdent(String url, String body, String navIdent) throws Exception {
+        var token = lagTokenForNavIdent(new NavIdent(navIdent));
+
+        return mockMvc.perform(
+                post(url)
+                        .content(body)
+                        .contentType("application/json")
+                        .header("Authorization", "Bearer " + token)
+        );
+    }
+}


### PR DESCRIPTION
For å kunne lagre informasjon om hvilke satser som er gjeldende for ulike perioder, oppretter vi en egen tabell som holder på satser.

Denne vil kunne benyttes til andre satser også (feks 5G), men er foreløpig tiltenkt årssatsen til VTA-O.