### PR TITLE
Ny jsonproperty: kanBehandles

### DIFF
--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/TilskuddPeriode.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/TilskuddPeriode.java
@@ -167,6 +167,7 @@ public class TilskuddPeriode implements Comparable<TilskuddPeriode> {
         setStatus(TilskuddPeriodeStatus.AVSLÅTT);
     }
 
+    @JsonProperty
     public boolean kanBehandles() {
         try {
             sjekkOmKanBehandles();


### PR DESCRIPTION
I stedet for at frontenden må drive med
tidsmatematikk for å avgjøre om beslutter
kan trykke på en knapp, kan frontenden heller
se på et boolean-flagg "kanBehandles".

Denne fasiliterer følgende frontend-endring: https://github.com/navikt/tiltaksgjennomforing/pull/1261