### PR TITLE
Lite-versjon av satsetabell

### DIFF
--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/InkluderingstilskuddStrategy.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/InkluderingstilskuddStrategy.java
@@ -7,21 +7,16 @@ import java.time.LocalDate;
 import java.util.HashMap;
 import java.util.Map;
 
-public class InkluderingstilskuddStrategy extends BaseAvtaleInnholdStrategy {
+import static no.nav.tag.tiltaksgjennomforing.satser.Sats.INKLUDERINGSTILSKUDD_SATS;
 
-    private final static LocalDate FØRSTE_JAN_2024 = LocalDate.of(2024, 1, 1);
-    private final static int INKLUDERINGSTILSKUDD_SATS_2024 = 149_100;
-    private final static int INKLUDERINGSTILSKUDD_SATS_2023 = 143_900;
+public class InkluderingstilskuddStrategy extends BaseAvtaleInnholdStrategy {
 
     public InkluderingstilskuddStrategy(AvtaleInnhold avtaleInnhold){
         super(avtaleInnhold);
     }
 
-    public static int getInkluderingstilskuddSats(LocalDate sluttDato) {
-        if (sluttDato != null && FØRSTE_JAN_2024.isAfter(sluttDato)) {
-            return INKLUDERINGSTILSKUDD_SATS_2023;
-        }
-        return INKLUDERINGSTILSKUDD_SATS_2024;
+    public static Integer getInkluderingstilskuddSats(LocalDate sluttDato) {
+        return INKLUDERINGSTILSKUDD_SATS.hentGjeldendeSats(sluttDato == null ? LocalDate.MAX : sluttDato);
     }
 
     @Override

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/satser/Sats.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/satser/Sats.java
@@ -1,0 +1,111 @@
+package no.nav.tag.tiltaksgjennomforing.satser;
+
+import java.time.LocalDate;
+import java.time.Month;
+import java.time.Year;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.NavigableMap;
+import java.util.Objects;
+import java.util.TreeMap;
+
+public class Sats {
+
+    public static final Sats INKLUDERINGSTILSKUDD_SATS = new Sats(List.of(
+            new SatsPeriodeData(
+                    149_100,
+                    LocalDate.of(2024, 1, 1),
+                    null
+            ),
+            new SatsPeriodeData(
+                    143_900,
+                    LocalDate.of(2000, 1, 1),
+                    LocalDate.of(2023, 12, 31)
+            )
+    ));
+
+    public static final Sats VTAO_SATS = new Sats(List.of(
+            new SatsPeriodeData(
+                    6_808,
+                    LocalDate.of(2024, 1, 1),
+                    LocalDate.of(2024, 12, 31)
+            ), new SatsPeriodeData(
+                    6_428,
+                    LocalDate.of(2023, 1, 1),
+                    LocalDate.of(2023, 12, 31)
+            ), new SatsPeriodeData(
+                    6_241,
+                    LocalDate.of(2022, 1, 1),
+                    LocalDate.of(2022, 12, 31)
+            )
+    ));
+
+    private final NavigableMap<LocalDate, Integer> satsePerioder;
+
+    Sats(List<SatsPeriodeData> satserEntitet) {
+        this.satsePerioder = lagPeriodesett(satserEntitet);
+    }
+
+    public NavigableMap<LocalDate, Integer> getSatsePerioder() {
+        return satsePerioder;
+    }
+
+    public Integer hentGjeldendeSats(LocalDate dato) {
+        var entry = satsePerioder.floorEntry(dato);
+        return entry == null ? null : entry.getValue();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        Sats sats = (Sats) o;
+        return Objects.equals(satsePerioder, sats.satsePerioder);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(satsePerioder);
+    }
+
+    @Override
+    public String toString() {
+        var string = new StringBuilder("Sats:\n");
+        var satseperiodeEntryset = new ArrayList<>(this.satsePerioder.entrySet());
+        for (int i = 0; i < satseperiodeEntryset.size() - 1; i++) {
+            string.append(satseperiodeEntryset.get(i).getKey());
+            string.append("\t");
+            string.append(satseperiodeEntryset.get(i + 1).getKey().minusDays(1));
+            string.append(":\t");
+            string.append(satseperiodeEntryset.get(i).getValue());
+            string.append("\n");
+        }
+        if (!satseperiodeEntryset.isEmpty()) {
+            var sistePeriode = satseperiodeEntryset.getLast();
+            string.append(sistePeriode.getKey());
+            string.append("\t");
+            string.append(LocalDate.MAX);
+            string.append(":\t");
+            string.append(sistePeriode.getValue());
+            string.append("\n");
+        }
+        return string.toString();
+    }
+
+    static NavigableMap<LocalDate, Integer> lagPeriodesett(List<SatsPeriodeData> satserEntitet) {
+        NavigableMap<LocalDate, Integer> m = new TreeMap<>();
+
+        satserEntitet.stream()
+                .sorted(Comparator.comparing(SatsPeriodeData::gyldigFraOgMed))
+                .forEach(sats -> {
+                    m.put(sats.gyldigFraOgMed(), sats.satsVerdi());
+                    if (sats.gyldigTilOgMed() != null) {
+                        m.put(sats.gyldigTilOgMed().plusDays(1), null);
+                    }
+                });
+
+        return m;
+    }
+}

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/satser/SatsPeriodeData.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/satser/SatsPeriodeData.java
@@ -1,0 +1,10 @@
+package no.nav.tag.tiltaksgjennomforing.satser;
+
+import java.time.LocalDate;
+
+public record SatsPeriodeData(
+        Integer satsVerdi,
+        LocalDate gyldigFraOgMed,
+        LocalDate gyldigTilOgMed
+) {
+}


### PR DESCRIPTION
I stedet for å opprette en databasetabell
for satser, som medfører en stor refaktorering
av løsningen for å kunne ta i bruk, kan vi bruke
singleton-objekter i stedet.

Ulempen her er at vi må redeploye appen for å
få inn nye års satser, men fordelen er at objektene
gjør oppslag litt enklere, slik vi ser i endringen
i InkluderingstilskuddStrategy-klassen.