### PR TITLE
Forkortet grunn på datadeling kafka-topics

### DIFF
--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/datadeling/AvtaleHendelseLytter.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/datadeling/AvtaleHendelseLytter.java
@@ -64,7 +64,8 @@ public class AvtaleHendelseLytter {
 
     @EventListener
     public void avtaleForkortet(AvtaleForkortet event) {
-        lagHendelse(event.getAvtale(), HendelseType.AVTALE_FORKORTET, event.getUtførtAv(), AvtaleHendelseUtførtAvRolle.VEILEDER);
+        String forkortetGrunn = event.getAnnetGrunn() != null ? event.getAnnetGrunn() : event.getGrunn();
+        lagHendelse(event.getAvtale(), HendelseType.AVTALE_FORKORTET, event.getUtførtAv(), AvtaleHendelseUtførtAvRolle.VEILEDER, forkortetGrunn);
     }
 
     @EventListener
@@ -168,10 +169,14 @@ public class AvtaleHendelseLytter {
     }
 
     private void lagHendelse(Avtale avtale, HendelseType hendelseType, Identifikator utførtAv, AvtaleHendelseUtførtAvRolle utførtAvRolle) {
+        lagHendelse(avtale, hendelseType, utførtAv, utførtAvRolle, null);
+    }
+    private void lagHendelse(Avtale avtale, HendelseType hendelseType, Identifikator utførtAv, AvtaleHendelseUtførtAvRolle utførtAvRolle, String forkortetGrunn) {
         LocalDateTime tidspunkt = Now.localDateTime();
         UUID meldingId = UUID.randomUUID();
 
         var melding = AvtaleMelding.create(avtale, avtale.getGjeldendeInnhold(), utførtAv, utførtAvRolle, hendelseType);
+        melding.setForkortetGrunn(forkortetGrunn);
         try {
             String meldingSomString = objectMapper.writeValueAsString(melding);
             AvtaleMeldingEntitet entitet = new AvtaleMeldingEntitet(meldingId, avtale.getId(), tidspunkt, hendelseType, avtale.statusSomEnum(), meldingSomString);

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/datadeling/AvtaleMelding.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/datadeling/AvtaleMelding.java
@@ -117,6 +117,7 @@ public class AvtaleMelding {
     AvtaleInnholdType innholdType;
     Identifikator utførtAv;
     AvtaleHendelseUtførtAvRolle utførtAvRolle;
+    String forkortetGrunn;
 
     public static AvtaleMelding create(Avtale avtale, AvtaleInnhold avtaleInnhold, Identifikator utførtAv, AvtaleHendelseUtførtAvRolle utførtAvAvtaleRolle, HendelseType hendelseType) {
 


### PR DESCRIPTION
Team Arena skulle gjerne hatt med grunn til forkortelse, da de har ulike statuser og ytelser som skal behandles ulikt avhengig av årsak, bla. kan de velge å sende ut "vurder konsekvens for ytelse" ting.