### PR TITLE
feat. oppdatere henting av Arena data til skyggetabeller

### DIFF
--- a/nais/prod-fss.yaml
+++ b/nais/prod-fss.yaml
@@ -40,12 +40,13 @@ spec:
     failureThreshold: 10
   replicas:
     min: 3
+    max: 10
   resources:
     limits:
       cpu: 2000m
       memory: 12000Mi
     requests:
-      cpu: 500m
+      cpu: 1000m
       memory: 6000Mi
   ingresses:
     - https://arbeidsgiver.nais.adeo.no/tiltaksgjennomforing-api/

--- a/nais/prod-fss.yaml
+++ b/nais/prod-fss.yaml
@@ -40,13 +40,12 @@ spec:
     failureThreshold: 10
   replicas:
     min: 3
-    max: 10
   resources:
     limits:
       cpu: 2000m
       memory: 12000Mi
     requests:
-      cpu: 1000m
+      cpu: 500m
       memory: 6000Mi
   ingresses:
     - https://arbeidsgiver.nais.adeo.no/tiltaksgjennomforing-api/

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/arena/client/ords/ArenaOrdsClient.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/arena/client/ords/ArenaOrdsClient.java
@@ -30,7 +30,7 @@ public class ArenaOrdsClient {
     }
 
     public Optional<ArenaOrdsFnrResponse> getFnr(int personId) {
-        ArenaOrdsFnrRequest request = new ArenaOrdsFnrRequest(List.of(personId));
+        ArenaOrdsFnrRequest request = new ArenaOrdsFnrRequest(List.of(new ArenaOrdsFnrRequest.Person(personId)));
 
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_JSON);

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/arena/client/ords/ArenaOrdsFnrRequest.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/arena/client/ords/ArenaOrdsFnrRequest.java
@@ -2,6 +2,6 @@ package no.nav.tag.tiltaksgjennomforing.arena.client.ords;
 
 import java.util.List;
 
-public record ArenaOrdsFnrRequest(
-    List<Integer> personListe
-) { }
+public record ArenaOrdsFnrRequest(List<Person> personListe) {
+    public record Person(Integer personId) {}
+}

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/arena/client/ords/ArenaOrdsFnrResponse.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/arena/client/ords/ArenaOrdsFnrResponse.java
@@ -2,12 +2,6 @@ package no.nav.tag.tiltaksgjennomforing.arena.client.ords;
 
 import java.util.List;
 
-public record ArenaOrdsFnrResponse(
-    List<Person> personListe
-) {
-    public record Person(
-        Integer personId,
-        String fnr
-    ) {
-    }
+public record ArenaOrdsFnrResponse(List<Person> personListe) {
+    public record Person(Integer personId, String fnr) {}
 }

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/arena/configuration/ArenaKafkaConsumerConfig.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/arena/configuration/ArenaKafkaConsumerConfig.java
@@ -27,7 +27,7 @@ public class ArenaKafkaConsumerConfig {
 
     private ConsumerFactory<String, String> consumerFactory(KafkaProperties kafkaProperties) {
         Map<String, Object> props = kafkaProperties.buildConsumerProperties(null);
-        props.put(ConsumerConfig.GROUP_ID_CONFIG, "tiltaksgjennomforing-api-2");
+        props.put(ConsumerConfig.GROUP_ID_CONFIG, "tiltaksgjennomforing-api-3");
         return new DefaultKafkaConsumerFactory<>(props);
     }
 }

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/arena/configuration/ArenaKafkaConsumerConfig.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/arena/configuration/ArenaKafkaConsumerConfig.java
@@ -27,7 +27,7 @@ public class ArenaKafkaConsumerConfig {
 
     private ConsumerFactory<String, String> consumerFactory(KafkaProperties kafkaProperties) {
         Map<String, Object> props = kafkaProperties.buildConsumerProperties(null);
-        props.put(ConsumerConfig.GROUP_ID_CONFIG, "tiltaksgjennomforing-api-3");
+        props.put(ConsumerConfig.GROUP_ID_CONFIG, "tiltaksgjennomforing-api-2");
         return new DefaultKafkaConsumerFactory<>(props);
     }
 }

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/arena/configuration/ArenaKafkaConsumerConfig.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/arena/configuration/ArenaKafkaConsumerConfig.java
@@ -27,7 +27,7 @@ public class ArenaKafkaConsumerConfig {
 
     private ConsumerFactory<String, String> consumerFactory(KafkaProperties kafkaProperties) {
         Map<String, Object> props = kafkaProperties.buildConsumerProperties(null);
-        props.put(ConsumerConfig.GROUP_ID_CONFIG, "tiltaksgjennomforing-api-1");
+        props.put(ConsumerConfig.GROUP_ID_CONFIG, "tiltaksgjennomforing-api-2");
         return new DefaultKafkaConsumerFactory<>(props);
     }
 }

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/arena/job/ArenaAgreementJob.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/arena/job/ArenaAgreementJob.java
@@ -26,7 +26,7 @@ public class ArenaAgreementJob {
         this.featureToggleService = featureToggleService;
     }
 
-    @Scheduled(fixedDelay = 30, timeUnit = TimeUnit.SECONDS)
+    @Scheduled(fixedRate = 30, timeUnit = TimeUnit.SECONDS)
     public void run() {
         if (!featureToggleService.isEnabled(FeatureToggle.ARENA_AVTALE_JOBB)) {
             return;

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/arena/job/ArenaEventProcessingJob.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/arena/job/ArenaEventProcessingJob.java
@@ -2,7 +2,7 @@ package no.nav.tag.tiltaksgjennomforing.arena.job;
 
 import no.nav.tag.tiltaksgjennomforing.Miljø;
 import no.nav.tag.tiltaksgjennomforing.arena.models.event.ArenaEvent;
-import no.nav.tag.tiltaksgjennomforing.arena.service.ArenaEventRetryService;
+import no.nav.tag.tiltaksgjennomforing.arena.service.ArenaEventProcessingJobService;
 import no.nav.tag.tiltaksgjennomforing.featuretoggles.FeatureToggle;
 import no.nav.tag.tiltaksgjennomforing.featuretoggles.FeatureToggleService;
 import org.springframework.context.annotation.Profile;
@@ -14,28 +14,28 @@ import java.util.concurrent.TimeUnit;
 
 @Component
 @Profile({ Miljø.DEV_FSS, Miljø.PROD_FSS })
-public class ArenaEventRetryJob {
-    private final ArenaEventRetryService arenaEventRetryService;
+public class ArenaEventProcessingJob {
+    private final ArenaEventProcessingJobService arenaEventRetryService;
     private final FeatureToggleService featureToggleService;
 
-    public ArenaEventRetryJob(
-        ArenaEventRetryService arenaEventRetryService,
+    public ArenaEventProcessingJob(
+        ArenaEventProcessingJobService arenaEventRetryService,
         FeatureToggleService featureToggleService
     ) {
         this.arenaEventRetryService = arenaEventRetryService;
         this.featureToggleService = featureToggleService;
     }
 
-    @Scheduled(fixedDelay = 60, timeUnit = TimeUnit.SECONDS)
+    @Scheduled(fixedDelay = 30, timeUnit = TimeUnit.SECONDS)
     public void run() {
-        if (!featureToggleService.isEnabled(FeatureToggle.ARENA_KAFKA)) {
+        if (!featureToggleService.isEnabled(FeatureToggle.ARENA_PROSESSERINGS_JOBB)) {
             return;
         }
 
-        List<ArenaEvent> arenaEvents = arenaEventRetryService.getAndUpdateRetryEvents();
+        List<ArenaEvent> arenaEvents = arenaEventRetryService.getAndUpdateEvents();
 
         if (!arenaEvents.isEmpty()) {
-            arenaEventRetryService.retry(arenaEvents);
+            arenaEventRetryService.process(arenaEvents);
         }
     }
 

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/arena/job/ArenaEventProcessingJob.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/arena/job/ArenaEventProcessingJob.java
@@ -26,7 +26,7 @@ public class ArenaEventProcessingJob {
         this.featureToggleService = featureToggleService;
     }
 
-    @Scheduled(fixedDelay = 30, timeUnit = TimeUnit.SECONDS)
+    @Scheduled(fixedRate = 60, timeUnit = TimeUnit.SECONDS)
     public void run() {
         if (!featureToggleService.isEnabled(FeatureToggle.ARENA_PROSESSERINGS_JOBB)) {
             return;

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/arena/kafka/ArenaKafkaConsumer.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/arena/kafka/ArenaKafkaConsumer.java
@@ -33,7 +33,7 @@ public class ArenaKafkaConsumer {
     public void arenaTiltakgjennomforingEndret(ConsumerRecord<String, String> record) {
         if (featureToggleService.isEnabled(FeatureToggle.ARENA_KAFKA)) {
             log.info("Mottatt melding for {}: {}", arenaKafkaProperties.getTiltakgjennomforingEndretTopic(), record.key());
-            arenaEventProcessingService.process(record.key(), record.value());
+            arenaEventProcessingService.create(record.key(), record.value());
         }
     }
 
@@ -41,7 +41,7 @@ public class ArenaKafkaConsumer {
     public void arenaTiltakdeltakerEndret(ConsumerRecord<String, String> record) {
         if (featureToggleService.isEnabled(FeatureToggle.ARENA_KAFKA)) {
             log.info("Mottatt melding for {}: {}", arenaKafkaProperties.getTiltakdeltakerEndretTopic(), record.key());
-            arenaEventProcessingService.process(record.key(), record.value());
+            arenaEventProcessingService.create(record.key(), record.value());
         }
     }
 
@@ -49,7 +49,7 @@ public class ArenaKafkaConsumer {
     public void arenaTiltaksakEndret(ConsumerRecord<String, String> record) {
         if (featureToggleService.isEnabled(FeatureToggle.ARENA_KAFKA)) {
             log.info("Mottatt melding for {}: {}", arenaKafkaProperties.getTiltakssakEndretTopic(), record.key());
-            arenaEventProcessingService.process(record.key(), record.value());
+            arenaEventProcessingService.create(record.key(), record.value());
         }
     }
 }

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/arena/models/event/ArenaEventStatus.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/arena/models/event/ArenaEventStatus.java
@@ -1,6 +1,7 @@
 package no.nav.tag.tiltaksgjennomforing.arena.models.event;
 
 public enum ArenaEventStatus {
+    CREATED,
     PENDING,
     PROCESSING,
     DONE,

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/arena/repository/ArenaEventRepository.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/arena/repository/ArenaEventRepository.java
@@ -15,11 +15,11 @@ public interface ArenaEventRepository extends JpaRepository<ArenaEvent, UUID> {
     Optional<ArenaEvent> findByArenaIdAndArenaTable(String arenaId, String arenaTable);
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
-    @Query("SELECT ae FROM ArenaEvent ae WHERE ae.status = 'CREATED' ORDER BY ae.operationTime ASC LIMIT 100")
+    @Query("SELECT ae FROM ArenaEvent ae WHERE ae.status = 'CREATED' ORDER BY ae.operationTime ASC LIMIT 10")
     List<ArenaEvent> findNewEventsForProcessing();
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
-    @Query("SELECT ae FROM ArenaEvent ae WHERE ae.status = 'RETRY' ORDER BY random() LIMIT 100")
+    @Query("SELECT ae FROM ArenaEvent ae WHERE ae.status = 'RETRY' ORDER BY random() LIMIT 10")
     List<ArenaEvent> findRetryEventsForProcessing();
 
 }

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/arena/repository/ArenaEventRepository.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/arena/repository/ArenaEventRepository.java
@@ -15,7 +15,7 @@ public interface ArenaEventRepository extends JpaRepository<ArenaEvent, UUID> {
     Optional<ArenaEvent> findByArenaIdAndArenaTable(String arenaId, String arenaTable);
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
-    @Query("SELECT ae FROM ArenaEvent ae WHERE ae.status = 'RETRY' ORDER BY random() LIMIT 100")
-    List<ArenaEvent> findRetryEvents();
+    @Query("SELECT ae FROM ArenaEvent ae WHERE ae.status = 'RETRY' OR ae.status = 'CREATED' ORDER BY random() LIMIT 100")
+    List<ArenaEvent> findEventsToProcess();
 
 }

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/arena/repository/ArenaEventRepository.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/arena/repository/ArenaEventRepository.java
@@ -2,6 +2,7 @@ package no.nav.tag.tiltaksgjennomforing.arena.repository;
 
 import jakarta.persistence.LockModeType;
 import no.nav.tag.tiltaksgjennomforing.arena.models.event.ArenaEvent;
+import no.nav.tag.tiltaksgjennomforing.arena.models.event.ArenaEventStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
@@ -15,7 +16,7 @@ public interface ArenaEventRepository extends JpaRepository<ArenaEvent, UUID> {
     Optional<ArenaEvent> findByArenaIdAndArenaTable(String arenaId, String arenaTable);
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
-    @Query("SELECT ae FROM ArenaEvent ae WHERE ae.status = 'RETRY' OR ae.status = 'CREATED' ORDER BY random() LIMIT 100")
-    List<ArenaEvent> findEventsToProcess();
+    @Query("SELECT ae FROM ArenaEvent ae WHERE ae.status = :status ORDER BY random() LIMIT 100")
+    List<ArenaEvent> findEventsToProcessByStatus(ArenaEventStatus status);
 
 }

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/arena/repository/ArenaEventRepository.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/arena/repository/ArenaEventRepository.java
@@ -2,7 +2,6 @@ package no.nav.tag.tiltaksgjennomforing.arena.repository;
 
 import jakarta.persistence.LockModeType;
 import no.nav.tag.tiltaksgjennomforing.arena.models.event.ArenaEvent;
-import no.nav.tag.tiltaksgjennomforing.arena.models.event.ArenaEventStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
@@ -16,7 +15,11 @@ public interface ArenaEventRepository extends JpaRepository<ArenaEvent, UUID> {
     Optional<ArenaEvent> findByArenaIdAndArenaTable(String arenaId, String arenaTable);
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
-    @Query("SELECT ae FROM ArenaEvent ae WHERE ae.status = :status ORDER BY random() LIMIT 100")
-    List<ArenaEvent> findEventsToProcessByStatus(ArenaEventStatus status);
+    @Query("SELECT ae FROM ArenaEvent ae WHERE ae.status = 'CREATED' ORDER BY ae.operationTime ASC LIMIT 100")
+    List<ArenaEvent> findNewEventsForProcessing();
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT ae FROM ArenaEvent ae WHERE ae.status = 'RETRY' ORDER BY random() LIMIT 100")
+    List<ArenaEvent> findRetryEventsForProcessing();
 
 }

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/arena/service/ArenaEventProcessingJobService.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/arena/service/ArenaEventProcessingJobService.java
@@ -13,13 +13,13 @@ import java.util.List;
 
 @Slf4j
 @Service
-public class ArenaEventRetryService {
+public class ArenaEventProcessingJobService {
     private final static int MAX_RETRY_COUNT = 4;
 
     private final ArenaEventRepository arenaEventRepository;
     private final ArenaEventProcessingService arenaEventProcessingService;
 
-    public ArenaEventRetryService(
+    public ArenaEventProcessingJobService(
         ArenaEventRepository arenaEventRepository,
         ArenaEventProcessingService arenaEventProcessingService
     ) {
@@ -28,8 +28,8 @@ public class ArenaEventRetryService {
     }
 
     @Transactional
-    public List<ArenaEvent> getAndUpdateRetryEvents() {
-        List<ArenaEvent> retryEvents = arenaEventRepository.findRetryEvents();
+    public List<ArenaEvent> getAndUpdateEvents() {
+        List<ArenaEvent> retryEvents = arenaEventRepository.findEventsToProcess();
         failEventsThatHaveReachedMaxRetryCount(retryEvents);
 
         return retryEvents
@@ -45,7 +45,7 @@ public class ArenaEventRetryService {
             .toList();
     }
 
-    public void retry(List<ArenaEvent> arenaEvents) {
+    public void process(List<ArenaEvent> arenaEvents) {
         log.info("Kjører retry på {} eventer", arenaEvents.size());
 
         for (ArenaEvent arenaEvent : arenaEvents) {

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/arena/service/ArenaEventProcessingJobService.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/arena/service/ArenaEventProcessingJobService.java
@@ -54,13 +54,8 @@ public class ArenaEventProcessingJobService {
     }
 
     private List<ArenaEvent> findEventsForProcessing() {
-        List<ArenaEvent> events = arenaEventRepository.findEventsToProcessByStatus(ArenaEventStatus.CREATED);
-
-        if (!events.isEmpty()) {
-            return events;
-        }
-
-        return arenaEventRepository.findEventsToProcessByStatus(ArenaEventStatus.RETRY);
+        List<ArenaEvent> events = arenaEventRepository.findNewEventsForProcessing();
+        return events.isEmpty() ? arenaEventRepository.findRetryEventsForProcessing() : events;
     }
 
     private void failEventsThatHaveReachedMaxRetryCount(List<ArenaEvent> arenaEvents) {

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/featuretoggles/FeatureToggle.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/featuretoggles/FeatureToggle.java
@@ -6,6 +6,7 @@ public enum FeatureToggle {
     ARBEIDSGIVERNOTIFIKASJON_MED_SAK_OG_SMS("arbeidsgivernotifikasjon-med-sak-og-sms"),
     SMS_TIL_MOBILNUMMER("sms-til-mobilnummer"),
     ARENA_AVTALE_JOBB("arenaAvtaleJobb"),
+    ARENA_PROSESSERINGS_JOBB("arenaProsesseringsJobb"),
     ARENA_KAFKA("arenaKafka"),
     ARBEIDSTRENING_READONLY("arbeidstreningReadonly"),
     PABEGYNT_AVTALE_RYDDE_JOBB("pabegyntAvtaleRyddeJobb"),;


### PR DESCRIPTION
Denne endringen gjør at vi kun lagrer meldinger fra Arena Kafka og deretter prosseserer dem i en egen jobb. Dette vil gjøre at vi får mindre feil og at ting går litt smidigere.

ORDS tjenesten for Arena ble også fikset - vi sendte ikke korrekt request. 

Til slutt resetter group-id for lesing.