### PR TITLE
Legg til tiltakstyper som filterargument

### DIFF
--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleQueryParameter.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleQueryParameter.java
@@ -2,10 +2,13 @@ package no.nav.tag.tiltaksgjennomforing.avtale;
 
 import lombok.Data;
 import lombok.experimental.Accessors;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -17,20 +20,28 @@ public class AvtaleQueryParameter {
     private NavIdent veilederNavIdent;
     private BedriftNr bedriftNr;
     private Fnr deltakerFnr;
+    @Nullable
     private Tiltakstype tiltakstype;
+    @Nullable
+    private List<Tiltakstype> tiltakstyper;
     private Status status;
     private Boolean erUfordelt;
     private TilskuddPeriodeStatus tilskuddPeriodeStatus;
     private String navEnhet;
     private Integer avtaleNr;
 
+    @NotNull
+    public List<Tiltakstype> getTiltakstyper() {
+        return tiltakstyper == null ? Collections.emptyList() : tiltakstyper;
+    }
+
     public boolean harFilterPaEnEntitet() {
         return erUfordelt != null ||
-            veilederNavIdent != null ||
-            bedriftNr != null ||
-            deltakerFnr != null ||
-            navEnhet != null ||
-            avtaleNr != null;
+                veilederNavIdent != null ||
+                bedriftNr != null ||
+                deltakerFnr != null ||
+                navEnhet != null ||
+                avtaleNr != null;
     }
 
     public boolean erUfordelt() {
@@ -42,6 +53,7 @@ public class AvtaleQueryParameter {
                 , Objects.toString(bedriftNr, "")
                 , Objects.toString(deltakerFnr, "")
                 , Objects.toString(tiltakstype, "")
+                , Objects.toString(tiltakstyper, "")
                 , Objects.toString(status, "")
                 , Objects.toString(erUfordelt, "")
                 , Objects.toString(tilskuddPeriodeStatus, "")

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleRepository.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleRepository.java
@@ -36,7 +36,7 @@ public interface AvtaleRepository extends JpaRepository<Avtale, UUID>, JpaSpecif
     Page<Avtale> findAllByBedriftNrInAndFeilregistrertIsFalse(Set<BedriftNr> bedriftNrList, Pageable pageable);
 
     @Timed(percentiles = {0.5d, 0.75d, 0.9d, 0.99d, 0.999d})
-    Page<Avtale> findAllByBedriftNrInAndTiltakstypeAndFeilregistrertIsFalse(Set<BedriftNr> bedriftNrList, Tiltakstype tiltakstype, Pageable pageable);
+    Page<Avtale> findAllByBedriftNrInAndTiltakstypeInAndFeilregistrertIsFalse(Set<BedriftNr> bedriftNrList, Set<Tiltakstype> tiltakstyper, Pageable pageable);
 
     @Timed(percentiles = {0.5d, 0.75d, 0.9d, 0.99d, 0.999d})
     Page<Avtale> findAllByDeltakerFnrAndFeilregistrertIsFalse(Fnr deltakerFnr, Pageable pageable);
@@ -156,7 +156,7 @@ public interface AvtaleRepository extends JpaRepository<Avtale, UUID>, JpaSpecif
                   (:deltakerFnr IS NULL OR a.deltakerFnr = :deltakerFnr) AND
                   (:bedriftNr IS NULL OR a.bedriftNr = :bedriftNr) AND
                   (:enhet IS NULL OR a.enhetGeografisk = :enhet OR a.enhetOppfolging = :enhet) AND
-                  (:tiltakstype IS NULL OR a.tiltakstype = :tiltakstype) AND
+                  (:tiltakstype IS NULL OR a.tiltakstype in :tiltakstype) AND
                   (:status IS NULL OR a.status = :status)
         """,
         countQuery = """
@@ -169,7 +169,7 @@ public interface AvtaleRepository extends JpaRepository<Avtale, UUID>, JpaSpecif
                   (:deltakerFnr IS NULL OR a.deltakerFnr = :deltakerFnr) AND
                   (:bedriftNr IS NULL OR a.bedriftNr = :bedriftNr) AND
                   (:enhet IS NULL OR a.enhetGeografisk = :enhet OR a.enhetOppfolging = :enhet) AND
-                  (:tiltakstype IS NULL OR a.tiltakstype = :tiltakstype) AND
+                  (:tiltakstype IS NULL OR a.tiltakstype in :tiltakstype) AND
                   (:status IS NULL OR a.status = :status)
         """
     )
@@ -179,7 +179,7 @@ public interface AvtaleRepository extends JpaRepository<Avtale, UUID>, JpaSpecif
         Fnr deltakerFnr,
         BedriftNr bedriftNr,
         String enhet,
-        Tiltakstype tiltakstype,
+        Set<Tiltakstype> tiltakstype,
         Status status,
         boolean ufordelt,
         Pageable pageable

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/Beslutter.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/Beslutter.java
@@ -21,6 +21,7 @@ import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
 import java.util.EnumSet;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -104,6 +105,7 @@ public class Beslutter extends Avtalepart<NavIdent> implements InternBruker {
 
         TilskuddPeriodeStatus status = queryParametre.getTilskuddPeriodeStatus();
         Tiltakstype tiltakstype = queryParametre.getTiltakstype();
+        List<Tiltakstype> tiltakstyper = queryParametre.getTiltakstyper();
         BedriftNr bedriftNr = queryParametre.getBedriftNr();
         Integer avtaleNr = queryParametre.getAvtaleNr();
         String filtrertNavEnhet = queryParametre.getNavEnhet();
@@ -114,20 +116,22 @@ public class Beslutter extends Avtalepart<NavIdent> implements InternBruker {
             status = TilskuddPeriodeStatus.UBEHANDLET;
         }
 
-        Set<Tiltakstype> tiltakstyper = new HashSet<>();
-        if (tiltakstype != null) {
-            tiltakstyper.add(tiltakstype);
+        Set<Tiltakstype> tiltakstypesett = new HashSet<>();
+        if (!tiltakstyper.isEmpty()) {
+            tiltakstypesett.addAll(tiltakstyper);
+        } else if (tiltakstype != null) {
+            tiltakstypesett.add(tiltakstype);
         } else {
-            tiltakstyper.add(Tiltakstype.SOMMERJOBB);
-            tiltakstyper.add(Tiltakstype.VARIG_LONNSTILSKUDD);
-            tiltakstyper.add(Tiltakstype.MIDLERTIDIG_LONNSTILSKUDD);
-            tiltakstyper.add(Tiltakstype.VTAO);
+            tiltakstypesett.add(Tiltakstype.SOMMERJOBB);
+            tiltakstypesett.add(Tiltakstype.VARIG_LONNSTILSKUDD);
+            tiltakstypesett.add(Tiltakstype.MIDLERTIDIG_LONNSTILSKUDD);
+            tiltakstypesett.add(Tiltakstype.VTAO);
         }
 
         return avtaleRepository.finnGodkjenteAvtalerMedTilskuddsperiodestatusOgNavEnheter(
                 status,
                 decisiondate,
-                tiltakstyper,
+                tiltakstypesett,
                 filtrertNavEnhet != null ? Set.of(filtrertNavEnhet) : navEnheter,
                 bedriftNr != null ? bedriftNr.asString() : null,
                 avtaleNr,

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleRepositoryTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleRepositoryTest.java
@@ -327,7 +327,7 @@ public class AvtaleRepositoryTest {
         Set<BedriftNr> bedriftNrSet = Set.of(lagretAvtale3.getBedriftNr(), lagretAvtale2.getBedriftNr(), lagretAvtale.getBedriftNr());
 
         Page<Avtale> avtalerFunnet = avtaleRepository
-            .findAllByBedriftNrInAndTiltakstypeAndFeilregistrertIsFalse(bedriftNrSet, lagretAvtale.getTiltakstype(), pageable);
+            .findAllByBedriftNrInAndTiltakstypeInAndFeilregistrertIsFalse(bedriftNrSet, Set.of(lagretAvtale.getTiltakstype()), pageable);
 
         assertThat(avtalerFunnet.getContent()).isNotEmpty();
         assertThat(avtalerFunnet.getTotalElements()).isEqualTo(1);
@@ -575,11 +575,11 @@ public class AvtaleRepositoryTest {
         avtale5.setVeilederNavIdent(new NavIdent("E123456"));
         avtaleRepository.save(avtale5);
 
-        Page<Avtale> resultat1 = avtaleRepository.sokEtterAvtale(null, null, null, null, null, Tiltakstype.INKLUDERINGSTILSKUDD, null, false, PageRequest.of(0, 10));
+        Page<Avtale> resultat1 = avtaleRepository.sokEtterAvtale(null, null, null, null, null, Set.of(Tiltakstype.INKLUDERINGSTILSKUDD), null, false, PageRequest.of(0, 10));
         assertThat(resultat1.getContent()).hasSize(1);
         assertThat(resultat1.getContent().getFirst().getId()).isEqualTo(avtale3.getId());
 
-        Page<Avtale> resultat2 = avtaleRepository.sokEtterAvtale(avtale3.getVeilederNavIdent(), null, null, null, null, Tiltakstype.INKLUDERINGSTILSKUDD, null, false, PageRequest.of(0, 10));
+        Page<Avtale> resultat2 = avtaleRepository.sokEtterAvtale(avtale3.getVeilederNavIdent(), null, null, null, null, Set.of(Tiltakstype.INKLUDERINGSTILSKUDD), null, false, PageRequest.of(0, 10));
         assertThat(resultat2.getContent()).hasSize(1);
         assertThat(resultat1.getContent().getFirst().getId()).isEqualTo(avtale3.getId());
     }

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/VeilederTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/VeilederTest.java
@@ -494,7 +494,7 @@ public class VeilederTest {
         query.setTiltakstype(Tiltakstype.MIDLERTIDIG_LONNSTILSKUDD);
         query.setStatus(Status.PÅBEGYNT);
         veileder.hentAlleAvtalerMedMuligTilgang(avtaleRepository, query, Pageable.unpaged());
-        verify(avtaleRepository).sokEtterAvtale(new NavIdent("Z123456"), null, null, null, null, Tiltakstype.MIDLERTIDIG_LONNSTILSKUDD, Status.PÅBEGYNT, false, Pageable.unpaged());
+        verify(avtaleRepository).sokEtterAvtale(new NavIdent("Z123456"), null, null, null, null, Set.of(Tiltakstype.MIDLERTIDIG_LONNSTILSKUDD), Status.PÅBEGYNT, false, Pageable.unpaged());
     }
 
     @Test
@@ -511,7 +511,7 @@ public class VeilederTest {
         query.setTiltakstype(Tiltakstype.MIDLERTIDIG_LONNSTILSKUDD);
         query.setStatus(Status.PÅBEGYNT);
         veileder.hentAlleAvtalerMedMuligTilgang(avtaleRepository, query, Pageable.unpaged());
-        verify(avtaleRepository).sokEtterAvtale(new NavIdent("Z000000"), null, null, null, null, Tiltakstype.MIDLERTIDIG_LONNSTILSKUDD, Status.PÅBEGYNT, false, Pageable.unpaged());
+        verify(avtaleRepository).sokEtterAvtale(new NavIdent("Z000000"), null, null, null, null, Set.of(Tiltakstype.MIDLERTIDIG_LONNSTILSKUDD), Status.PÅBEGYNT, false, Pageable.unpaged());
     }
 
     @Test
@@ -533,7 +533,7 @@ public class VeilederTest {
         query.setStatus(Status.KLAR_FOR_OPPSTART);
         query.setNavEnhet("4802");
         veileder.hentAlleAvtalerMedMuligTilgang(avtaleRepository, query, Pageable.unpaged());
-        verify(avtaleRepository).sokEtterAvtale(null, null, null, null, "4802", Tiltakstype.SOMMERJOBB, Status.KLAR_FOR_OPPSTART, true, Pageable.unpaged());
+        verify(avtaleRepository).sokEtterAvtale(null, null, null, null, "4802", Set.of(Tiltakstype.SOMMERJOBB), Status.KLAR_FOR_OPPSTART, true, Pageable.unpaged());
     }
 
     @Test
@@ -557,6 +557,6 @@ public class VeilederTest {
         query.setTiltakstype(Tiltakstype.ARBEIDSTRENING);
         query.setStatus(Status.MANGLER_GODKJENNING);
         veileder.hentAlleAvtalerMedMuligTilgang(avtaleRepository, query, Pageable.unpaged());
-        verify(avtaleRepository).sokEtterAvtale(new NavIdent("Z000000"), 1, new Fnr("12345678901"), new BedriftNr("123456789"), "4802", Tiltakstype.ARBEIDSTRENING, Status.MANGLER_GODKJENNING, false, Pageable.unpaged());
+        verify(avtaleRepository).sokEtterAvtale(new NavIdent("Z000000"), 1, new Fnr("12345678901"), new BedriftNr("123456789"), "4802", Set.of(Tiltakstype.ARBEIDSTRENING), Status.MANGLER_GODKJENNING, false, Pageable.unpaged());
     }
 }


### PR DESCRIPTION
Frontenden vil kunne sende inn en liste over tiltak som backenden skal slå opp på.

Men vi må i mellomtiden være bakoverkompatibel slik at det fortsatt er mulig å søke på en enkelt tiltakstype