### PR TITLE
feat. forbedring av ryddejobb

### DIFF
--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleRepository.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleRepository.java
@@ -127,13 +127,11 @@ public interface AvtaleRepository extends JpaRepository<Avtale, UUID>, JpaSpecif
             @Param("avtaleNr") Integer avtaleNr,
             Pageable pageable);
 
-    @Query(value = "SELECT avtale.* " +
-            "FROM avtale, avtale_innhold " +
-            "WHERE avtale.gjeldende_innhold_id = avtale_innhold.id " +
-            "AND avtale_innhold.avtale_inngått IS NULL " +
-            "AND avtale.annullert_tidspunkt IS NULL " +
-            "AND avtale.avbrutt IS FALSE",
-            nativeQuery = true)
+    @Query("""
+        SELECT a
+        FROM Avtale a
+        WHERE a.status = no.nav.tag.tiltaksgjennomforing.avtale.Status.PÅBEGYNT OR a.status = no.nav.tag.tiltaksgjennomforing.avtale.Status.MANGLER_GODKJENNING
+    """)
     List<Avtale> findAvtalerSomErPabegyntEllerManglerGodkjenning();
 
     @Query("""

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/jobber/PabegynteAvtalerRyddeJobb.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/jobber/PabegynteAvtalerRyddeJobb.java
@@ -1,0 +1,32 @@
+package no.nav.tag.tiltaksgjennomforing.avtale.jobber;
+
+import lombok.extern.slf4j.Slf4j;
+import no.nav.tag.tiltaksgjennomforing.Miljø;
+import no.nav.tag.tiltaksgjennomforing.avtale.service.PabegynteAvtalerRyddeService;
+import no.nav.tag.tiltaksgjennomforing.leader.LeaderPodCheck;
+import org.springframework.context.annotation.Profile;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@Profile({ Miljø.DEV_FSS, Miljø.PROD_FSS })
+public class PabegynteAvtalerRyddeJobb {
+    private final LeaderPodCheck leaderPodCheck;
+    private final PabegynteAvtalerRyddeService pabegynteAvtalerRyddeService;
+
+    public PabegynteAvtalerRyddeJobb(
+        LeaderPodCheck leaderPodCheck,
+        PabegynteAvtalerRyddeService pabegynteAvtalerRyddeService
+    ) {
+        this.leaderPodCheck = leaderPodCheck;
+        this.pabegynteAvtalerRyddeService = pabegynteAvtalerRyddeService;
+    }
+
+    @Scheduled(cron = "0 10 0 * * *")
+    public void run() {
+        if (leaderPodCheck.isLeaderPod()) {
+            pabegynteAvtalerRyddeService.ryddAvtalerSomErPabegyntEllerManglerGodkjenning();
+        }
+    }
+}

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/service/PabegynteAvtalerRyddeService.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/service/PabegynteAvtalerRyddeService.java
@@ -9,7 +9,7 @@ import no.nav.tag.tiltaksgjennomforing.featuretoggles.FeatureToggle;
 import no.nav.tag.tiltaksgjennomforing.featuretoggles.FeatureToggleService;
 import no.nav.tag.tiltaksgjennomforing.utils.Now;
 import org.springframework.context.annotation.Profile;
-import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.ZoneId;
@@ -22,7 +22,7 @@ import java.util.stream.Collectors;
 import static no.nav.tag.tiltaksgjennomforing.avtale.AvtaleUtlopHandling.START_DATO_FOR_RYDDING;
 
 @Slf4j
-@Component
+@Service
 @Profile({ Miljø.DEV_FSS, Miljø.PROD_FSS })
 public class PabegynteAvtalerRyddeService {
     private final AvtaleRepository avtaleRepository;

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/service/PabegynteAvtalerRyddeServiceTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/service/PabegynteAvtalerRyddeServiceTest.java
@@ -1,9 +1,12 @@
 package no.nav.tag.tiltaksgjennomforing.avtale.service;
 
+import jakarta.transaction.Transactional;
+import no.nav.tag.tiltaksgjennomforing.Miljø;
 import no.nav.tag.tiltaksgjennomforing.avtale.Avtale;
 import no.nav.tag.tiltaksgjennomforing.avtale.AvtaleRepository;
 import no.nav.tag.tiltaksgjennomforing.avtale.AvtaleUtlopHandling;
 import no.nav.tag.tiltaksgjennomforing.avtale.Status;
+import no.nav.tag.tiltaksgjennomforing.avtale.TestData;
 import no.nav.tag.tiltaksgjennomforing.featuretoggles.FeatureToggle;
 import no.nav.tag.tiltaksgjennomforing.featuretoggles.FeatureToggleService;
 import no.nav.tag.tiltaksgjennomforing.utils.Now;
@@ -16,6 +19,10 @@ import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -23,24 +30,31 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.List;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+@ActiveProfiles(Miljø.TEST)
+@SpringBootTest
+@DirtiesContext
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
 class PabegynteAvtalerRyddeServiceTest {
 
-    @Mock
+    @Autowired
     private AvtaleRepository avtaleRepository;
 
     @Mock
-    private FeatureToggleService featureToggleService;
+    private AvtaleRepository avtaleRepositoryMock;
+
+    @Mock
+    private FeatureToggleService featureToggleServiceMock;
 
     @BeforeEach
     void beforeEach() {
-        when(featureToggleService.isEnabled(FeatureToggle.PABEGYNT_AVTALE_RYDDE_JOBB)).thenReturn(true);
+        when(featureToggleServiceMock.isEnabled(FeatureToggle.PABEGYNT_AVTALE_RYDDE_JOBB)).thenReturn(true);
     }
 
     @AfterEach
@@ -62,27 +76,27 @@ class PabegynteAvtalerRyddeServiceTest {
             mockAvtale(LocalDateTime.of(2025, 5, 19, 11, 20))
         );
 
-        when(avtaleRepository.findAvtalerSomErPabegyntEllerManglerGodkjenning()).thenReturn(avtaler);
+        when(avtaleRepositoryMock.findAvtalerSomErPabegyntEllerManglerGodkjenning()).thenReturn(avtaler);
 
         PabegynteAvtalerRyddeService pabegynteAvtalerRyddeService = new PabegynteAvtalerRyddeService(
-            avtaleRepository,
-            featureToggleService
+            avtaleRepositoryMock,
+            featureToggleServiceMock
         );
         pabegynteAvtalerRyddeService.ryddAvtalerSomErPabegyntEllerManglerGodkjenning();
 
-        verify(avtaleRepository, times(0)).save(any());
+        verify(avtaleRepositoryMock, times(0)).save(any());
 
         Now.fixedDate(LocalDate.of(2024, 11, 21));
 
         pabegynteAvtalerRyddeService.ryddAvtalerSomErPabegyntEllerManglerGodkjenning();
 
-        verify(avtaleRepository, times(0)).save(any());
+        verify(avtaleRepositoryMock, times(0)).save(any());
 
         Now.fixedDate(LocalDate.of(2024, 11, 27));
 
         pabegynteAvtalerRyddeService.ryddAvtalerSomErPabegyntEllerManglerGodkjenning();
 
-        verify(avtaleRepository, times(0)).save(any());
+        verify(avtaleRepositoryMock, times(0)).save(any());
     }
 
     @Test
@@ -105,11 +119,11 @@ class PabegynteAvtalerRyddeServiceTest {
             mockAvtale(LocalDateTime.of(2025, 5, 19, 11, 20))
         );
 
-        when(avtaleRepository.findAvtalerSomErPabegyntEllerManglerGodkjenning()).thenReturn(avtaler);
+        when(avtaleRepositoryMock.findAvtalerSomErPabegyntEllerManglerGodkjenning()).thenReturn(avtaler);
 
         PabegynteAvtalerRyddeService pabegynteAvtalerRyddeService = new PabegynteAvtalerRyddeService(
-            avtaleRepository,
-            featureToggleService
+            avtaleRepositoryMock,
+            featureToggleServiceMock
         );
         pabegynteAvtalerRyddeService.ryddAvtalerSomErPabegyntEllerManglerGodkjenning();
 
@@ -118,7 +132,7 @@ class PabegynteAvtalerRyddeServiceTest {
         verify(skalVarsle3, times(1)).utlop(AvtaleUtlopHandling.VARSEL_EN_UKE);
         verify(skalVarsle4, times(1)).utlop(AvtaleUtlopHandling.VARSEL_EN_UKE);
         verify(skalVarsle5, times(1)).utlop(AvtaleUtlopHandling.VARSEL_EN_UKE);
-        verify(avtaleRepository, times(5)).save(any());
+        verify(avtaleRepositoryMock, times(5)).save(any());
     }
 
     @Test
@@ -141,11 +155,11 @@ class PabegynteAvtalerRyddeServiceTest {
             mockAvtale(LocalDateTime.of(2025, 5, 19, 11, 20))
         );
 
-        when(avtaleRepository.findAvtalerSomErPabegyntEllerManglerGodkjenning()).thenReturn(avtaler);
+        when(avtaleRepositoryMock.findAvtalerSomErPabegyntEllerManglerGodkjenning()).thenReturn(avtaler);
 
         PabegynteAvtalerRyddeService pabegynteAvtalerRyddeService = new PabegynteAvtalerRyddeService(
-            avtaleRepository,
-            featureToggleService
+            avtaleRepositoryMock,
+            featureToggleServiceMock
         );
         pabegynteAvtalerRyddeService.ryddAvtalerSomErPabegyntEllerManglerGodkjenning();
 
@@ -154,7 +168,7 @@ class PabegynteAvtalerRyddeServiceTest {
         verify(skalVarsle3, times(1)).utlop(AvtaleUtlopHandling.VARSEL_24_TIMER);
         verify(skalVarsle4, times(1)).utlop(AvtaleUtlopHandling.VARSEL_24_TIMER);
         verify(skalVarsle5, times(1)).utlop(AvtaleUtlopHandling.VARSEL_24_TIMER);
-        verify(avtaleRepository, times(5)).save(any());
+        verify(avtaleRepositoryMock, times(5)).save(any());
     }
 
     @Test
@@ -177,11 +191,11 @@ class PabegynteAvtalerRyddeServiceTest {
             mockAvtale(LocalDateTime.of(2025, 5, 19, 11, 20))
         );
 
-        when(avtaleRepository.findAvtalerSomErPabegyntEllerManglerGodkjenning()).thenReturn(avtaler);
+        when(avtaleRepositoryMock.findAvtalerSomErPabegyntEllerManglerGodkjenning()).thenReturn(avtaler);
 
         PabegynteAvtalerRyddeService pabegynteAvtalerRyddeService = new PabegynteAvtalerRyddeService(
-            avtaleRepository,
-            featureToggleService
+            avtaleRepositoryMock,
+            featureToggleServiceMock
         );
         pabegynteAvtalerRyddeService.ryddAvtalerSomErPabegyntEllerManglerGodkjenning();
 
@@ -190,7 +204,7 @@ class PabegynteAvtalerRyddeServiceTest {
         verify(skalUtlope3, times(1)).utlop(AvtaleUtlopHandling.UTLOP);
         verify(skalUtlope4, times(1)).utlop(AvtaleUtlopHandling.UTLOP);
         verify(skalUtlope5, times(1)).utlop(AvtaleUtlopHandling.UTLOP);
-        verify(avtaleRepository, times(5)).save(any());
+        verify(avtaleRepositoryMock, times(5)).save(any());
     }
 
     @Test
@@ -217,18 +231,74 @@ class PabegynteAvtalerRyddeServiceTest {
             mockAvtale(LocalDateTime.of(2024, 10, 20, 12, 0))
         );
 
-        when(avtaleRepository.findAvtalerSomErPabegyntEllerManglerGodkjenning()).thenReturn(avtaler);
+        when(avtaleRepositoryMock.findAvtalerSomErPabegyntEllerManglerGodkjenning()).thenReturn(avtaler);
 
         PabegynteAvtalerRyddeService pabegynteAvtalerRyddeService = new PabegynteAvtalerRyddeService(
-            avtaleRepository,
-            featureToggleService
+            avtaleRepositoryMock,
+            featureToggleServiceMock
         );
         pabegynteAvtalerRyddeService.ryddAvtalerSomErPabegyntEllerManglerGodkjenning();
 
         verify(skalUtlope, times(1)).utlop(AvtaleUtlopHandling.UTLOP);
         verify(skalVarsles24Timer, times(1)).utlop(AvtaleUtlopHandling.VARSEL_24_TIMER);
         verify(skalVarsles1Uke, times(1)).utlop(AvtaleUtlopHandling.VARSEL_EN_UKE);
-        verify(avtaleRepository, times(3)).save(any());
+        verify(avtaleRepositoryMock, times(3)).save(any());
+    }
+
+    @Test
+    @Transactional
+    void skal_bare_ta_avtaler_som_er_pabegynt_eller_mangler_godkjenning() {
+        PabegynteAvtalerRyddeService pabegynteAvtalerRyddeService = new PabegynteAvtalerRyddeService(
+            avtaleRepository,
+            featureToggleServiceMock
+        );
+
+        Now.fixedDate(LocalDate.of(2025, 1, 1));
+
+        Avtale avtale1  = TestData.enArbeidstreningAvtaleGodkjentAvVeileder();
+        avtale1.setStatus(Status.ANNULLERT);
+        avtale1.setSistEndret(ZonedDateTime.of(2024, 10, 8, 12, 0, 0, 0, ZoneId.systemDefault()).toInstant());
+        avtaleRepository.save(avtale1);
+
+        Avtale avtale2  = TestData.enArbeidstreningAvtaleGodkjentAvVeileder();
+        avtale2.setStatus(Status.AVBRUTT);
+        avtale2.setSistEndret(ZonedDateTime.of(2024, 10, 7, 12, 0, 0, 0, ZoneId.systemDefault()).toInstant());
+        avtaleRepository.save(avtale2);
+
+        Avtale avtale3  = TestData.enArbeidstreningAvtaleGodkjentAvVeileder();
+        avtale3.setStatus(Status.KLAR_FOR_OPPSTART);
+        avtale3.setSistEndret(ZonedDateTime.of(2024, 10, 6, 12, 0, 0, 0, ZoneId.systemDefault()).toInstant());
+        avtaleRepository.save(avtale3);
+
+        Avtale avtale4  = TestData.enArbeidstreningAvtaleGodkjentAvVeileder();
+        avtale4.setStatus(Status.GJENNOMFØRES);
+        avtale4.setSistEndret(ZonedDateTime.of(2024, 10, 5, 12, 0, 0, 0, ZoneId.systemDefault()).toInstant());
+        avtaleRepository.save(avtale4);
+
+        Avtale avtale5  = TestData.enArbeidstreningAvtaleGodkjentAvVeileder();
+        avtale5.setStatus(Status.AVSLUTTET);
+        avtale5.setSistEndret(ZonedDateTime.of(2024, 10, 4, 12, 0, 0, 0, ZoneId.systemDefault()).toInstant());
+        avtaleRepository.save(avtale5);
+
+        Avtale avtale6  = TestData.enArbeidstreningAvtaleGodkjentAvVeileder();
+        avtale6.setStatus(Status.MANGLER_GODKJENNING);
+        avtale6.setSistEndret(ZonedDateTime.of(2024, 10, 3, 12, 0, 0, 0, ZoneId.systemDefault()).toInstant());
+        avtaleRepository.save(avtale6);
+
+        Avtale avtale7  = TestData.enArbeidstreningAvtaleGodkjentAvVeileder();
+        avtale7.setStatus(Status.PÅBEGYNT);
+        avtale7.setSistEndret(ZonedDateTime.of(2024, 10, 2, 12, 0, 0, 0, ZoneId.systemDefault()).toInstant());
+        avtaleRepository.save(avtale7);
+
+        pabegynteAvtalerRyddeService.ryddAvtalerSomErPabegyntEllerManglerGodkjenning();
+
+        assertThat(avtaleRepository.findById(avtale1.getId()).map(Avtale::getStatus).orElse(null)).isEqualTo(Status.ANNULLERT);
+        assertThat(avtaleRepository.findById(avtale2.getId()).map(Avtale::getStatus).orElse(null)).isEqualTo(Status.AVBRUTT);
+        assertThat(avtaleRepository.findById(avtale3.getId()).map(Avtale::getStatus).orElse(null)).isEqualTo(Status.KLAR_FOR_OPPSTART);
+        assertThat(avtaleRepository.findById(avtale4.getId()).map(Avtale::getStatus).orElse(null)).isEqualTo(Status.GJENNOMFØRES);
+        assertThat(avtaleRepository.findById(avtale5.getId()).map(Avtale::getStatus).orElse(null)).isEqualTo(Status.AVSLUTTET);
+        assertThat(avtaleRepository.findById(avtale6.getId()).map(Avtale::getStatus).orElse(null)).isEqualTo(Status.ANNULLERT);
+        assertThat(avtaleRepository.findById(avtale7.getId()).map(Avtale::getStatus).orElse(null)).isEqualTo(Status.ANNULLERT);
     }
 
     private static Avtale mockAvtale(LocalDateTime sistEndret) {

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/service/PabegynteAvtalerRyddeServiceTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/service/PabegynteAvtalerRyddeServiceTest.java
@@ -1,4 +1,4 @@
-package no.nav.tag.tiltaksgjennomforing.avtale.jobber;
+package no.nav.tag.tiltaksgjennomforing.avtale.service;
 
 import no.nav.tag.tiltaksgjennomforing.avtale.Avtale;
 import no.nav.tag.tiltaksgjennomforing.avtale.AvtaleRepository;
@@ -6,7 +6,6 @@ import no.nav.tag.tiltaksgjennomforing.avtale.AvtaleUtlopHandling;
 import no.nav.tag.tiltaksgjennomforing.avtale.Status;
 import no.nav.tag.tiltaksgjennomforing.featuretoggles.FeatureToggle;
 import no.nav.tag.tiltaksgjennomforing.featuretoggles.FeatureToggleService;
-import no.nav.tag.tiltaksgjennomforing.leader.LeaderPodCheck;
 import no.nav.tag.tiltaksgjennomforing.utils.Now;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -31,7 +30,7 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
-class PabegynteAvtalerRyddejobbTest {
+class PabegynteAvtalerRyddeServiceTest {
 
     @Mock
     private AvtaleRepository avtaleRepository;
@@ -39,13 +38,9 @@ class PabegynteAvtalerRyddejobbTest {
     @Mock
     private FeatureToggleService featureToggleService;
 
-    @Mock
-    private LeaderPodCheck leaderPodCheck;
-
     @BeforeEach
     void beforeEach() {
         when(featureToggleService.isEnabled(FeatureToggle.PABEGYNT_AVTALE_RYDDE_JOBB)).thenReturn(true);
-        when(leaderPodCheck.isLeaderPod()).thenReturn(true);
     }
 
     @AfterEach
@@ -69,24 +64,23 @@ class PabegynteAvtalerRyddejobbTest {
 
         when(avtaleRepository.findAvtalerSomErPabegyntEllerManglerGodkjenning()).thenReturn(avtaler);
 
-        PabegynteAvtalerRyddejobb påbegynteAvtalerRyddejobb = new PabegynteAvtalerRyddejobb(
+        PabegynteAvtalerRyddeService pabegynteAvtalerRyddeService = new PabegynteAvtalerRyddeService(
             avtaleRepository,
-            featureToggleService,
-            leaderPodCheck
+            featureToggleService
         );
-        påbegynteAvtalerRyddejobb.run();
+        pabegynteAvtalerRyddeService.ryddAvtalerSomErPabegyntEllerManglerGodkjenning();
 
         verify(avtaleRepository, times(0)).save(any());
 
         Now.fixedDate(LocalDate.of(2024, 11, 21));
 
-        påbegynteAvtalerRyddejobb.run();
+        pabegynteAvtalerRyddeService.ryddAvtalerSomErPabegyntEllerManglerGodkjenning();
 
         verify(avtaleRepository, times(0)).save(any());
 
         Now.fixedDate(LocalDate.of(2024, 11, 27));
 
-        påbegynteAvtalerRyddejobb.run();
+        pabegynteAvtalerRyddeService.ryddAvtalerSomErPabegyntEllerManglerGodkjenning();
 
         verify(avtaleRepository, times(0)).save(any());
     }
@@ -113,12 +107,11 @@ class PabegynteAvtalerRyddejobbTest {
 
         when(avtaleRepository.findAvtalerSomErPabegyntEllerManglerGodkjenning()).thenReturn(avtaler);
 
-        PabegynteAvtalerRyddejobb påbegynteAvtalerRyddejobb = new PabegynteAvtalerRyddejobb(
+        PabegynteAvtalerRyddeService pabegynteAvtalerRyddeService = new PabegynteAvtalerRyddeService(
             avtaleRepository,
-            featureToggleService,
-            leaderPodCheck
+            featureToggleService
         );
-        påbegynteAvtalerRyddejobb.run();
+        pabegynteAvtalerRyddeService.ryddAvtalerSomErPabegyntEllerManglerGodkjenning();
 
         verify(skalVarsle1, times(1)).utlop(AvtaleUtlopHandling.VARSEL_EN_UKE);
         verify(skalVarsle2, times(1)).utlop(AvtaleUtlopHandling.VARSEL_EN_UKE);
@@ -150,12 +143,11 @@ class PabegynteAvtalerRyddejobbTest {
 
         when(avtaleRepository.findAvtalerSomErPabegyntEllerManglerGodkjenning()).thenReturn(avtaler);
 
-        PabegynteAvtalerRyddejobb påbegynteAvtalerRyddejobb = new PabegynteAvtalerRyddejobb(
+        PabegynteAvtalerRyddeService pabegynteAvtalerRyddeService = new PabegynteAvtalerRyddeService(
             avtaleRepository,
-            featureToggleService,
-            leaderPodCheck
+            featureToggleService
         );
-        påbegynteAvtalerRyddejobb.run();
+        pabegynteAvtalerRyddeService.ryddAvtalerSomErPabegyntEllerManglerGodkjenning();
 
         verify(skalVarsle1, times(1)).utlop(AvtaleUtlopHandling.VARSEL_24_TIMER);
         verify(skalVarsle2, times(1)).utlop(AvtaleUtlopHandling.VARSEL_24_TIMER);
@@ -187,12 +179,11 @@ class PabegynteAvtalerRyddejobbTest {
 
         when(avtaleRepository.findAvtalerSomErPabegyntEllerManglerGodkjenning()).thenReturn(avtaler);
 
-        PabegynteAvtalerRyddejobb påbegynteAvtalerRyddejobb = new PabegynteAvtalerRyddejobb(
+        PabegynteAvtalerRyddeService pabegynteAvtalerRyddeService = new PabegynteAvtalerRyddeService(
             avtaleRepository,
-            featureToggleService,
-            leaderPodCheck
+            featureToggleService
         );
-        påbegynteAvtalerRyddejobb.run();
+        pabegynteAvtalerRyddeService.ryddAvtalerSomErPabegyntEllerManglerGodkjenning();
 
         verify(skalUtlope1, times(1)).utlop(AvtaleUtlopHandling.UTLOP);
         verify(skalUtlope2, times(1)).utlop(AvtaleUtlopHandling.UTLOP);
@@ -228,41 +219,16 @@ class PabegynteAvtalerRyddejobbTest {
 
         when(avtaleRepository.findAvtalerSomErPabegyntEllerManglerGodkjenning()).thenReturn(avtaler);
 
-        PabegynteAvtalerRyddejobb påbegynteAvtalerRyddejobb = new PabegynteAvtalerRyddejobb(
+        PabegynteAvtalerRyddeService pabegynteAvtalerRyddeService = new PabegynteAvtalerRyddeService(
             avtaleRepository,
-            featureToggleService,
-            leaderPodCheck
+            featureToggleService
         );
-        påbegynteAvtalerRyddejobb.run();
+        pabegynteAvtalerRyddeService.ryddAvtalerSomErPabegyntEllerManglerGodkjenning();
 
         verify(skalUtlope, times(1)).utlop(AvtaleUtlopHandling.UTLOP);
         verify(skalVarsles24Timer, times(1)).utlop(AvtaleUtlopHandling.VARSEL_24_TIMER);
         verify(skalVarsles1Uke, times(1)).utlop(AvtaleUtlopHandling.VARSEL_EN_UKE);
         verify(avtaleRepository, times(3)).save(any());
-    }
-
-    @Test
-    void skal_bare_ta_avtaler_som_er_pabegynt_eller_mangler_godkjenning() {
-        Now.fixedDate(LocalDate.of(2025, 1, 1));
-
-        List<Avtale> avtaler = List.of(
-            mockAvtale(LocalDateTime.of(2024, 10, 8, 12, 0), Status.ANNULLERT),
-            mockAvtale(LocalDateTime.of(2024, 10, 7, 12, 0), Status.AVBRUTT),
-            mockAvtale(LocalDateTime.of(2024, 10, 6, 12, 0), Status.KLAR_FOR_OPPSTART),
-            mockAvtale(LocalDateTime.of(2024, 10, 5, 12, 0), Status.GJENNOMFØRES),
-            mockAvtale(LocalDateTime.of(2024, 10, 4, 12, 0), Status.AVSLUTTET)
-        );
-
-        when(avtaleRepository.findAvtalerSomErPabegyntEllerManglerGodkjenning()).thenReturn(avtaler);
-
-        PabegynteAvtalerRyddejobb påbegynteAvtalerRyddejobb = new PabegynteAvtalerRyddejobb(
-            avtaleRepository,
-            featureToggleService,
-            leaderPodCheck
-        );
-        påbegynteAvtalerRyddejobb.run();
-
-        verify(avtaleRepository, times(0)).save(any());
     }
 
     private static Avtale mockAvtale(LocalDateTime sistEndret) {


### PR DESCRIPTION
* Egen service med Transactional
* Kjøre jobben 10 over 12 - 5 min etter status jobben
* Bruke nytt status-felt for å hente avtaler fra databasen