### PR TITLE
Legg til felt for gjeldende tilskuddsperiode

### DIFF
--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/Avtale.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/Avtale.java
@@ -895,7 +895,9 @@ public class Avtale extends AbstractAggregateRoot<Avtale> implements AvtaleMedFn
      * før etter endringen.
      * <p>
      * TODO: Fjern gammel logikk, og denne disclaimeren
+     * @deprecated Når vi fjerner logikk og bruker feltet i stedet, vil lombok generere en getter, men metodenavnet vil bli getXXXX
      */
+    @Deprecated
     @Nullable
     @JsonProperty
     public TilskuddPeriode gjeldendeTilskuddsperiode() {
@@ -906,6 +908,11 @@ public class Avtale extends AbstractAggregateRoot<Avtale> implements AvtaleMedFn
             log.debug("Gjeldende tilskuddsperiode ikke oppdatert? Fant {}, men kalkulerte {}", gjeldendeFraDbId, gjeldendePeriodeKalkulertId);
         }
         return gjeldendePeriode;
+    }
+
+    @Nullable
+    public TilskuddPeriode getGjeldendeTilskuddsperiode() {
+        return gjeldendeTilskuddsperiode();
     }
 
     private TilskuddPeriode gjeldendeTilskuddsperiodeGammel() {

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/Avtale.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/Avtale.java
@@ -903,7 +903,7 @@ public class Avtale extends AbstractAggregateRoot<Avtale> implements AvtaleMedFn
         var gjeldendePeriodeKalkulertId = gjeldendePeriode != null ? gjeldendePeriode.getId() : null;
         var gjeldendeFraDbId = this.gjeldendeTilskuddsperiode != null ? this.gjeldendeTilskuddsperiode.getId() : null;
         if (Objects.equals(gjeldendePeriodeKalkulertId, gjeldendeFraDbId)) {
-            log.warn("Gjeldende tilskuddsperiode ikke oppdatert? Fant {}, men kalkulerte {}", gjeldendeFraDbId, gjeldendePeriodeKalkulertId);
+            log.debug("Gjeldende tilskuddsperiode ikke oppdatert? Fant {}, men kalkulerte {}", gjeldendeFraDbId, gjeldendePeriodeKalkulertId);
         }
         return gjeldendePeriode;
     }

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/Avtale.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/Avtale.java
@@ -895,9 +895,7 @@ public class Avtale extends AbstractAggregateRoot<Avtale> implements AvtaleMedFn
      * før etter endringen.
      * <p>
      * TODO: Fjern gammel logikk, og denne disclaimeren
-     * @deprecated Når vi fjerner logikk og bruker feltet i stedet, vil lombok generere en getter, men metodenavnet vil bli getXXXX
      */
-    @Deprecated
     @Nullable
     @JsonProperty
     public TilskuddPeriode gjeldendeTilskuddsperiode() {
@@ -908,11 +906,6 @@ public class Avtale extends AbstractAggregateRoot<Avtale> implements AvtaleMedFn
             log.debug("Gjeldende tilskuddsperiode ikke oppdatert? Fant {}, men kalkulerte {}", gjeldendeFraDbId, gjeldendePeriodeKalkulertId);
         }
         return gjeldendePeriode;
-    }
-
-    @Nullable
-    public TilskuddPeriode getGjeldendeTilskuddsperiode() {
-        return gjeldendeTilskuddsperiode();
     }
 
     private TilskuddPeriode gjeldendeTilskuddsperiodeGammel() {

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/Avtale.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/Avtale.java
@@ -902,7 +902,7 @@ public class Avtale extends AbstractAggregateRoot<Avtale> implements AvtaleMedFn
         var gjeldendePeriode = gjeldendeTilskuddsperiodeGammel();
         var gjeldendePeriodeKalkulertId = gjeldendePeriode != null ? gjeldendePeriode.getId() : null;
         var gjeldendeFraDbId = this.gjeldendeTilskuddsperiode != null ? this.gjeldendeTilskuddsperiode.getId() : null;
-        if (Objects.equals(gjeldendePeriodeKalkulertId, gjeldendeFraDbId)) {
+        if (!Objects.equals(gjeldendePeriodeKalkulertId, gjeldendeFraDbId)) {
             log.debug("Gjeldende tilskuddsperiode ikke oppdatert? Fant {}, men kalkulerte {}", gjeldendeFraDbId, gjeldendePeriodeKalkulertId);
         }
         return gjeldendePeriode;

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/Avtale.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/Avtale.java
@@ -178,6 +178,7 @@ public class Avtale extends AbstractAggregateRoot<Avtale> implements AvtaleMedFn
 
     @OneToOne(cascade = CascadeType.ALL)
     @Nullable
+    @JsonIgnore
     private TilskuddPeriode gjeldendeTilskuddsperiode;
     @OneToMany(mappedBy = "avtale", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
     @Fetch(FetchMode.SUBSELECT)

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/Avtale.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/Avtale.java
@@ -2,6 +2,7 @@ package no.nav.tag.tiltaksgjennomforing.avtale;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.annotation.Nullable;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
@@ -103,6 +104,7 @@ import java.time.LocalDateTime;
 import java.util.Comparator;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.SortedSet;
@@ -174,6 +176,9 @@ public class Avtale extends AbstractAggregateRoot<Avtale> implements AvtaleMedFn
     @Enumerated(EnumType.STRING)
     private Formidlingsgruppe formidlingsgruppe;
 
+    @OneToOne(cascade = CascadeType.ALL)
+    @Nullable
+    private TilskuddPeriode gjeldendeTilskuddsperiode;
     @OneToMany(mappedBy = "avtale", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
     @Fetch(FetchMode.SUBSELECT)
     @SortNatural
@@ -883,9 +888,30 @@ public class Avtale extends AbstractAggregateRoot<Avtale> implements AvtaleMedFn
         return tilskuddPeriode.toArray(new TilskuddPeriode[0])[index];
     }
 
+    /**
+     * Vi ønsker å migrere til at "gjeldende tilskuddsperiode" lagres i databasen for å legge til rette for bedre
+     * filtreringsmuligheter for besluttere. I en overgangsfase bør all logikk basere seg på gammel implementasjon som
+     * "kalkulerer" gjeldende periode, men vi bør også logge eventuelle avvik for å sikre at systemet fungerer likt som
+     * før etter endringen.
+     * <p>
+     * TODO: Fjern gammel logikk, og denne disclaimeren
+     */
+    @Nullable
     @JsonProperty
     public TilskuddPeriode gjeldendeTilskuddsperiode() {
-        TreeSet<TilskuddPeriode> aktiveTilskuddsperioder = new TreeSet<>(tilskuddPeriode.stream().filter(TilskuddPeriode::isAktiv).collect(Collectors.toSet()));
+        var gjeldendePeriode = gjeldendeTilskuddsperiodeGammel();
+        var gjeldendePeriodeKalkulertId = gjeldendePeriode != null ? gjeldendePeriode.getId() : null;
+        var gjeldendeFraDbId = this.gjeldendeTilskuddsperiode != null ? this.gjeldendeTilskuddsperiode.getId() : null;
+        if (Objects.equals(gjeldendePeriodeKalkulertId, gjeldendeFraDbId)) {
+            log.warn("Gjeldende tilskuddsperiode ikke oppdatert? Fant {}, men kalkulerte {}", gjeldendeFraDbId, gjeldendePeriodeKalkulertId);
+        }
+        return gjeldendePeriode;
+    }
+
+    private TilskuddPeriode gjeldendeTilskuddsperiodeGammel() {
+        TreeSet<TilskuddPeriode> aktiveTilskuddsperioder = tilskuddPeriode.stream()
+                .filter(TilskuddPeriode::isAktiv)
+                .collect(Collectors.toCollection(TreeSet::new));
 
         if (aktiveTilskuddsperioder.isEmpty()) {
             return null;

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/TilskuddPeriode.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/TilskuddPeriode.java
@@ -42,7 +42,7 @@ public class TilskuddPeriode implements Comparable<TilskuddPeriode> {
     @EqualsAndHashCode.Include
     private UUID id = UUID.randomUUID();
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY) // Unngå rekursiv query-loop (avtale.gjeldendetilskudd->tilskudd.avtale->...)
     @JoinColumn(name = "avtale_id")
     @JsonIgnore
     @ToString.Exclude

--- a/src/main/resources/db/migration/V111__gjeldende_tilskuddsperiode.sql
+++ b/src/main/resources/db/migration/V111__gjeldende_tilskuddsperiode.sql
@@ -1,0 +1,3 @@
+ALTER TABLE avtale
+    ADD COLUMN gjeldende_tilskuddsperiode uuid
+    CONSTRAINT fk_gjeldende_tilskuddsperiode REFERENCES tilskudd_periode (id);

--- a/src/main/resources/db/migration/V111__gjeldende_tilskuddsperiode.sql
+++ b/src/main/resources/db/migration/V111__gjeldende_tilskuddsperiode.sql
@@ -1,3 +1,3 @@
 ALTER TABLE avtale
-    ADD COLUMN gjeldende_tilskuddsperiode uuid
+    ADD COLUMN gjeldende_tilskuddsperiode_id uuid
     CONSTRAINT fk_gjeldende_tilskuddsperiode REFERENCES tilskudd_periode (id);


### PR DESCRIPTION
For å enklere kunne filtrere på relevante avtaler må vi kunne vite hvilken tilskuddsperiode som er "gjeldende" til enhver tid.

På samme måte som vi har en "gjeldende avtaleinnhold" så vil vi også ha en "gjeldende tilskuddsperiode".

Foreløpig vil gammel måte å hente ut gjeldende periode på bli brukt, og så logger vi et varsel for alle
eventuelle avvik som dukker opp før vi er komfortable med at migreringen har blitt robust nok.