### PR TITLE
rename gjeldendeTilskuddsperiode()

### DIFF
--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/Avtale.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/Avtale.java
@@ -835,7 +835,7 @@ public class Avtale extends AbstractAggregateRoot<Avtale> implements AvtaleMedFn
         if (beslutter.equals(gjeldendeInnhold.getGodkjentAvNavIdent())) {
             throw new FeilkodeException(Feilkode.TILSKUDDSPERIODE_IKKE_GODKJENNE_EGNE);
         }
-        TilskuddPeriode gjeldendePeriode = gjeldendeTilskuddsperiode();
+        TilskuddPeriode gjeldendePeriode = getGjeldendeTilskuddsperiode();
 
         // Sjekk om samme løpenummer allerede er godkjent og annullert. Trenger da en "ekstra" resendingsnummer
         Integer resendingsnummer = finnResendingsNummer(gjeldendePeriode);
@@ -859,7 +859,7 @@ public class Avtale extends AbstractAggregateRoot<Avtale> implements AvtaleMedFn
         if (!erGodkjentAvVeileder()) {
             throw new FeilkodeException(Feilkode.TILSKUDDSPERIODE_KAN_KUN_BEHANDLES_VED_INNGAATT_AVTALE);
         }
-        TilskuddPeriode gjeldendePeriode = gjeldendeTilskuddsperiode();
+        TilskuddPeriode gjeldendePeriode = getGjeldendeTilskuddsperiode();
         gjeldendePeriode.avslå(beslutter, avslagsårsaker, avslagsforklaring);
         utforEndring(new TilskuddsperiodeAvslått(this, beslutter, gjeldendePeriode));
     }
@@ -878,7 +878,7 @@ public class Avtale extends AbstractAggregateRoot<Avtale> implements AvtaleMedFn
     }
 
     protected TilskuddPeriodeStatus getGjeldendeTilskuddsperiodestatus() {
-        TilskuddPeriode tilskuddPeriode = gjeldendeTilskuddsperiode();
+        TilskuddPeriode tilskuddPeriode = getGjeldendeTilskuddsperiode();
         if (tilskuddPeriode == null) {
             return null;
         }
@@ -899,7 +899,7 @@ public class Avtale extends AbstractAggregateRoot<Avtale> implements AvtaleMedFn
      */
     @Nullable
     @JsonProperty
-    public TilskuddPeriode gjeldendeTilskuddsperiode() {
+    public TilskuddPeriode getGjeldendeTilskuddsperiode() {
         var gjeldendePeriode = gjeldendeTilskuddsperiodeGammel();
         var gjeldendePeriodeKalkulertId = gjeldendePeriode != null ? gjeldendePeriode.getId() : null;
         var gjeldendeFraDbId = this.gjeldendeTilskuddsperiode != null ? this.gjeldendeTilskuddsperiode.getId() : null;

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleSorterer.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleSorterer.java
@@ -15,7 +15,7 @@ public class AvtaleSorterer {
             case AvtaleInnhold.Fields.deltakerFornavn -> Comparator.comparing(avtale -> lowercaseEllerNull(avtale.getGjeldendeInnhold().getDeltakerFornavn()), Comparator.nullsLast(Comparator.naturalOrder()));
             case "status" -> Comparator.comparing(avtale -> avtale.getStatus().getBeskrivelse().toLowerCase());
             case "startDato" ->
-                    Comparator.comparing(avtale -> (avtale.gjeldendeTilskuddsperiode() != null ? avtale.gjeldendeTilskuddsperiode().getStartDato() : avtale.getGjeldendeInnhold().getStartDato()), Comparator.nullsLast(Comparator.naturalOrder()));
+                    Comparator.comparing(avtale -> (avtale.getGjeldendeTilskuddsperiode() != null ? avtale.getGjeldendeTilskuddsperiode().getStartDato() : avtale.getGjeldendeInnhold().getStartDato()), Comparator.nullsLast(Comparator.naturalOrder()));
             default -> Comparator.comparing(Avtale::getSistEndret, Comparator.reverseOrder());
         };
     }

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/varsel/Varsel.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/varsel/Varsel.java
@@ -41,7 +41,7 @@ public class Varsel extends AbstractAggregateRoot<Varsel> {
     private AvtaleHendelseUtførtAvRolle utførtAv;
 
     private static String tilskuddsperiodeAvslåttTekst(Avtale avtale, String hendelseTypeTekst) {
-        TilskuddPeriode gjeldendePeriode = avtale.gjeldendeTilskuddsperiode();
+        TilskuddPeriode gjeldendePeriode = avtale.getGjeldendeTilskuddsperiode();
         String avslagÅrsaker = gjeldendePeriode.getAvslagsårsaker().stream()
                 .map(type -> type.getTekst().toLowerCase()).collect(Collectors.joining(", "));
         return hendelseTypeTekst
@@ -56,11 +56,11 @@ public class Varsel extends AbstractAggregateRoot<Varsel> {
         return switch (hendelseType) {
             case TILSKUDDSPERIODE_AVSLATT -> tilskuddsperiodeAvslåttTekst(avtale, hendelseType.getTekst());
             case TILSKUDDSPERIODE_GODKJENT -> {
-                if (avtale.gjeldendeTilskuddsperiode() != null
-                        && avtale.gjeldendeTilskuddsperiode().getStartDato() != null
-                        && avtale.gjeldendeTilskuddsperiode().getSluttDato() != null) {
+                if (avtale.getGjeldendeTilskuddsperiode() != null
+                        && avtale.getGjeldendeTilskuddsperiode().getStartDato() != null
+                        && avtale.getGjeldendeTilskuddsperiode().getSluttDato() != null) {
                     DateTimeFormatter norskDatoformat = DateTimeFormatter.ofPattern("dd.MM.yyyy");
-                    yield hendelseType.getTekst() + "\n(" + avtale.gjeldendeTilskuddsperiode().getStartDato().format(norskDatoformat) + " til " + avtale.gjeldendeTilskuddsperiode().getSluttDato().format(norskDatoformat) + ")";
+                    yield hendelseType.getTekst() + "\n(" + avtale.getGjeldendeTilskuddsperiode().getStartDato().format(norskDatoformat) + " til " + avtale.getGjeldendeTilskuddsperiode().getSluttDato().format(norskDatoformat) + ")";
                 } else {
                     yield hendelseType.getTekst();
                 }

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/GjeldendeTilskuddsperiodeTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/GjeldendeTilskuddsperiodeTest.java
@@ -20,27 +20,27 @@ public class GjeldendeTilskuddsperiodeTest {
 
         Avtale avtale = TestData.enLonnstilskuddAvtaleMedAltUtfyltMedGodkjentForEtterregistrering(avtaleStart, avtaleSlutt);
 
-        assertThat(avtale.tilskuddsperiode(0)).isEqualTo(avtale.gjeldendeTilskuddsperiode());
+        assertThat(avtale.tilskuddsperiode(0)).isEqualTo(avtale.getGjeldendeTilskuddsperiode());
 
         avtale.godkjennTilskuddsperiode(TestData.enNavIdent2(), "0000");
-        assertThat(avtale.tilskuddsperiode(1)).isEqualTo(avtale.gjeldendeTilskuddsperiode());
+        assertThat(avtale.tilskuddsperiode(1)).isEqualTo(avtale.getGjeldendeTilskuddsperiode());
 
         avtale.godkjennTilskuddsperiode(TestData.enNavIdent2(), "0000");
-        assertThat(avtale.tilskuddsperiode(2)).isEqualTo(avtale.gjeldendeTilskuddsperiode());
+        assertThat(avtale.tilskuddsperiode(2)).isEqualTo(avtale.getGjeldendeTilskuddsperiode());
 
         avtale.godkjennTilskuddsperiode(TestData.enNavIdent2(), "0000");
-        assertThat(avtale.tilskuddsperiode(3)).isEqualTo(avtale.gjeldendeTilskuddsperiode());
+        assertThat(avtale.tilskuddsperiode(3)).isEqualTo(avtale.getGjeldendeTilskuddsperiode());
 
         avtale.godkjennTilskuddsperiode(TestData.enNavIdent2(), "0000");
-        assertThat(avtale.tilskuddsperiode(4)).isEqualTo(avtale.gjeldendeTilskuddsperiode());
+        assertThat(avtale.tilskuddsperiode(4)).isEqualTo(avtale.getGjeldendeTilskuddsperiode());
 
 
         avtale.godkjennTilskuddsperiode(TestData.enNavIdent2(), "0000");
-        assertThat(avtale.tilskuddsperiode(5)).isEqualTo(avtale.gjeldendeTilskuddsperiode());
+        assertThat(avtale.tilskuddsperiode(5)).isEqualTo(avtale.getGjeldendeTilskuddsperiode());
 
         // Tilskuddsperiode index 5 har startdato som er mer enn 3 mnd frem i tid og vil ikke bli godkjent, slik den vil fortsatt være gjeldende.
         avtale.godkjennTilskuddsperiode(TestData.enNavIdent2(), "0000");
-        assertThat(avtale.tilskuddsperiode(5)).isEqualTo(avtale.gjeldendeTilskuddsperiode());
+        assertThat(avtale.tilskuddsperiode(5)).isEqualTo(avtale.getGjeldendeTilskuddsperiode());
 
         Now.resetClock();
     }
@@ -51,7 +51,7 @@ public class GjeldendeTilskuddsperiodeTest {
         LocalDate avtaleStart = Now.localDate();
         LocalDate avtaleSlutt = Now.localDate();
         Avtale avtale = enMidlertidigLønnstilskuddsAvtaleMedStartOgSluttGodkjentAvAlleParter(avtaleStart, avtaleSlutt);
-        assertThat(avtale.tilskuddsperiode(0)).isEqualTo(avtale.gjeldendeTilskuddsperiode());
+        assertThat(avtale.tilskuddsperiode(0)).isEqualTo(avtale.getGjeldendeTilskuddsperiode());
     }
 
     // 5
@@ -60,7 +60,7 @@ public class GjeldendeTilskuddsperiodeTest {
         LocalDate avtaleStart = Now.localDate().plusDays(15);
         LocalDate avtaleSlutt = Now.localDate().plusMonths(8);
         Avtale avtale = enMidlertidigLønnstilskuddsAvtaleMedStartOgSluttGodkjentAvAlleParter(avtaleStart, avtaleSlutt);
-        assertThat(avtale.tilskuddsperiode(0)).isEqualTo(avtale.gjeldendeTilskuddsperiode());
+        assertThat(avtale.tilskuddsperiode(0)).isEqualTo(avtale.getGjeldendeTilskuddsperiode());
     }
 
     // 6
@@ -73,7 +73,7 @@ public class GjeldendeTilskuddsperiodeTest {
         Avtale avtale = TestData.enLonnstilskuddAvtaleMedAltUtfyltMedGodkjentForEtterregistrering(avtaleStart, avtaleSlutt);
 
         avtale.avslåTilskuddsperiode(TestData.enNavIdent2(), EnumSet.of(Avslagsårsak.ANNET), "Forklaring");
-        assertThat(avtale.tilskuddsperiode(0)).isEqualTo(avtale.gjeldendeTilskuddsperiode());
+        assertThat(avtale.tilskuddsperiode(0)).isEqualTo(avtale.getGjeldendeTilskuddsperiode());
         Now.resetClock();
     }
 
@@ -84,7 +84,7 @@ public class GjeldendeTilskuddsperiodeTest {
         LocalDate avtaleSlutt = Now.localDate().plusMonths(8);
         Avtale avtale = enMidlertidigLønnstilskuddsAvtaleMedStartOgSluttGodkjentAvAlleParter(avtaleStart, avtaleSlutt);
         avtale.avslåTilskuddsperiode(TestData.enNavIdent2(), EnumSet.of(Avslagsårsak.ANNET), "Forklaring");
-        assertThat(avtale.tilskuddsperiode(0)).isEqualTo(avtale.gjeldendeTilskuddsperiode());
+        assertThat(avtale.tilskuddsperiode(0)).isEqualTo(avtale.getGjeldendeTilskuddsperiode());
     }
 
     // 8
@@ -95,10 +95,10 @@ public class GjeldendeTilskuddsperiodeTest {
         LocalDate avtaleStart = Now.localDate();
         LocalDate avtaleSlutt = Now.localDate().plusMonths(6);
         Avtale avtale = enMidlertidigLønnstilskuddsAvtaleMedStartOgSluttGodkjentAvAlleParter(avtaleStart, avtaleSlutt);
-        assertThat(avtale.gjeldendeTilskuddsperiode().getStartDato()).isEqualTo(avtaleStart);
+        assertThat(avtale.getGjeldendeTilskuddsperiode().getStartDato()).isEqualTo(avtaleStart);
         avtale.godkjennTilskuddsperiode(TestData.enNavIdent2(), avtale.getEnhetGeografisk());
-        assertThat(avtale.gjeldendeTilskuddsperiode().getStartDato()).isEqualTo(avtaleStart);
-        assertThat(avtale.gjeldendeTilskuddsperiode().getStatus()).isEqualTo(TilskuddPeriodeStatus.GODKJENT);
+        assertThat(avtale.getGjeldendeTilskuddsperiode().getStartDato()).isEqualTo(avtaleStart);
+        assertThat(avtale.getGjeldendeTilskuddsperiode().getStatus()).isEqualTo(TilskuddPeriodeStatus.GODKJENT);
         Now.resetClock();
     }
 
@@ -109,16 +109,16 @@ public class GjeldendeTilskuddsperiodeTest {
         LocalDate avtaleSlutt = Now.localDate().plusMonths(6);
         Avtale avtale = enMidlertidigLønnstilskuddsAvtaleMedStartOgSluttGodkjentAvAlleParter(avtaleStart, avtaleSlutt);
 
-        assertThat(avtale.gjeldendeTilskuddsperiode().getStartDato()).isEqualTo(avtaleStart);
+        assertThat(avtale.getGjeldendeTilskuddsperiode().getStartDato()).isEqualTo(avtaleStart);
         avtale.godkjennTilskuddsperiode(TestData.enNavIdent2(), avtale.getEnhetGeografisk());
-        assertThat(avtale.gjeldendeTilskuddsperiode()).isEqualTo(avtale.tilskuddsperiode(1));
+        assertThat(avtale.getGjeldendeTilskuddsperiode()).isEqualTo(avtale.tilskuddsperiode(1));
         avtale.godkjennTilskuddsperiode(TestData.enNavIdent2(), avtale.getEnhetGeografisk());
-        assertThat(avtale.gjeldendeTilskuddsperiode()).isEqualTo(avtale.tilskuddsperiode(2));
+        assertThat(avtale.getGjeldendeTilskuddsperiode()).isEqualTo(avtale.tilskuddsperiode(2));
         avtale.godkjennTilskuddsperiode(TestData.enNavIdent2(), avtale.getEnhetGeografisk());
-        assertThat(avtale.gjeldendeTilskuddsperiode()).isEqualTo(avtale.tilskuddsperiode(3));
+        assertThat(avtale.getGjeldendeTilskuddsperiode()).isEqualTo(avtale.tilskuddsperiode(3));
         avtale.godkjennTilskuddsperiode(TestData.enNavIdent2(), avtale.getEnhetGeografisk());
-        assertThat(avtale.gjeldendeTilskuddsperiode()).isEqualTo(avtale.tilskuddsperiode(3));
-        assertThat(avtale.gjeldendeTilskuddsperiode().getStatus()).isEqualTo(TilskuddPeriodeStatus.GODKJENT);
+        assertThat(avtale.getGjeldendeTilskuddsperiode()).isEqualTo(avtale.tilskuddsperiode(3));
+        assertThat(avtale.getGjeldendeTilskuddsperiode().getStatus()).isEqualTo(TilskuddPeriodeStatus.GODKJENT);
 
 
     }

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/varsel/VarselFactoryTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/varsel/VarselFactoryTest.java
@@ -20,7 +20,7 @@ class VarselFactoryTest {
     Avtale avtale = TestData.enMidlertidigLonnstilskuddAvtaleMedSpesieltTilpassetInnsatsGodkjentAvVeileder();
     VarselFactory factory = new VarselFactory(avtale, AvtaleHendelseUtførtAvRolle.BESLUTTER, TestData.enNavIdent() , HendelseType.TILSKUDDSPERIODE_GODKJENT);
     DateTimeFormatter norskDatoformat = DateTimeFormatter.ofPattern("dd.MM.yyyy");
-    assertEquals("Tilskuddsperiode har blitt godkjent av beslutter\n(" + avtale.gjeldendeTilskuddsperiode().getStartDato().format(norskDatoformat) + " til " + avtale.gjeldendeTilskuddsperiode().getSluttDato().format(norskDatoformat) + ")",factory.veileder().getTekst());
+    assertEquals("Tilskuddsperiode har blitt godkjent av beslutter\n(" + avtale.getGjeldendeTilskuddsperiode().getStartDato().format(norskDatoformat) + " til " + avtale.getGjeldendeTilskuddsperiode().getSluttDato().format(norskDatoformat) + ")",factory.veileder().getTekst());
   }
 
   @Test
@@ -29,14 +29,14 @@ class VarselFactoryTest {
     TilskuddPeriode tilskuddPeriode = Mockito.mock(TilskuddPeriode.class);
     when(tilskuddPeriode.getStartDato()).thenReturn(null);
     when(tilskuddPeriode.getSluttDato()).thenReturn(null);
-    when(avtale.gjeldendeTilskuddsperiode()).thenReturn(tilskuddPeriode);
+    when(avtale.getGjeldendeTilskuddsperiode()).thenReturn(tilskuddPeriode);
     VarselFactory factory = new VarselFactory(avtale, AvtaleHendelseUtførtAvRolle.BESLUTTER, TestData.enNavIdent() , HendelseType.TILSKUDDSPERIODE_GODKJENT);
     assertEquals("Tilskuddsperiode har blitt godkjent av beslutter",factory.veileder().getTekst());
   }
   @Test
   public void skal_returnere_tilskuddsperiode_er_null(){
     Avtale avtale = Mockito.mock(Avtale.class);
-    when(avtale.gjeldendeTilskuddsperiode()).thenReturn(null);
+    when(avtale.getGjeldendeTilskuddsperiode()).thenReturn(null);
     VarselFactory factory = new VarselFactory(avtale, AvtaleHendelseUtførtAvRolle.BESLUTTER, TestData.enNavIdent() , HendelseType.TILSKUDDSPERIODE_GODKJENT);
     assertEquals("Tilskuddsperiode har blitt godkjent av beslutter",factory.veileder().getTekst());
   }


### PR DESCRIPTION
Omdøper metoden til getGjeldende.... for å på sikt fjerne metoden og referere til felt direkte (lombok lager en getter med navnet getGjeldende...)

Inntil det faktiske gjeldende-feltet i databasen
tas i bruk så overstyrer vi fortsatt get-metoden.