### PR TITLE
Overstyr beregnTilskuddsbeløpForPeriode for VTAO

### DIFF
--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/tilskuddsperiode/beregning/VTAOLonnstilskuddAvtaleBeregningStrategy.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/tilskuddsperiode/beregning/VTAOLonnstilskuddAvtaleBeregningStrategy.java
@@ -68,4 +68,13 @@ public class VTAOLonnstilskuddAvtaleBeregningStrategy extends GenerellLonnstilsk
         tilskuddsperioder.forEach(t -> t.setEnhetsnavn(gjeldendeInnhold.getEnhetsnavnKostnadssted()));
         return tilskuddsperioder;
     }
+
+    @Override
+    public Integer beregnTilskuddsbeløpForPeriode(Avtale avtale, LocalDate startDato, LocalDate sluttDato) {
+        var vtaoSats = VTAO_SATS.hentGjeldendeSats(startDato);
+        if (vtaoSats == null) {
+            return null;
+        }
+        return LonnstilskuddAvtaleBeregningStrategy.beløpForPeriode(startDato, sluttDato, vtaoSats);
+    }
 }


### PR DESCRIPTION
Forkortinger som kortet ned en vtao-periode ble ikke gitt et beløp for perioden, og ville feile med nullpointer.