### PR TITLE
feat. ikke bruk tiltakgjennomforingId som primary key i ArenaAgreementMigration

### DIFF
--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/arena/models/migration/ArenaAgreementMigration.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/arena/models/migration/ArenaAgreementMigration.java
@@ -18,6 +18,7 @@ import java.util.UUID;
 @AllArgsConstructor(access = lombok.AccessLevel.PRIVATE)
 public class ArenaAgreementMigration {
     @Id
+    private UUID id;
     private Integer tiltakgjennomforingId;
     @Enumerated(EnumType.STRING)
     private ArenaAgreementMigrationStatus status;

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/arena/service/ArenaAgreementProcessingService.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/arena/service/ArenaAgreementProcessingService.java
@@ -130,7 +130,7 @@ public class ArenaAgreementProcessingService {
     }
 
     private void saveMigrationStatus(
-            Integer id,
+            Integer tiltakgjennomforingId,
             ArenaAgreementMigrationStatus status,
             ArenaMigrationAction action,
             UUID eksternId,
@@ -138,7 +138,8 @@ public class ArenaAgreementProcessingService {
     ) {
         arenaAgreementMigrationRepository.save(
             ArenaAgreementMigration.builder()
-                .tiltakgjennomforingId(id)
+                .id(UUID.randomUUID())
+                .tiltakgjennomforingId(tiltakgjennomforingId)
                 .status(status)
                 .action(action)
                 .avtaleId(agreementId)

--- a/src/main/resources/db/migration/V116__ny_primary_key_arena_agreement_migration.sql
+++ b/src/main/resources/db/migration/V116__ny_primary_key_arena_agreement_migration.sql
@@ -1,0 +1,9 @@
+ALTER TABLE arena_agreement_migration ADD COLUMN id UUID;
+UPDATE arena_agreement_migration SET id = gen_random_uuid();
+ALTER TABLE arena_agreement_migration ALTER COLUMN id SET NOT NULL;
+
+ALTER TABLE arena_agreement_migration DROP CONSTRAINT IF EXISTS arena_agreement_migration_pkey; -- Postgres
+ALTER TABLE arena_agreement_migration DROP CONSTRAINT IF EXISTS constraint_8b1; -- H2
+ALTER TABLE arena_agreement_migration DROP CONSTRAINT IF EXISTS constraint_8b1c; -- H2
+
+ALTER TABLE arena_agreement_migration ADD PRIMARY KEY (id);


### PR DESCRIPTION
Det kan være flere instanser av tiltaksgjennomføringer, derfor er det litt dumt at det blir brukt som primary key.