### PR TITLE
feat. kjøre mindre batcher for migreringsjobb

### DIFF
--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/arena/repository/ArenaAgreementMigrationRepository.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/arena/repository/ArenaAgreementMigrationRepository.java
@@ -39,7 +39,7 @@ public interface ArenaAgreementMigrationRepository extends JpaRepository<ArenaAg
         LEFT JOIN ArenaOrdsArbeidsgiver aoa ON atg.arbgivIdArrangor = aoa.arbgivIdArrangor
         WHERE atg.tiltakgjennomforingId NOT IN (SELECT tiltakgjennomforingId FROM ArenaAgreementMigration) OR
               atd.tiltakdeltakerId NOT IN (SELECT tiltakdeltakerId FROM ArenaAgreementMigration)
-        ORDER BY atd.tiltakgjennomforingId LIMIT 5000
+        ORDER BY atd.tiltakgjennomforingId LIMIT 2500
     """)
     List<ArenaAgreementAggregate> findMigrationAgreementAggregates();
 


### PR DESCRIPTION
I Q0 begynte jobben å gå treigere etterhvert fordi det ble litt for mange avtaler å prosessere samtidig. Siden vi skal kjøre migrering parallelt med annen vanlig drift er det derfor lurt å sette ned størrelsen på antall vi kjører per jobb.

Løpetid på jobben vil bli ca 1 time og 15 min med denne endringen.