### PR TITLE
Ikke auditlogg listeoppslag

### DIFF
--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/AlleredeRegistrertAvtale.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/AlleredeRegistrertAvtale.java
@@ -4,8 +4,6 @@ package no.nav.tag.tiltaksgjennomforing.avtale;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import no.nav.tag.tiltaksgjennomforing.infrastruktur.auditing.AvtaleMedFnrOgBedriftNr;
-import no.nav.tag.tiltaksgjennomforing.infrastruktur.FnrOgBedrift;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -16,7 +14,7 @@ import java.util.stream.Stream;
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
-public class AlleredeRegistrertAvtale implements AvtaleMedFnrOgBedriftNr {
+public class AlleredeRegistrertAvtale {
 
     private UUID id;
     private Integer avtaleNr;
@@ -68,10 +66,5 @@ public class AlleredeRegistrertAvtale implements AvtaleMedFnrOgBedriftNr {
                 Tiltakstype.MIDLERTIDIG_LONNSTILSKUDD,
                 Tiltakstype.VARIG_LONNSTILSKUDD
         ).contains(avtale.getTiltakstype())));
-    }
-
-    @Override
-    public FnrOgBedrift getFnrOgBedrift() {
-        return new FnrOgBedrift(getDeltakerFnr(), getBedriftNr());
     }
 }

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleController.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleController.java
@@ -163,7 +163,6 @@ public class AvtaleController {
                 );
     }
 
-    @AuditLogging("Hent liste over avtaler om arbeidsmarkedstiltak")
     @GetMapping
     @Timed(percentiles = {0.5d, 0.75d, 0.9d, 0.99d, 0.999d})
     public Map<String, Object> hentAlleAvtalerInnloggetBrukerHarTilgangTil(
@@ -184,7 +183,6 @@ public class AvtaleController {
         return avtaler;
     }
 
-    @AuditLogging("Hent liste over avtaler om arbeidsmarkedstiltak")
     @GetMapping("/sok")
     @Timed(percentiles = {0.5d, 0.75d, 0.9d, 0.99d, 0.999d})
     public Map<String, Object> hentAlleAvtalerInnloggetBrukerHarTilgangTilMedGet(
@@ -236,7 +234,6 @@ public class AvtaleController {
         }
     }
 
-    @AuditLogging("Hent liste over avtaler om arbeidsmarkedstiltak")
     @PostMapping("/sok")
     @Timed(percentiles = {0.5d, 0.75d, 0.9d, 0.99d, 0.999d})
     public Map<String, Object> hentAlleAvtalerInnloggetBrukerHarTilgangTilMedPost(
@@ -277,7 +274,6 @@ public class AvtaleController {
         return stringObjectHashMap;
     }
 
-    @AuditLogging("Hent liste over avtaler om arbeidsmarkedstiltak")
     @GetMapping("/beslutter-liste")
     @Timed(percentiles = {0.5d, 0.75d, 0.9d, 0.99d, 0.999d})
     public Map<String, Object> finnGodkjenteAvtalerMedTilskuddsperiodestatusOgNavEnheterListe(
@@ -404,7 +400,6 @@ public class AvtaleController {
 
     // Arbeidsgiver-operasjoner
 
-    @AuditLogging("Hent liste over avtaler om arbeidsmarkedstiltak")
     @GetMapping("/min-side-arbeidsgiver")
     public List<Avtale> hentAlleAvtalerForMinSideArbeidsgiver(@RequestParam("bedriftNr") BedriftNr bedriftNr) {
         Arbeidsgiver arbeidsgiver = innloggingService.hentArbeidsgiver();
@@ -438,7 +433,6 @@ public class AvtaleController {
     /**
      * VEILEDER-OPERASJONER
      **/
-    @AuditLogging("Hent liste over registrerte avtaler for bruker")
     @GetMapping("/deltaker-allerede-paa-tiltak")
     @Transactional
     public ResponseEntity<List<AlleredeRegistrertAvtale>> sjekkOmDeltakerAlleredeErRegistrertPaaTiltak(
@@ -464,7 +458,6 @@ public class AvtaleController {
     /**
      * VEILEDER-OPERASJONER
      **/
-    @AuditLogging("Hent liste over registrerte avtaler for bruker")
     @PostMapping("/deltaker-allerede-paa-tiltak")
     @Transactional
     public ResponseEntity<List<AlleredeRegistrertAvtale>> sjekkOmDeltakerAlleredeErRegistrertPaaTiltak(

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleMinimalListevisning.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleMinimalListevisning.java
@@ -6,7 +6,6 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import no.nav.tag.tiltaksgjennomforing.infrastruktur.FnrOgBedrift;
-import no.nav.tag.tiltaksgjennomforing.infrastruktur.auditing.AvtaleMedFnrOgBedriftNr;
 
 import java.time.Instant;
 import java.time.LocalDate;
@@ -15,7 +14,7 @@ import java.time.LocalDate;
 @AllArgsConstructor
 @NoArgsConstructor
 @Data
-public class AvtaleMinimalListevisning implements AvtaleMedFnrOgBedriftNr {
+public class AvtaleMinimalListevisning {
     private String id;
     private String deltakerFornavn;
     private String deltakerEtternavn;
@@ -49,10 +48,5 @@ public class AvtaleMinimalListevisning implements AvtaleMedFnrOgBedriftNr {
                 .sistEndret(avtale.getSistEndret())
                 .fnrOgBedrift(new FnrOgBedrift(avtale.getDeltakerFnr(), avtale.getBedriftNr()))
                 .build();
-    }
-
-    @Override
-    public FnrOgBedrift getFnrOgBedrift() {
-        return this.fnrOgBedrift;
     }
 }

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/BeslutterOversiktDTO.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/BeslutterOversiktDTO.java
@@ -7,7 +7,7 @@ import no.nav.tag.tiltaksgjennomforing.infrastruktur.FnrOgBedrift;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
-public interface BeslutterOversiktDTO extends AvtaleMedFnrOgBedriftNr {
+public interface BeslutterOversiktDTO {
     String getId();
     Integer getAvtaleNr();
     Tiltakstype getTiltakstype();
@@ -25,10 +25,4 @@ public interface BeslutterOversiktDTO extends AvtaleMedFnrOgBedriftNr {
     String getAntallUbehandlet();
     LocalDateTime getOpprettetTidspunkt();
     LocalDateTime getSistEndret();
-
-    @JsonIgnore
-    @Override
-    default FnrOgBedrift getFnrOgBedrift() {
-        return new FnrOgBedrift(getDeltakerFnr(), getBedriftNr());
-    }
 }


### PR DESCRIPTION
Dersom informasjonen til en deltaker dukker opp
i en listevisning, skal ikke dette medføre logging til arcsight.

Formålet med auditlogging er å logge oppslag på en spesifikk bruker, men listeoppslagene vil skape
unødvendig støy.

Dette er beskrevet i etterlevelseskrav K253.1