### PR TITLE
Inkluder "sistEndret" og "id" i auditlogging

### DIFF
--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/Avtale.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/Avtale.java
@@ -84,7 +84,7 @@ import no.nav.tag.tiltaksgjennomforing.exceptions.SamtidigeEndringerException;
 import no.nav.tag.tiltaksgjennomforing.exceptions.TilgangskontrollException;
 import no.nav.tag.tiltaksgjennomforing.exceptions.VeilederSkalGodkjenneSistException;
 import no.nav.tag.tiltaksgjennomforing.infrastruktur.FnrOgBedrift;
-import no.nav.tag.tiltaksgjennomforing.infrastruktur.auditing.AvtaleMedFnrOgBedriftNr;
+import no.nav.tag.tiltaksgjennomforing.infrastruktur.auditing.AuditerbarEntitet;
 import no.nav.tag.tiltaksgjennomforing.persondata.Navn;
 import no.nav.tag.tiltaksgjennomforing.persondata.NavnFormaterer;
 import no.nav.tag.tiltaksgjennomforing.tilskuddsperiode.beregning.EndreTilskuddsberegning;
@@ -129,7 +129,7 @@ import static no.nav.tag.tiltaksgjennomforing.utils.Utils.sjekkAtIkkeNull;
 @NoArgsConstructor
 @FieldNameConstants
 @Builder
-public class Avtale extends AbstractAggregateRoot<Avtale> implements AvtaleMedFnrOgBedriftNr {
+public class Avtale extends AbstractAggregateRoot<Avtale> implements AuditerbarEntitet {
 
     @Id
     @EqualsAndHashCode.Include

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleMinimalListevisning.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleMinimalListevisning.java
@@ -5,7 +5,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import no.nav.tag.tiltaksgjennomforing.infrastruktur.FnrOgBedrift;
 
 import java.time.Instant;
 import java.time.LocalDate;
@@ -28,8 +27,6 @@ public class AvtaleMinimalListevisning {
     private boolean erGodkjentTaushetserklæringAvMentor;
     private TilskuddPeriodeStatus gjeldendeTilskuddsperiodeStatus;
     private Instant sistEndret;
-    @JsonIgnore
-    private FnrOgBedrift fnrOgBedrift;
 
     public static AvtaleMinimalListevisning fromAvtale(Avtale avtale) {
         return AvtaleMinimalListevisning.builder()
@@ -46,7 +43,6 @@ public class AvtaleMinimalListevisning {
                 .erGodkjentTaushetserklæringAvMentor(avtale.erGodkjentTaushetserklæringAvMentor())
                 .gjeldendeTilskuddsperiodeStatus(avtale.getGjeldendeTilskuddsperiodestatus())
                 .sistEndret(avtale.getSistEndret())
-                .fnrOgBedrift(new FnrOgBedrift(avtale.getDeltakerFnr(), avtale.getBedriftNr()))
                 .build();
     }
 }

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/BeslutterOversiktDTO.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/BeslutterOversiktDTO.java
@@ -1,14 +1,14 @@
 package no.nav.tag.tiltaksgjennomforing.avtale;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import no.nav.tag.tiltaksgjennomforing.infrastruktur.auditing.AvtaleMedFnrOgBedriftNr;
-import no.nav.tag.tiltaksgjennomforing.infrastruktur.FnrOgBedrift;
 
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.UUID;
 
 public interface BeslutterOversiktDTO {
-    String getId();
+    UUID getId();
     Integer getAvtaleNr();
     Tiltakstype getTiltakstype();
     NavIdent getVeilederNavIdent();
@@ -24,5 +24,5 @@ public interface BeslutterOversiktDTO {
     String getStatus();
     String getAntallUbehandlet();
     LocalDateTime getOpprettetTidspunkt();
-    LocalDateTime getSistEndret();
+    Instant getSistEndret();
 }

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/infrastruktur/auditing/AuditElement.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/infrastruktur/auditing/AuditElement.java
@@ -1,0 +1,23 @@
+package no.nav.tag.tiltaksgjennomforing.infrastruktur.auditing;
+
+import no.nav.tag.tiltaksgjennomforing.avtale.BedriftNr;
+import no.nav.tag.tiltaksgjennomforing.avtale.Fnr;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record AuditElement(
+        UUID id,
+        Instant sistEndret,
+        Fnr deltakerFnr,
+        BedriftNr bedriftNr
+) {
+    public static AuditElement of(AuditerbarEntitet entitet) {
+        return new AuditElement(
+                entitet.getId(),
+                entitet.getSistEndret(),
+                entitet.getFnrOgBedrift().deltakerFnr(),
+                entitet.getFnrOgBedrift().bedriftNr()
+        );
+    }
+}

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/infrastruktur/auditing/AuditEntry.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/infrastruktur/auditing/AuditEntry.java
@@ -7,6 +7,7 @@ public record AuditEntry(
         String appNavn,
         String utførtAv,
         String oppslagPå,
+        String entitetId,
         EventType eventType,
         boolean forespørselTillatt,
         Instant oppslagUtførtTid,

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/infrastruktur/auditing/AuditerbarEntitet.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/infrastruktur/auditing/AuditerbarEntitet.java
@@ -1,0 +1,29 @@
+package no.nav.tag.tiltaksgjennomforing.infrastruktur.auditing;
+
+import no.nav.tag.tiltaksgjennomforing.infrastruktur.FnrOgBedrift;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * Definerer kontrakten som trengs for å auditlogge oppslaget på
+ * en entitet. For at auditlogging skal fungere må vi vite om:
+ * <p>
+ * - id til entiteten<br/>
+ * - sistEndret-tidspunkt<br/>
+ * - fødselsnummer og bedriftsnummer
+ * <p>
+ * id og sistEndret-tidspunkt brukes for å identifisere en unik enhet
+ * som det gjøres oppslag på (flere oppslag på samme data skal ignoreres)
+ * <p>
+ * fnr brukes for å finne ut hvem det ble gjort oppslag på
+ * <p>
+ * bedrift brukes dersom oppslag utføres av arbeidsgiver; auditlogging gjort
+ * av arbeidsgivere skal ikke logges som et oppslag fra deres fødselsnummer,
+ * men skal heller sies å ha blitt gjort av bedriften de tilhører
+ */
+public interface AuditerbarEntitet {
+    UUID getId();
+    Instant getSistEndret();
+    FnrOgBedrift getFnrOgBedrift();
+}

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/infrastruktur/auditing/AvtaleMedFnrOgBedriftNr.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/infrastruktur/auditing/AvtaleMedFnrOgBedriftNr.java
@@ -1,7 +1,0 @@
-package no.nav.tag.tiltaksgjennomforing.infrastruktur.auditing;
-
-import no.nav.tag.tiltaksgjennomforing.infrastruktur.FnrOgBedrift;
-
-public interface AvtaleMedFnrOgBedriftNr {
-    FnrOgBedrift getFnrOgBedrift();
-}


### PR DESCRIPTION
Formålet med endringen er å kunne spore unike oppslag på en deltaker sin informasjon.

Hvorfor behøver vi den informasjonen? Fordi auditlogging av oppslag skal kun skje dersom en avtale ikke har endret seg! Men det medfører at auditlogging-appen vår vet at et oppslag er unikt.