### PR TITLE
Logg at oppfølging av tiltak er utført

### DIFF
--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/HendelseType.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/HendelseType.java
@@ -57,8 +57,8 @@ public enum HendelseType {
     ARBEIDSGIVERS_GODKJENNING_OPPHEVET_AV_VEILEDER("Arbeidsgivers godkjenning opphevet av veileder"),
     UTLOPER_OM_1_UKE("Avtale vil automatisk slettes om 1 uke dersom det ikke foretas noen endringer"),
     UTLOPER_OM_24_TIMER("Avtale vil automatisk slettes i dag dersom det ikke foretas noen endringer innen kl 23:59"),
-    OPPFØLGING_AV_TILTAK_KREVES_VARSEL("Oppfølging av tiltaket kreves"),
-    OPPFØLGING_AV_TILTAK_UTFØRT("Oppfølging utført"),
+    OPPFØLGING_AV_TILTAK_KREVES("Oppfølging av tiltaket kreves"),
+    OPPFØLGING_AV_TILTAK_UTFØRT("Oppfølging av tiltaket utført"),
     PATCH("Patching av avtalehendelse");
 
     private final String tekst;

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/HendelseType.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/HendelseType.java
@@ -57,7 +57,8 @@ public enum HendelseType {
     ARBEIDSGIVERS_GODKJENNING_OPPHEVET_AV_VEILEDER("Arbeidsgivers godkjenning opphevet av veileder"),
     UTLOPER_OM_1_UKE("Avtale vil automatisk slettes om 1 uke dersom det ikke foretas noen endringer"),
     UTLOPER_OM_24_TIMER("Avtale vil automatisk slettes i dag dersom det ikke foretas noen endringer innen kl 23:59"),
-    OPPFØLGING_KREVES_VARSEL("Oppfølging av tiltaket kreves"),
+    OPPFØLGING_AV_TILTAK_KREVES_VARSEL("Oppfølging av tiltaket kreves"),
+    OPPFØLGING_AV_TILTAK_UTFØRT("Oppfølging utført"),
     PATCH("Patching av avtalehendelse");
 
     private final String tekst;

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/oppfolging/OppfølgingVarsleJobb.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/oppfolging/OppfølgingVarsleJobb.java
@@ -29,7 +29,7 @@ public class OppfølgingVarsleJobb {
         List<Avtale> avtaler = avtaleRepository.finnAvtalerSomSnartSkalFølgesOpp(dagenDato);
         if (!avtaler.isEmpty()) log.info("Fant {} avtaler som krever oppfølging. Oppretter varsel til veileder på disse.", avtaler.size());
         avtaler.forEach(avtale -> {
-            Varsel varsel = Varsel.nyttVarsel(avtale.getVeilederNavIdent(), true, avtale, Avtalerolle.VEILEDER, AvtaleHendelseUtførtAvRolle.SYSTEM, Identifikator.SYSTEM, HendelseType.OPPFØLGING_AV_TILTAK_KREVES_VARSEL, null);
+            Varsel varsel = Varsel.nyttVarsel(avtale.getVeilederNavIdent(), true, avtale, Avtalerolle.VEILEDER, AvtaleHendelseUtførtAvRolle.SYSTEM, Identifikator.SYSTEM, HendelseType.OPPFØLGING_AV_TILTAK_KREVES, null);
             varselRepository.save(varsel);
             avtale.setOppfolgingVarselSendt(Now.instant());
         });

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/oppfolging/OppfølgingVarsleJobb.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/oppfolging/OppfølgingVarsleJobb.java
@@ -29,7 +29,7 @@ public class OppfølgingVarsleJobb {
         List<Avtale> avtaler = avtaleRepository.finnAvtalerSomSnartSkalFølgesOpp(dagenDato);
         if (!avtaler.isEmpty()) log.info("Fant {} avtaler som krever oppfølging. Oppretter varsel til veileder på disse.", avtaler.size());
         avtaler.forEach(avtale -> {
-            Varsel varsel = Varsel.nyttVarsel(avtale.getVeilederNavIdent(), true, avtale, Avtalerolle.VEILEDER, AvtaleHendelseUtførtAvRolle.SYSTEM, Identifikator.SYSTEM, HendelseType.OPPFØLGING_KREVES_VARSEL, null);
+            Varsel varsel = Varsel.nyttVarsel(avtale.getVeilederNavIdent(), true, avtale, Avtalerolle.VEILEDER, AvtaleHendelseUtførtAvRolle.SYSTEM, Identifikator.SYSTEM, HendelseType.OPPFØLGING_AV_TILTAK_KREVES_VARSEL, null);
             varselRepository.save(varsel);
             avtale.setOppfolgingVarselSendt(Now.instant());
         });

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/varsel/LagVarselFraAvtaleHendelser.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/varsel/LagVarselFraAvtaleHendelser.java
@@ -37,6 +37,7 @@ import no.nav.tag.tiltaksgjennomforing.avtale.events.InkluderingstilskuddEndret;
 import no.nav.tag.tiltaksgjennomforing.avtale.events.KontaktinformasjonEndret;
 import no.nav.tag.tiltaksgjennomforing.avtale.events.MålEndret;
 import no.nav.tag.tiltaksgjennomforing.avtale.events.OmMentorEndret;
+import no.nav.tag.tiltaksgjennomforing.avtale.events.OppfolgingAvAvtaleGodkjent;
 import no.nav.tag.tiltaksgjennomforing.avtale.events.OppfølgingOgTilretteleggingEndret;
 import no.nav.tag.tiltaksgjennomforing.avtale.events.SignertAvMentor;
 import no.nav.tag.tiltaksgjennomforing.avtale.events.StillingsbeskrivelseEndret;
@@ -123,6 +124,7 @@ public class LagVarselFraAvtaleHendelser {
         VarselFactory factory = new VarselFactory(event.getAvtale(), AvtaleHendelseUtførtAvRolle.VEILEDER, null, HendelseType.GODKJENNINGER_OPPHEVET_AV_VEILEDER);
         varselRepository.saveAll(factory.alleParter());
     }
+
     @EventListener
     public void godkjentAvDeltaker(GodkjentAvDeltaker event) {
         VarselFactory factory = new VarselFactory(event.getAvtale(), AvtaleHendelseUtførtAvRolle.DELTAKER, event.getUtfortAv(), HendelseType.GODKJENT_AV_DELTAKER);
@@ -167,13 +169,13 @@ public class LagVarselFraAvtaleHendelser {
 
     @EventListener
     public void godkjentForEtterregistrering(GodkjentForEtterregistrering event) {
-        VarselFactory factory = new VarselFactory (event.getAvtale(), AvtaleHendelseUtførtAvRolle.BESLUTTER, event.getUtfortAv(), HendelseType.GODKJENT_FOR_ETTERREGISTRERING);
+        VarselFactory factory = new VarselFactory(event.getAvtale(), AvtaleHendelseUtførtAvRolle.BESLUTTER, event.getUtfortAv(), HendelseType.GODKJENT_FOR_ETTERREGISTRERING);
         varselRepository.save(factory.veileder());
     }
 
     @EventListener
     public void fjernetEtterregistrering(FjernetEtterregistrering event) {
-        VarselFactory factory = new VarselFactory (event.getAvtale(), AvtaleHendelseUtførtAvRolle.BESLUTTER, event.getUtfortAv(), HendelseType.FJERNET_ETTERREGISTRERING);
+        VarselFactory factory = new VarselFactory(event.getAvtale(), AvtaleHendelseUtførtAvRolle.BESLUTTER, event.getUtfortAv(), HendelseType.FJERNET_ETTERREGISTRERING);
         varselRepository.save(factory.veileder());
     }
 
@@ -289,6 +291,15 @@ public class LagVarselFraAvtaleHendelser {
     public void endreOppfølgingOgTilretteleggingInformasjon(OppfølgingOgTilretteleggingEndret event) {
         VarselFactory factory = new VarselFactory(event.getAvtale(), AvtaleHendelseUtførtAvRolle.VEILEDER, event.getUtførtAv(), HendelseType.OPPFØLGING_OG_TILRETTELEGGING_ENDRET);
         varselRepository.saveAll(factory.alleParter());
+    }
+
+    @EventListener
+    public void oppfølgingAvAvtaleGodkjent(OppfolgingAvAvtaleGodkjent event) {
+        Varsel veilederVarsel = new VarselFactory(event.getAvtale(), AvtaleHendelseUtførtAvRolle.VEILEDER, event.getUtførtAv(), HendelseType.OPPFØLGING_AV_TILTAK_UTFØRT).veileder();
+        // Veileder utfører handlingen, så vi behøver ingen varsel
+        veilederVarsel.setLest(true);
+        veilederVarsel.setBjelle(false);
+        varselRepository.save(veilederVarsel);
     }
 
     @EventListener


### PR DESCRIPTION
Gjøres ved å opprette et "varsel" uten bjelle og
som allerede er lest.