### PR TITLE
feat. bruk AD-grupper for tilgangssjekk for henting av diskresjonskoder

### DIFF
--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/AdGruppeProperties.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/AdGruppeProperties.java
@@ -8,7 +8,9 @@ import java.util.UUID;
 
 @Data
 @Component
-@ConfigurationProperties(prefix = "tiltaksgjennomforing.beslutter-ad-gruppe")
-public class BeslutterAdGruppeProperties {
-    private UUID id;
+@ConfigurationProperties(prefix = "tiltaksgjennomforing.ad-grupper")
+public class AdGruppeProperties {
+    private UUID beslutter;
+    private UUID fortroligAdresse;
+    private UUID strengtFortroligAdresse;
 }

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/AdGruppeTilganger.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/AdGruppeTilganger.java
@@ -1,0 +1,15 @@
+package no.nav.tag.tiltaksgjennomforing.autorisasjon;
+
+public record AdGruppeTilganger(
+    boolean beslutter,
+    boolean fortroligAdresse,
+    boolean strengtFortroligAdresse
+) {
+    public static AdGruppeTilganger av(AdGruppeProperties adGrupperProperties, TokenUtils tokenUtils) {
+        return new AdGruppeTilganger(
+            tokenUtils.harAdGruppe(adGrupperProperties.getBeslutter()),
+            tokenUtils.harAdGruppe(adGrupperProperties.getFortroligAdresse()),
+            tokenUtils.harAdGruppe(adGrupperProperties.getStrengtFortroligAdresse())
+        );
+    }
+}

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/Veileder.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/Veileder.java
@@ -1,6 +1,7 @@
 package no.nav.tag.tiltaksgjennomforing.avtale;
 
 import lombok.extern.slf4j.Slf4j;
+import no.nav.tag.tiltaksgjennomforing.autorisasjon.AdGruppeTilganger;
 import no.nav.tag.tiltaksgjennomforing.autorisasjon.Diskresjonskode;
 import no.nav.tag.tiltaksgjennomforing.autorisasjon.InnloggetBruker;
 import no.nav.tag.tiltaksgjennomforing.autorisasjon.InnloggetVeileder;
@@ -41,14 +42,12 @@ import java.util.stream.Collectors;
 
 @Slf4j
 public class Veileder extends Avtalepart<NavIdent> implements InternBruker {
-    private static final String NAV_VIKAFOSSEN = "2103";
-
     private static final SecureLog secureLog = SecureLog.getLogger(log);
 
     private final TilgangskontrollService tilgangskontrollService;
     private final PersondataService persondataService;
     private final SlettemerkeProperties slettemerkeProperties;
-    private final boolean harAdGruppeForBeslutter;
+    private final AdGruppeTilganger adGruppeTilganger;
     private final Norg2Client norg2Client;
     private final Set<NavEnhet> navEnheter;
     private final VeilarboppfolgingService veilarboppfolgingService;
@@ -63,7 +62,7 @@ public class Veileder extends Avtalepart<NavIdent> implements InternBruker {
             Norg2Client norg2Client,
             Set<NavEnhet> navEnheter,
             SlettemerkeProperties slettemerkeProperties,
-            boolean harAdGruppeForBeslutter,
+            AdGruppeTilganger adGruppeTilganger,
             VeilarboppfolgingService veilarboppfolgingService,
             FeatureToggleService featureToggleService
     ) {
@@ -75,24 +74,9 @@ public class Veileder extends Avtalepart<NavIdent> implements InternBruker {
         this.norg2Client = norg2Client;
         this.navEnheter = navEnheter;
         this.slettemerkeProperties = slettemerkeProperties;
-        this.harAdGruppeForBeslutter = harAdGruppeForBeslutter;
+        this.adGruppeTilganger = adGruppeTilganger;
         this.veilarboppfolgingService = veilarboppfolgingService;
         this.featureToggleService = featureToggleService;
-    }
-
-    @Deprecated
-    public Veileder(
-            NavIdent identifikator,
-            TilgangskontrollService tilgangskontrollService,
-            PersondataService persondataService,
-            Norg2Client norg2Client,
-            Set<NavEnhet> navEnheter,
-            SlettemerkeProperties slettemerkeProperties,
-            boolean harAdGruppeForBeslutter,
-            VeilarboppfolgingService veilarboppfolgingService,
-            FeatureToggleService featureToggleService
-    ) {
-        this(identifikator, null, tilgangskontrollService, persondataService, norg2Client, navEnheter, slettemerkeProperties, harAdGruppeForBeslutter, veilarboppfolgingService, featureToggleService);
     }
 
     @Override
@@ -103,10 +87,8 @@ public class Veileder extends Avtalepart<NavIdent> implements InternBruker {
     ) {
         Page<Avtale> avtaler = hentAvtalerMedLesetilgang(avtaleRepository, queryParametre, pageable);
 
-        boolean isSkalViseDiskresjonskoder = avtaler.getContent().stream()
-            .anyMatch(avtale -> NAV_VIKAFOSSEN.equals(avtale.getEnhetOppfolging()));
-
-        Map<Fnr, Diskresjonskode> diskresjon = isSkalViseDiskresjonskoder ? persondataService.hentDiskresjonskoder(
+        boolean isSkalHenteDiskresjonskoder = adGruppeTilganger.fortroligAdresse() || adGruppeTilganger.strengtFortroligAdresse();
+        Map<Fnr, Diskresjonskode> diskresjon = isSkalHenteDiskresjonskoder ? persondataService.hentDiskresjonskoder(
             avtaler.getContent().stream().map(Avtale::getDeltakerFnr).collect(Collectors.toSet())
         ) : Map.of();
 
@@ -219,7 +201,7 @@ public class Veileder extends Avtalepart<NavIdent> implements InternBruker {
 
     @Override
     public InnloggetBruker innloggetBruker() {
-        return new InnloggetVeileder(getIdentifikator(), navEnheter, harAdGruppeForBeslutter);
+        return new InnloggetVeileder(getIdentifikator(), navEnheter, adGruppeTilganger.beslutter());
     }
 
     public void delAvtaleMedAvtalepart(Avtalerolle avtalerolle, Avtale avtale) {

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/featuretoggles/enhet/NavEnhet.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/featuretoggles/enhet/NavEnhet.java
@@ -1,9 +1,17 @@
 package no.nav.tag.tiltaksgjennomforing.featuretoggles.enhet;
 
+import lombok.EqualsAndHashCode;
 import lombok.Value;
 
 @Value
+@EqualsAndHashCode(of = "verdi")
 public class NavEnhet {
+    public static final NavEnhet NAV_VIKAFOSSEN = new NavEnhet("2103", "Nav Vikafossen");
+
     String verdi;
     String navn;
+
+    public boolean equalsEnhetsnummer(String verdi) {
+        return this.equals(new NavEnhet(verdi, null));
+    }
 }

--- a/src/main/resources/config/application-dev-fss.yaml
+++ b/src/main/resources/config/application-dev-fss.yaml
@@ -104,6 +104,10 @@ tiltaksgjennomforing:
     consumerId: ${tiltaksgjennomforing.serviceuser.username}
     azureConfig: true
     realClient: true
+  ad-grupper:
+    beslutter: fbfea82d-13da-43ad-a2f2-d7f21cb95f12
+    fortrolig-adresse: ea930b6b-9397-44d9-b9e6-f4cf527a632a
+    strengt-fortrolig-adresse: 5ef775f2-61f8-4283-bf3d-8d03f428aa14
   database:
     database-navn: tiltaksgjennomforing-p15-preprod
     database-url: ${spring.datasource.url}

--- a/src/main/resources/config/application-dev-gcp-labs.yaml
+++ b/src/main/resources/config/application-dev-gcp-labs.yaml
@@ -28,8 +28,10 @@ no.nav.security.jwt:
 tiltaksgjennomforing:
   kontoregister:
     fake: true
-  beslutter-ad-gruppe:
-    id: 1a1d2745-952f-4a0f-839f-9530145b1d4a
+  ad-grupper:
+    beslutter: 1a1d2745-952f-4a0f-839f-9530145b1d4a
+    fortrolig-adresse: ea930b6b-9397-44d9-b9e6-f4cf527a632a
+    strengt-fortrolig-adresse: 5ef775f2-61f8-4283-bf3d-8d03f428aa14
   kafka:
     enabled: false
     fake-url: http://tiltak-refusjon-api-labs/fake-kafka

--- a/src/main/resources/config/application-prod-fss.yaml
+++ b/src/main/resources/config/application-prod-fss.yaml
@@ -101,6 +101,10 @@ tiltaksgjennomforing:
     consumerId: ${tiltaksgjennomforing.serviceuser.username}
     azureConfig: true
     realClient: true
+  ad-grupper:
+    beslutter: 156f4f79-6909-4be1-8045-323f55590898
+    fortrolig-adresse: 9ec6487d-f37a-4aad-a027-cd221c1ac32b
+    strengt-fortrolig-adresse: ad7b87a6-9180-467c-affc-20a566b0fec0
   database:
     database-navn: tiltaksgjennomforing-p15-prod
     database-url: ${spring.datasource.url}

--- a/src/main/resources/config/application.yaml
+++ b/src/main/resources/config/application.yaml
@@ -54,8 +54,6 @@ tiltaksgjennomforing:
   retry: # Delay i millisekunder mellom hver retry
     delay: 1000
     max-delay: 20000
-  beslutter-ad-gruppe:
-    id: ${beslutter.ad.gruppe}
   kafka:
     enabled: true
   dokgen:

--- a/src/test/java/no/nav/security/jwt/test/support/TokenGeneratorController.java
+++ b/src/test/java/no/nav/security/jwt/test/support/TokenGeneratorController.java
@@ -7,7 +7,7 @@ import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import no.nav.security.token.support.core.api.Unprotected;
-import no.nav.tag.tiltaksgjennomforing.autorisasjon.BeslutterAdGruppeProperties;
+import no.nav.tag.tiltaksgjennomforing.autorisasjon.AdGruppeProperties;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -29,10 +29,10 @@ public class TokenGeneratorController {
 
     public static final String ISSO_IDTOKEN = "isso-idtoken";
     public static final String SELVBETJENING_IDTOKEN = "selvbetjening-idtoken";
-    private BeslutterAdGruppeProperties beslutterAdGruppeProperties;
+    private AdGruppeProperties adGruppeProperties;
 
-    public TokenGeneratorController(BeslutterAdGruppeProperties beslutterAdGruppeProperties) {
-        this.beslutterAdGruppeProperties = beslutterAdGruppeProperties;
+    public TokenGeneratorController(AdGruppeProperties adGruppeProperties) {
+        this.adGruppeProperties = adGruppeProperties;
     }
 
     private static void bakeCookie(
@@ -97,7 +97,7 @@ public class TokenGeneratorController {
                                        @RequestParam(value = "expiry", required = false) String expiry,
                                        HttpServletResponse response) throws IOException {
         bakeCookie(subject, cookieName, redirect, expiry, response, new HashMap<>(), "selvbetjening", "aud-selvbetjening", acrLevel,
-                List.of(beslutterAdGruppeProperties.getId().toString()));
+                List.of(adGruppeProperties.getBeslutter().toString()));
     }
 
     @Unprotected
@@ -110,7 +110,7 @@ public class TokenGeneratorController {
                              HttpServletResponse response
     ) throws IOException {
         bakeCookie(subject, cookieName, redirect, expiry, response, Collections.singletonMap("NAVident", navIdent), "isso", "aud-isso", null,
-                Collections.singletonList(beslutterAdGruppeProperties.getId().toString()));
+                Collections.singletonList(adGruppeProperties.getBeslutter().toString()));
     }
 
     @Unprotected

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/InnloggetBrukerTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/InnloggetBrukerTest.java
@@ -56,12 +56,13 @@ public class InnloggetBrukerTest {
     public void harTilgang__veileder_skal_ha_lesetilgang_til_avtale_hvis_toggle_er_på_og_tilgangskontroll_er_ok() {
         Veileder veileder = new Veileder(
                 navIdent,
+                null,
                 tilgangskontrollService,
                 persondataService,
                 norg2Client,
                 Collections.emptySet(),
                 new SlettemerkeProperties(),
-                false,
+                TestData.INGEN_AD_GRUPPER,
                 veilarboppfolgingService,
                 featureToggleService
         );
@@ -78,12 +79,13 @@ public class InnloggetBrukerTest {
     public void harTilgang__veileder_skal_ikke_ha_lesetilgang_til_avtale_hvis_toggle_er_på_og_tilgangskontroll_feiler() {
         Veileder veileder = new Veileder(
                 navIdent,
+                null,
                 tilgangskontrollService,
                 persondataService,
                 norg2Client,
                 Collections.emptySet(),
                 new SlettemerkeProperties(),
-                false,
+                TestData.INGEN_AD_GRUPPER,
                 veilarboppfolgingService,
                 featureToggleService
         );
@@ -99,12 +101,13 @@ public class InnloggetBrukerTest {
     public void harTilgang__veileder_skal_ha_skrivetilgang_til_avtale_hvis_toggle_er_på_og_tilgangskontroll_er_ok() {
         Veileder veileder = new Veileder(
                 navIdent,
+                null,
                 tilgangskontrollService,
                 persondataService,
                 norg2Client,
                 Collections.emptySet(),
                 new SlettemerkeProperties(),
-                false,
+                TestData.INGEN_AD_GRUPPER,
                 veilarboppfolgingService,
                 featureToggleService
         );
@@ -121,12 +124,13 @@ public class InnloggetBrukerTest {
     public void harTilgang__veileder_skal_ikke_ha_skrivetilgang_til_avtale_hvis_toggle_er_på_og_tilgangskontroll_feiler() {
         Veileder veileder = new Veileder(
                 navIdent,
+                null,
                 tilgangskontrollService,
                 persondataService,
                 norg2Client,
                 Collections.emptySet(),
                 new SlettemerkeProperties(),
-                false,
+                TestData.INGEN_AD_GRUPPER,
                 veilarboppfolgingService,
                 featureToggleService
         );
@@ -155,12 +159,13 @@ public class InnloggetBrukerTest {
         assertThat(
                 new Veileder(
                         new NavIdent("X123456"),
+                        null,
                         tilgangskontrollService,
                         persondataService,
                         norg2Client,
                         Collections.emptySet(),
                         new SlettemerkeProperties(),
-                        false,
+                        TestData.INGEN_AD_GRUPPER,
                         veilarboppfolgingService,
                         featureToggleService
                 ).harTilgangTilAvtale(avtale)
@@ -172,12 +177,13 @@ public class InnloggetBrukerTest {
         assertThat(
                 new Veileder(
                         new NavIdent("X123456"),
+                        null,
                         tilgangskontrollService,
                         persondataService,
                         norg2Client,
                         Collections.emptySet(),
                         new SlettemerkeProperties(),
-                        false,
+                        TestData.INGEN_AD_GRUPPER,
                         veilarboppfolgingService,
                         featureToggleService
                 ).harTilgangTilAvtale(avtale)

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/InnloggingServiceTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/InnloggingServiceTest.java
@@ -47,7 +47,7 @@ public class InnloggingServiceTest {
     private SystembrukerProperties systembrukerProperties;
 
     @Mock
-    private BeslutterAdGruppeProperties beslutterAdGruppeProperties;
+    private AdGruppeProperties beslutterAdGruppeProperties;
 
     @Mock
     private ArbeidsgiverTokenStrategyFactoryImpl arbeidsgiverTokenStrategyFactory;

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleApiTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleApiTest.java
@@ -71,12 +71,13 @@ public class AvtaleApiTest {
         var navIdent = TestData.enNavIdent();
         Veileder veileder = new Veileder(
                 navIdent,
+                null,
                 tilgangskontrollService,
                 persondataService,
                 norg2Client,
                 Collections.emptySet(),
                 new SlettemerkeProperties(),
-                false,
+                TestData.INGEN_AD_GRUPPER,
                 veilarboppfolgingService,
                 featureToggleService
         );

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleControllerTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleControllerTest.java
@@ -121,12 +121,13 @@ public class AvtaleControllerTest {
         værInnloggetSom(
                 new Veileder(
                         new NavIdent("Z333333"),
+                        null,
                         tilgangskontrollService,
                         persondataService,
                         norg2Client,
                         Collections.emptySet(),
                         new SlettemerkeProperties(),
-                        false,
+                        TestData.INGEN_AD_GRUPPER,
                         veilarboppfolgingService,
                         featureToggleServiceMock
                 )
@@ -145,12 +146,13 @@ public class AvtaleControllerTest {
         NavIdent identTilInnloggetVeileder = new NavIdent("Z333333");
         Veileder veileder = new Veileder(
                 identTilInnloggetVeileder,
+                null,
                 tilgangskontrollService,
                 persondataService,
                 norg2Client,
                 Collections.emptySet(),
                 new SlettemerkeProperties(),
-                false,
+                TestData.INGEN_AD_GRUPPER,
                 veilarboppfolgingService,
                 featureToggleServiceMock
         );
@@ -188,12 +190,13 @@ public class AvtaleControllerTest {
         NavIdent navIdent = new NavIdent("Z123456");
         Veileder veileder = new Veileder(
                 navIdent,
+                null,
                 tilgangskontrollService,
                 persondataService,
                 norg2Client,
                 Collections.emptySet(),
                 new SlettemerkeProperties(),
-                false,
+                TestData.INGEN_AD_GRUPPER,
                 veilarboppfolgingService,
                 featureToggleServiceMock
         );
@@ -227,12 +230,13 @@ public class AvtaleControllerTest {
         NavIdent navIdent = new NavIdent("Z123456");
         Veileder veileder = new Veileder(
                 navIdent,
+                null,
                 tilgangskontrollService,
                 persondataService,
                 norg2Client,
                 Collections.emptySet(),
                 new SlettemerkeProperties(),
-                false,
+                TestData.INGEN_AD_GRUPPER,
                 veilarboppfolgingService,
                 featureToggleServiceMock
         );
@@ -285,12 +289,13 @@ public class AvtaleControllerTest {
         );
         var veileder = new Veileder(
                 navIdent,
+                null,
                 tilgangskontrollService,
                 persondataService,
                 norg2Client,
                 Set.of(navEnhet),
                 new SlettemerkeProperties(),
-                false,
+                TestData.INGEN_AD_GRUPPER,
                 veilarboppfolgingService,
                 featureToggleServiceMock
         );
@@ -347,12 +352,13 @@ public class AvtaleControllerTest {
         Avtale avtale = TestData.enArbeidstreningAvtale();
         Veileder veileder = new Veileder(
                 enNavIdent(),
+                null,
                 tilgangskontrollService,
                 persondataService,
                 norg2Client,
                 Collections.emptySet(),
                 new SlettemerkeProperties(),
-                false,
+                TestData.INGEN_AD_GRUPPER,
                 veilarboppfolgingService,
                 featureToggleServiceMock
         );
@@ -420,12 +426,13 @@ public class AvtaleControllerTest {
         when(featureToggleServiceMock.isEnabled(FeatureToggle.KODE_6_SPERRE)).thenReturn(true);
         Veileder enNavAnsatt = new Veileder(
                 new NavIdent("T000000"),
+                null,
                 tilgangskontrollService,
                 persondataServiceIMetode,
                 norg2Client,
                 Collections.emptySet(),
                 new SlettemerkeProperties(),
-                false,
+                TestData.INGEN_AD_GRUPPER,
                 veilarboppfolgingService,
                 featureToggleServiceMock
         );
@@ -448,12 +455,13 @@ public class AvtaleControllerTest {
         when(featureToggleServiceMock.isEnabled(FeatureToggle.KODE_6_SPERRE)).thenReturn(false);
         Veileder enNavAnsatt = new Veileder(
                 new NavIdent("T000000"),
+                null,
                 tilgangskontrollService,
                 persondataServiceIMetode,
                 norg2Client,
                 Collections.emptySet(),
                 new SlettemerkeProperties(),
-                false,
+                TestData.INGEN_AD_GRUPPER,
                 veilarboppfolgingService,
                 featureToggleServiceMock
         );
@@ -476,12 +484,13 @@ public class AvtaleControllerTest {
         when(featureToggleServiceMock.isEnabled(FeatureToggle.KODE_6_SPERRE)).thenReturn(true);
         Veileder enNavAnsatt = new Veileder(
                 new NavIdent("T000000"),
+                null,
                 tilgangskontrollService,
                 persondataServiceIMetode,
                 norg2Client,
                 Collections.emptySet(),
                 new SlettemerkeProperties(),
-                false,
+                TestData.INGEN_AD_GRUPPER,
                 veilarboppfolgingService,
                 featureToggleServiceMock
         );
@@ -559,12 +568,13 @@ public class AvtaleControllerTest {
         NavIdent identTilInnloggetVeileder = new NavIdent("Z333333");
         Veileder veileder = new Veileder(
                 identTilInnloggetVeileder,
+                null,
                 tilgangskontrollService,
                 persondataService,
                 norg2Client,
                 Collections.emptySet(),
                 new SlettemerkeProperties(),
-                false,
+                TestData.INGEN_AD_GRUPPER,
                 veilarboppfolgingService,
                 featureToggleServiceMock
         );
@@ -588,12 +598,13 @@ public class AvtaleControllerTest {
         NavIdent identTilInnloggetVeileder = new NavIdent("Z333333");
         Veileder veileder = new Veileder(
                 identTilInnloggetVeileder,
+                null,
                 tilgangskontrollService,
                 persondataService,
                 norg2Client,
                 Collections.emptySet(),
                 new SlettemerkeProperties(),
-                false,
+                TestData.INGEN_AD_GRUPPER,
                 veilarboppfolgingService,
                 featureToggleServiceMock
         );
@@ -615,12 +626,13 @@ public class AvtaleControllerTest {
         NavIdent identTilInnloggetVeileder = new NavIdent("Z333333");
         Veileder veileder = new Veileder(
                 identTilInnloggetVeileder,
+                null,
                 tilgangskontrollService,
                 persondataService,
                 norg2Client,
                 Collections.emptySet(),
                 new SlettemerkeProperties(),
-                false,
+                TestData.INGEN_AD_GRUPPER,
                 veilarboppfolgingService,
                 featureToggleServiceMock
         );

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleTest.java
@@ -1532,12 +1532,13 @@ public class AvtaleTest {
 
         Veileder veileder = new Veileder(
                 avtale.getVeilederNavIdent(),
+                null,
                 tilgangskontrollService,
                 persondataService,
                 mock(Norg2Client.class),
                 Set.of(new NavEnhet("4802", "Trysil")),
                 mock(SlettemerkeProperties.class),
-                false,
+                TestData.INGEN_AD_GRUPPER,
                 mock(VeilarboppfolgingService.class),
                 mock(FeatureToggleService.class)
         );
@@ -1569,12 +1570,13 @@ public class AvtaleTest {
 
         Veileder veileder = new Veileder(
                 avtale.getVeilederNavIdent(),
+                null,
                 tilgangskontrollService,
                 persondataService,
                 mock(Norg2Client.class),
                 Set.of(new NavEnhet("4802", "Trysil")),
                 mock(SlettemerkeProperties.class),
-                false,
+                TestData.INGEN_AD_GRUPPER,
                 mock(VeilarboppfolgingService.class),
                 mock(FeatureToggleService.class)
         );
@@ -1678,12 +1680,13 @@ public class AvtaleTest {
 
         Veileder veileder = new Veileder(
                 avtale.getVeilederNavIdent(),
+                null,
                 tilgangskontrollService,
                 persondataService,
                 mock(Norg2Client.class),
                 Set.of(new NavEnhet("4802", "Trysil")),
                 mock(SlettemerkeProperties.class),
-                false,
+                TestData.INGEN_AD_GRUPPER,
                 mock(VeilarboppfolgingService.class),
                 mock(FeatureToggleService.class)
         );
@@ -1720,12 +1723,13 @@ public class AvtaleTest {
 
         Veileder veileder = new Veileder(
                 avtale.getVeilederNavIdent(),
+                null,
                 tilgangskontrollService,
                 persondataService,
                 mock(Norg2Client.class),
                 Set.of(new NavEnhet("4802", "Trysil")),
                 mock(SlettemerkeProperties.class),
-                false,
+                TestData.INGEN_AD_GRUPPER,
                 mock(VeilarboppfolgingService.class),
                 mock(FeatureToggleService.class)
         );

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/BeslutterTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/BeslutterTest.java
@@ -53,12 +53,13 @@ class BeslutterTest {
 
         Veileder veileder = new Veileder(
                 avtale.getVeilederNavIdent(),
+                null,
                 tilgangskontrollService,
                 persondataService,
                 mock(Norg2Client.class),
                 Set.of(new NavEnhet("4802", "Trysil")),
                 mock(SlettemerkeProperties.class),
-                false,
+                TestData.INGEN_AD_GRUPPER,
                 mock(VeilarboppfolgingService.class),
                 featureToggleServiceMock);
 

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/TestData.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/TestData.java
@@ -1,6 +1,7 @@
 package no.nav.tag.tiltaksgjennomforing.avtale;
 
 import no.nav.arbeidsgiver.altinnrettigheter.proxy.klient.model.AltinnReportee;
+import no.nav.tag.tiltaksgjennomforing.autorisasjon.AdGruppeTilganger;
 import no.nav.tag.tiltaksgjennomforing.autorisasjon.Diskresjonskode;
 import no.nav.tag.tiltaksgjennomforing.autorisasjon.InnloggetArbeidsgiver;
 import no.nav.tag.tiltaksgjennomforing.autorisasjon.InnloggetBeslutter;
@@ -47,10 +48,10 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 public class TestData {
-
     public static NavEnhet ENHET_OPPFØLGING = new NavEnhet("0906", "Oslo gamlebyen");
     public static NavEnhet ENHET_GEOGRAFISK = new NavEnhet("0904", "Vinstra");
     public static Integer ET_AVTALENR = 10;
+    public static AdGruppeTilganger INGEN_AD_GRUPPER = new AdGruppeTilganger(false, false, false);
 
     public static FeatureToggleService featureToggleService = mock(FeatureToggleService.class);
 
@@ -878,12 +879,13 @@ public class TestData {
         final VeilarboppfolgingService veilarbArenaClient = mock(VeilarboppfolgingService.class);
         var veileder = new Veileder(
                 avtale.getVeilederNavIdent(),
+                null,
                 tilgangskontrollService,
                 persondataService,
                 norg2Client,
                 Set.of(new NavEnhet(avtale.getEnhetOppfolging(), avtale.getEnhetsnavnOppfolging())),
                 new SlettemerkeProperties(),
-                false,
+                TestData.INGEN_AD_GRUPPER,
                 veilarbArenaClient,
                 featureToggleService
         );
@@ -910,12 +912,13 @@ public class TestData {
 
         var veileder = new Veileder(
                 avtale.getVeilederNavIdent(),
+                null,
                 tilgangskontrollService,
                 persondataService,
                 mock(Norg2Client.class),
                 Set.of(new NavEnhet("4802", "Oslo gamlebyen")),
                 new SlettemerkeProperties(),
-                false,
+                TestData.INGEN_AD_GRUPPER,
                 veilarboppfolgingService,
                 featureToggleService
         );
@@ -953,6 +956,7 @@ public class TestData {
     public static Beslutter enBeslutter(Avtale avtale) {
         TilgangskontrollService tilgangskontrollService = mock(TilgangskontrollService.class);
         Norg2Client norg2Client = mock(Norg2Client.class);
+        PersondataService persondataService = mock(PersondataService.class);
         NavIdent navIdent = new NavIdent("B999999");
         var beslutter = new Beslutter(navIdent, UUID.randomUUID(), Set.of(), tilgangskontrollService, norg2Client);
         when(tilgangskontrollService.harSkrivetilgangTilKandidat(beslutter, avtale.getDeltakerFnr())).thenReturn(true);
@@ -1074,12 +1078,13 @@ public class TestData {
         PersondataService persondataService = mock(PersondataService.class);
         var veileder = new Veileder(
                 navIdent,
+                null,
                 tilgangskontrollService,
                 persondataService,
                 mock(Norg2Client.class),
                 Set.of(ENHET_OPPFØLGING),
                 new SlettemerkeProperties(),
-                false,
+                TestData.INGEN_AD_GRUPPER,
                 veilarboppfolgingService,
                 featureToggleService
         );
@@ -1092,12 +1097,13 @@ public class TestData {
         TilgangskontrollService tilgangskontrollService = mock(TilgangskontrollService.class);
         var veileder = new Veileder(
                 avtale.getVeilederNavIdent(),
+                null,
                 tilgangskontrollService,
                 persondataService,
                 mock(Norg2Client.class),
                 Set.of(ENHET_OPPFØLGING),
                 new SlettemerkeProperties(),
-                false,
+                TestData.INGEN_AD_GRUPPER,
                 mock(VeilarboppfolgingService.class),
                 featureToggleService
         );

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/VeilederTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/VeilederTest.java
@@ -240,12 +240,13 @@ public class VeilederTest {
         when(veilarboppfolgingServiceMock.hentOgSjekkOppfolgingstatus(avtale)).thenReturn(new Oppfølgingsstatus(Formidlingsgruppe.ARBEIDSSOKER, Kvalifiseringsgruppe.VARIG_TILPASSET_INNSATS, "0906"));
         Veileder veileder = new Veileder(
                 avtale.getVeilederNavIdent(),
+                null,
                 tilgangskontrollService,
                 persondataService,
                 mock(Norg2Client.class),
                 Set.of(new NavEnhet("4802", "Trysil")),
                 mock(SlettemerkeProperties.class),
-                false,
+                TestData.INGEN_AD_GRUPPER,
                 veilarboppfolgingServiceMock,
                 featureToggleServiceMock
         );
@@ -420,12 +421,13 @@ public class VeilederTest {
 
         Veileder veileder = new Veileder(
                 navIdent,
+                null,
                 tilgangskontrollService,
                 new PersondataService(persondataClient),
                 norg2Client,
                 Set.of(navEnhet),
                 new SlettemerkeProperties(),
-                false,
+                TestData.INGEN_AD_GRUPPER,
                 veilarboppfolgingService,
                 featureToggleServiceMock
         );
@@ -471,12 +473,13 @@ public class VeilederTest {
 
         Veileder veileder = new Veileder(
                 navIdent,
+                null,
                 tilgangskontrollService,
                 new PersondataService(persondataClient),
                 norg2Client,
                 Set.of(navEnhet),
                 new SlettemerkeProperties(),
-                false,
+                TestData.INGEN_AD_GRUPPER,
                 veilarboppfolgingService,
                 featureToggleServiceMock
         );
@@ -506,12 +509,13 @@ public class VeilederTest {
         FeatureToggleService featureToggleServiceMock = mock(FeatureToggleService.class);
         Veileder veileder = new Veileder(
                 navIdent,
+                null,
                 tilgangskontrollService,
                 mock(PersondataService.class),
                 mock(Norg2Client.class),
                 Set.of(new NavEnhet("4802", "Trysil")),
                 slettemerkeProperties,
-                false,
+                TestData.INGEN_AD_GRUPPER,
                 mock(VeilarboppfolgingService.class),
                 featureToggleServiceMock
         );
@@ -535,12 +539,13 @@ public class VeilederTest {
         slettemerkeProperties.setIdent(List.of(new NavIdent("Z123456")));
         Veileder veileder = new Veileder(
                 navIdent,
+                null,
                 tilgangskontrollService,
                 mock(PersondataService.class),
                 mock(Norg2Client.class),
                 Set.of(new NavEnhet("4802", "Trysil")),
                 slettemerkeProperties,
-                false,
+                TestData.INGEN_AD_GRUPPER,
                 mock(VeilarboppfolgingService.class),
                 featureToggleServiceMock
         );

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/VtaoTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/VtaoTest.java
@@ -60,12 +60,13 @@ public class VtaoTest {
         var navIdent = TestData.enNavIdent();
         Veileder veileder = new Veileder(
                 navIdent,
+                null,
                 tilgangskontrollService,
                 persondataService,
                 norg2Client,
                 Collections.emptySet(),
                 new SlettemerkeProperties(),
-                false,
+                TestData.INGEN_AD_GRUPPER,
                 veilarboppfolgingService,
                 featureToggleService
         );
@@ -84,12 +85,13 @@ public class VtaoTest {
         var navIdent = TestData.enNavIdent();
         Veileder veileder = new Veileder(
                 navIdent,
+                null,
                 tilgangskontrollService,
                 persondataService,
                 norg2Client,
                 Collections.emptySet(),
                 new SlettemerkeProperties(),
-                false,
+                TestData.INGEN_AD_GRUPPER,
                 veilarboppfolgingService,
                 featureToggleService
         );
@@ -148,12 +150,13 @@ public class VtaoTest {
         var navIdent = TestData.enNavIdent();
         Veileder veileder = new Veileder(
                 navIdent,
+                null,
                 tilgangskontrollService,
                 persondataService,
                 norg2Client,
                 Collections.emptySet(),
                 new SlettemerkeProperties(),
-                false,
+                TestData.INGEN_AD_GRUPPER,
                 veilarboppfolgingService,
                 featureToggleService
         );
@@ -210,12 +213,13 @@ public class VtaoTest {
         var navIdent = TestData.enNavIdent();
         Veileder veileder = new Veileder(
                 navIdent,
+                null,
                 tilgangskontrollService,
                 persondataService,
                 norg2Client,
                 Collections.emptySet(),
                 new SlettemerkeProperties(),
-                false,
+                TestData.INGEN_AD_GRUPPER,
                 veilarboppfolgingService,
                 featureToggleService
         );

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/infrastruktur/caching/CachingConfigMockTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/infrastruktur/caching/CachingConfigMockTest.java
@@ -272,12 +272,13 @@ public class CachingConfigMockTest {
 
         Veileder veileder = new Veileder(
                 avtale.getVeilederNavIdent(),
+                null,
                 tilgangskontrollService,
                 new PersondataService(persondataClient),
                 norg2Client,
                 Set.of(new NavEnhet(avtale.getEnhetOppfolging(), avtale.getEnhetsnavnOppfolging())),
                 new SlettemerkeProperties(),
-                false,
+                TestData.INGEN_AD_GRUPPER,
                 veilarboppfolgingService,
                 mockFeatureToggleService
         );

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/infrastruktur/caching/CachingConfigTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/infrastruktur/caching/CachingConfigTest.java
@@ -179,13 +179,15 @@ public class CachingConfigTest {
 
         Veileder veileder = new Veileder(
                 avtale.getVeilederNavIdent(),
+                null,
                 mockTilgangskontrollService,
                 new PersondataService(persondataClient),
                 norg2Client,
                 Set.of(new NavEnhet(avtale.getEnhetOppfolging(), avtale.getEnhetsnavnOppfolging())),
                 new SlettemerkeProperties(),
-                false,
-            veilarboppfolgingService, featureToggleServiceMock
+                TestData.INGEN_AD_GRUPPER,
+                veilarboppfolgingService,
+                featureToggleServiceMock
         );
 
         lenient().when(mockTilgangskontrollService.harSkrivetilgangTilKandidat(

--- a/src/test/resources/config/application-dockercompose.yml
+++ b/src/test/resources/config/application-dockercompose.yml
@@ -39,8 +39,10 @@ tiltaksgjennomforing:
     uri: http://localhost:8090/kontoregister/api/v1/hent-kontonr-org
     consumerId: tiltak-refusjon-api
     realClient: true
-  beslutter-ad-gruppe:
-    id: 1a1d2745-952f-4a0f-839f-9530145b1d4a
+  ad-grupper:
+    beslutter: 1a1d2745-952f-4a0f-839f-9530145b1d4a
+    fortrolig-adresse: ea930b6b-9397-44d9-b9e6-f4cf527a632a
+    strengt-fortrolig-adresse: 5ef775f2-61f8-4283-bf3d-8d03f428aa14
   kafka:
     enabled: true
 

--- a/src/test/resources/config/application-local.yaml
+++ b/src/test/resources/config/application-local.yaml
@@ -69,8 +69,10 @@ tiltaksgjennomforing:
     uri: http://localhost:8090/kontoregister/api/v1/hent-kontonr-org
     consumerId: tiltak-refusjon-api
     realClient: true
-  beslutter-ad-gruppe:
-    id: 1a1d2745-952f-4a0f-839f-9530145b1d4a
+  ad-grupper:
+    beslutter: 1a1d2745-952f-4a0f-839f-9530145b1d4a
+    fortrolig-adresse: ea930b6b-9397-44d9-b9e6-f4cf527a632a
+    strengt-fortrolig-adresse: 5ef775f2-61f8-4283-bf3d-8d03f428aa14
   kafka:
     enabled: false
     fake-url: http://localhost:8081/fake-kafka

--- a/src/test/resources/config/application-test.yaml
+++ b/src/test/resources/config/application-test.yaml
@@ -54,8 +54,10 @@ tiltaksgjennomforing:
     uri: http://localhost:8090/kontoregister/api/v1/hent-kontonr-org
     consumerId: tiltak-refusjon-api
     realClient: true
-  beslutter-ad-gruppe:
-    id: 1a1d2745-952f-4a0f-839f-9530145b1d4a
+  ad-grupper:
+    beslutter: 1a1d2745-952f-4a0f-839f-9530145b1d4a
+    fortrolig-adresse: ea930b6b-9397-44d9-b9e6-f4cf527a632a
+    strengt-fortrolig-adresse: 5ef775f2-61f8-4283-bf3d-8d03f428aa14
   kafka:
     enabled: false
     fake-url: http://localhost:8081/fake-kafka


### PR DESCRIPTION
Bruk AD-grupper som indikasjon på om veileder har tilgang til fortrolig eller strengt fortrolig adresser for å vite om vi må hente diskresjonskoder i oversikten