### PR TITLE
Rutine for oppdatering av VTAO-tilskudd

### DIFF
--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/TilskuddPeriodeRepository.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/TilskuddPeriodeRepository.java
@@ -2,8 +2,10 @@ package no.nav.tag.tiltaksgjennomforing.avtale;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Query;
 
 import java.time.LocalDate;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -15,4 +17,11 @@ public interface TilskuddPeriodeRepository extends JpaRepository<TilskuddPeriode
 
     List<TilskuddPeriode> findAllByAvtaleAndSluttDatoBefore(Avtale avtale, LocalDate sluttDato);
 
+    @Query("""
+          select t from TilskuddPeriode t join fetch t.avtale av
+          where av.tiltakstype = 'VTAO'
+          and t.status = 'UBEHANDLET'
+          and t.beløp is null and year(t.startDato) in (:aar)
+        """)
+    List<TilskuddPeriode> ubehandledeVtaoTilskuddUtenBelopForAar(Collection<Integer> aar);
 }

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/admin/AdminController.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/admin/AdminController.java
@@ -37,9 +37,12 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
+
+import static no.nav.tag.tiltaksgjennomforing.satser.Sats.VTAO_SATS;
 
 @ProtectedWithClaims(issuer = "azure-access-token", claimMap = { "groups=fb516b74-0f2e-4b62-bad8-d70b82c3ae0b" })
 @RestController
@@ -261,6 +264,22 @@ public class AdminController {
         LocalDate startDato = LocalDate.parse((String) parametere.getOrDefault("startDato", null));
         avtale.midlertidigEndreAvtale(Now.instant(), startDato);
         avtaleRepository.save(avtale);
+    }
+
+    @PostMapping("/oppdater-tilskuddsperiode-belop-vtao")
+    @Transactional
+    public void oppdaterTilskuddsperiodeBelopVtao() {
+        Set<Integer> kjenteVtaoSatsAar = VTAO_SATS.getSatsePerioder().keySet().stream()
+            .map(LocalDate::getYear)
+            .collect(Collectors.toSet());
+        List<TilskuddPeriode> perioderUtenBelop = tilskuddPeriodeRepository.ubehandledeVtaoTilskuddUtenBelopForAar(
+            kjenteVtaoSatsAar
+        );
+
+        perioderUtenBelop.forEach(tilskuddPeriode -> {
+            tilskuddPeriode.setBeløp(VTAO_SATS.hentGjeldendeSats(tilskuddPeriode.getStartDato()));
+        });
+        tilskuddPeriodeRepository.saveAll(perioderUtenBelop);
     }
 
     @GetMapping("/avtale/diskresjonssjekk")

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/satser/Sats.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/satser/Sats.java
@@ -28,6 +28,14 @@ public class Sats {
             )
     ));
 
+    /**
+     * Singleton for å hente ut VTAO-sats for en gitt dato.
+     * <p>
+     * <b>OBS:</b> Når man legger til sats for et nytt år, så vil ikke eksisterende
+     * tilskuddsperioder få oppdatert beløpene sine. Kall admin-endepunktet
+     * <code>oppdater-tilskuddsperiode-belop-vtao</code> når ny sats er lagt til
+     * og deployet.
+     */
     public static final Sats VTAO_SATS = new Sats(List.of(
             new SatsPeriodeData(
                     7_067,


### PR DESCRIPTION
Hvert år får vi ny VTAO-sats, som vi per dags dato hardkoder inn. Men når vi legger til ny sats vil tilskuddsperioder som allerede er generert ikke bli oppdatert med nye beløp.

Derfor legger vi inn et admin-endepunkt som kan kjøres for å etterfylle beløp på tilskuddsperiodene.

På sikt kan vi kanskje finne en bedre rutine på dette, men dette er noe som skal skje en gang i året, så denne rutinen er kanskje ikke ekstremt smertefull.