### PR TITLE
endepunkt for a resende arbeidstrening til dvh

### DIFF
--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleRepository.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleRepository.java
@@ -64,6 +64,8 @@ public interface AvtaleRepository extends JpaRepository<Avtale, UUID>, JpaSpecif
 
     List<Avtale> findAllByGjeldendeInnhold_AvtaleInngåttNotNull();
 
+    List<Avtale> findAllByTiltakstypeInAndGjeldendeInnhold_AvtaleInngåttNotNull(Tiltakstype tiltakstype);
+
     @Query(value = """
         select a from Avtale a
             where a.tiltakstype in (:tiltakstyper)

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/datavarehus/AvroTiltakHendelseFabrikk.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/datavarehus/AvroTiltakHendelseFabrikk.java
@@ -76,7 +76,7 @@ public class AvroTiltakHendelseFabrikk {
     }
 
     private Boolean erMaster(Avtale avtale) {
-        if (avtale.getTiltakstype() == Tiltakstype.SOMMERJOBB || avtale.getTiltakstype() == Tiltakstype.MIDLERTIDIG_LONNSTILSKUDD || avtale.getTiltakstype() == Tiltakstype.VARIG_LONNSTILSKUDD) {
+        if (avtale.getTiltakstype() == Tiltakstype.SOMMERJOBB || avtale.getTiltakstype() == Tiltakstype.MIDLERTIDIG_LONNSTILSKUDD || avtale.getTiltakstype() == Tiltakstype.VARIG_LONNSTILSKUDD || avtale.getTiltakstype() == Tiltakstype.ARBEIDSTRENING) {
             return Boolean.TRUE;
         }
         return Boolean.FALSE;

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/datavarehus/DvhAvtalePatchService.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/datavarehus/DvhAvtalePatchService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import no.nav.tag.tiltaksgjennomforing.avtale.Avtale;
 import no.nav.tag.tiltaksgjennomforing.avtale.AvtaleRepository;
+import no.nav.tag.tiltaksgjennomforing.avtale.Tiltakstype;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -35,6 +36,23 @@ public class DvhAvtalePatchService {
             log.info("Avtale {} skal ikke patches i DVH", avtale.getId());
         });
         log.info("Migrert {} antall avtaler", antallPatchet.get());
+    }
+
+    @Async
+    public void lagDvhPatchMeldingerForTiltakstype(Tiltakstype tiltakstype) {
+        AtomicInteger antallPatchet = new AtomicInteger();
+        List<Avtale> avtaler = avtaleRepository.findAllByTiltakstypeInAndGjeldendeInnhold_AvtaleInngåttNotNull(tiltakstype);
+        avtaler.forEach(avtale -> {
+            if(skalPatches(avtale)) {
+                lagDvhPatchMelding(avtale);
+                antallPatchet.getAndIncrement();
+                if(antallPatchet.get() % 100 == 0) {
+                    log.info("Migrert {} antall avtaler med tiltakstype {}", antallPatchet.get(), tiltakstype);
+                }
+            }
+            log.info("Avtale {} skal ikke patches i DVH", avtale.getId());
+        });
+        log.info("Migrert {} antall avtaler med tiltakstype {}}", antallPatchet.get(), tiltakstype);
     }
 
     @Transactional

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/datavarehus/InternalDvhMeldingProdusentController.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/datavarehus/InternalDvhMeldingProdusentController.java
@@ -5,6 +5,8 @@ import lombok.extern.slf4j.Slf4j;
 import no.nav.security.token.support.core.api.ProtectedWithClaims;
 import no.nav.tag.tiltaksgjennomforing.autorisasjon.TokenUtils;
 import no.nav.tag.tiltaksgjennomforing.avtale.AvtaleRepository;
+import no.nav.tag.tiltaksgjennomforing.avtale.Tiltakstype;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -40,6 +42,12 @@ public class InternalDvhMeldingProdusentController {
     public void patchAlleAvtaler() {
         log.info("Patcher alle avtaler til dvh");
         dvhAvtalePatchService.lagDvhPatchMeldingForAlleAvtaler();
+    }
+
+    @PostMapping("patchtiltakstype/{tiltakstype}")
+    public void patchTiltakstype(@PathVariable Tiltakstype tiltakstype) {
+        log.info("Patcher avtaler med tiltakstype {} til dvh", tiltakstype);
+        dvhAvtalePatchService.lagDvhPatchMeldingerForTiltakstype(tiltakstype);
     }
 
     private record PatchRequest(List<UUID> avtaleIder) {


### PR DESCRIPTION
Datavarehus/Dvh leser i dag både data fra Arena og oss. De betrakter Arena foreløpig som master, men nå vil de gå over til oss.
Da ønsker de at vi setter et masterflagg på meldingene til true og at vi sender meldinger på alle arbeidstreninger på nytt..

I det øyeblikket denne går ut i prod vil jo alle hendelser på arbeidstrening få master=true på meldinger til datavarehus, potensielt (sannsyneligvis) før vi rekker å kalle admin-endepunktet for å sende arbeidstreninger på nytt. Men det gjør kanskje ikke noe..

Bør også sjekke om de trenger absolutt alle arbeidstreninger fra helt tilbake til 2019...