### PR TITLE
Fiks varsel om manglende cache-statistikk

### DIFF
--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/infrastruktur/cache/CacheConfig.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/infrastruktur/cache/CacheConfig.java
@@ -28,6 +28,7 @@ public class CacheConfig {
                 caffMan.registerCustomCache(cache.getName(), Caffeine.newBuilder()
                         .expireAfterWrite(Duration.ofMinutes(cache.getExpiryInMinutes()))
                         .maximumSize(cache.getMaximumSize())
+                        .recordStats()
                         .build()));
         return caffMan;
     }

--- a/src/main/resources/config/application.yaml
+++ b/src/main/resources/config/application.yaml
@@ -94,9 +94,6 @@ no.nav.security.jwt:
 
 caches:
   caffeine:
-    - name: pdl_cache
-      expiryInMinutes: 60
-      maximumSize: 1000
     - name: norgnavn_cache
       expiryInMinutes: 60
       maximumSize: 1000


### PR DESCRIPTION
I loggene våre logges blant annet denne warning'en:

The cache 'pdl_cache' is not recording statistics. No meters except 'cache.size' will be registered. Call 'Caffeine#recordStats()' prior to building the cache for metrics to be recorded.

For å logge cache-metrikker legger vi til recordStats i metoden som bygger cachene våre.