### PR TITLE
Bruk uri-variabler i utgående http-requests

### DIFF
--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/TiltaksgjennomforingConfiguration.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/TiltaksgjennomforingConfiguration.java
@@ -1,5 +1,6 @@
 package no.nav.tag.tiltaksgjennomforing;
 
+import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.client.RestTemplate;
@@ -7,7 +8,7 @@ import org.springframework.web.client.RestTemplate;
 @Configuration
 class TiltaksgjennomforingConfiguration {
     @Bean
-    public RestTemplate noAuthRestTemplate() {
-        return new RestTemplate();
+    public RestTemplate noAuthRestTemplate(RestTemplateBuilder restTemplateBuilder) {
+        return restTemplateBuilder.build();
     }
 }

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/arena/client/hendelse/HendelseAktivitetsplanClient.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/arena/client/hendelse/HendelseAktivitetsplanClient.java
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 
+import java.util.Map;
 import java.util.UUID;
 
 @Component
@@ -23,12 +24,12 @@ public class HendelseAktivitetsplanClient {
         this.restTemplate = azureRestTemplate;
     }
 
-    public void putAktivietsplanId(UUID avtaleId, UUID aktivitetsplanId) {
-        putAktivietsplanId(avtaleId, aktivitetsplanId, false);
+    public void putAktivitetsplanId(UUID avtaleId, UUID aktivitetsplanId) {
+        putAktivitetsplanId(avtaleId, aktivitetsplanId, false);
     }
 
-    public void putAktivietsplanId(UUID avtaleId, UUID aktivitetsplanId, boolean resendSisteMelding) {
-        HendelseAktivietsplanIdRequest request = new HendelseAktivietsplanIdRequest(
+    public void putAktivitetsplanId(UUID avtaleId, UUID aktivitetsplanId, boolean resendSisteMelding) {
+        HendelseAktivitetsplanIdRequest request = new HendelseAktivitetsplanIdRequest(
             aktivitetsplanId,
             resendSisteMelding
         );
@@ -38,10 +39,11 @@ public class HendelseAktivitetsplanClient {
 
         try {
             restTemplate.put(
-                baseUrl + "/tiltak-hendelse-aktivitetsplan/api/avtale/" + avtaleId.toString() + "/aktivitetsplan-id",
-                new HttpEntity<>(request, headers)
+                baseUrl + "/tiltak-hendelse-aktivitetsplan/api/avtale/{avtaleId}/aktivitetsplan-id",
+                new HttpEntity<>(request, headers),
+                Map.of("avtaleId", avtaleId.toString())
             );
-        } catch(RestClientException e) {
+        } catch (RestClientException e) {
             throw new RuntimeException(
                 "Klarte ikke å oppdatere aktivitetsplan id i tiltak-hendelse-aktivitetsplan for avtale: " + avtaleId,
                 e
@@ -55,10 +57,11 @@ public class HendelseAktivitetsplanClient {
 
         try {
             restTemplate.postForLocation(
-                baseUrl + "/tiltak-hendelse-aktivitetsplan/api/avtale/" + avtaleId.toString() + "/send-siste-melding",
-                new HttpEntity<>(null, headers)
+                baseUrl + "/tiltak-hendelse-aktivitetsplan/api/avtale/{avtaleId}/send-siste-melding",
+                new HttpEntity<>(null, headers),
+                Map.of("avtaleId", avtaleId.toString())
             );
-        } catch(RestClientException e) {
+        } catch (RestClientException e) {
             throw new RuntimeException(
                 "Feil ved ny sending av aktivitetsplanmelding for avtale: " + avtaleId,
                 e

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/arena/client/hendelse/HendelseAktivitetsplanIdRequest.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/arena/client/hendelse/HendelseAktivitetsplanIdRequest.java
@@ -2,7 +2,7 @@ package no.nav.tag.tiltaksgjennomforing.arena.client.hendelse;
 
 import java.util.UUID;
 
-public record HendelseAktivietsplanIdRequest(
+public record HendelseAktivitetsplanIdRequest(
     UUID aktivitetsplanId,
     boolean resendSisteMelding
 ) {}

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/arena/client/ords/ArenaOrdsClient.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/arena/client/ords/ArenaOrdsClient.java
@@ -15,7 +15,7 @@ import java.util.Optional;
 
 @Component
 public class ArenaOrdsClient {
-    private String baseUrl;
+    private final String baseUrl;
     private final RestTemplate restTemplate;
     private final ArenaOrdsTokenClient tokenClient;
 

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/arena/service/ArenaAgreementProcessingService.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/arena/service/ArenaAgreementProcessingService.java
@@ -334,7 +334,7 @@ public class ArenaAgreementProcessingService {
 
     private void transferAktivitetsplankort(Avtale avtale, Integer deltakerId) {
         UUID aktivitetsplanId = aktivitetArenaAclClient.getAktivitetsId(deltakerId);
-        hendelseAktivitetsplanClient.putAktivietsplanId(avtale.getId(), aktivitetsplanId);
+        hendelseAktivitetsplanClient.putAktivitetsplanId(avtale.getId(), aktivitetsplanId);
     }
 
     private Optional<ArenaMigrationAction> validate(Avtale avtale, ArenaAgreementAggregate agreementAggregate) {

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/admin/AktivitetsplanAdminController.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/admin/AktivitetsplanAdminController.java
@@ -39,7 +39,7 @@ public class AktivitetsplanAdminController {
 
         Integer deltakerId = deltakerIder.stream().findFirst().orElseThrow(RessursFinnesIkkeException::new);
         UUID aktivitetsplanId = aktivitetArenaAclClient.getAktivitetsId(deltakerId);
-        hendelseAktivitetsplanClient.putAktivietsplanId(avtaleId, aktivitetsplanId, true);
+        hendelseAktivitetsplanClient.putAktivitetsplanId(avtaleId, aktivitetsplanId, true);
     }
 
     /*
@@ -59,7 +59,7 @@ public class AktivitetsplanAdminController {
     @PostMapping("/avtale/{avtaleId}/generer-ny-id")
     public void genererNyId(@PathVariable UUID avtaleId) {
         avtaleRepository.findById(avtaleId).orElseThrow(RessursFinnesIkkeException::new);
-        hendelseAktivitetsplanClient.putAktivietsplanId(avtaleId, UUID.randomUUID(), true);
+        hendelseAktivitetsplanClient.putAktivitetsplanId(avtaleId, UUID.randomUUID(), true);
     }
 
 }

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/enhet/Norg2Client.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/enhet/Norg2Client.java
@@ -8,20 +8,24 @@ import org.springframework.stereotype.Component;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.client.RestTemplate;
 
+import java.util.Map;
 import java.util.Objects;
 
 @Slf4j
 @Component
 @Validated
 public class Norg2Client {
-
-    private final Norg2GeografiskProperties norg2GeografiskProperties;
-    private final Norg2OppfølgingProperties norg2OppfølgingProperties;
+    private final String baseGeografiskUrl;
+    private final String baseOppfølgingUrl;
     private final RestTemplate restTemplate;
 
-    public Norg2Client(Norg2GeografiskProperties norg2GeografiskProperties, Norg2OppfølgingProperties norg2OppfølgingProperties, RestTemplate noAuthRestTemplate) {
-        this.norg2GeografiskProperties = norg2GeografiskProperties;
-        this.norg2OppfølgingProperties = norg2OppfølgingProperties;
+    public Norg2Client(
+        Norg2GeografiskProperties norg2GeografiskProperties,
+        Norg2OppfølgingProperties norg2OppfølgingProperties,
+        RestTemplate noAuthRestTemplate
+    ) {
+        this.baseGeografiskUrl = norg2GeografiskProperties.getUrl();
+        this.baseOppfølgingUrl = norg2OppfølgingProperties.getUrl();
         this.restTemplate = noAuthRestTemplate;
     }
 
@@ -38,7 +42,11 @@ public class Norg2Client {
 
     public Norg2GeoResponse hentGeografiskEnhet(String geoOmråde) {
         try {
-            Norg2GeoResponse norg2GeoResponse = restTemplate.getForObject(norg2GeografiskProperties.getUrl() + geoOmråde, Norg2GeoResponse.class);
+            Norg2GeoResponse norg2GeoResponse = restTemplate.getForObject(
+                baseGeografiskUrl + "{geoOmråde}",
+                Norg2GeoResponse.class,
+                Map.of("geoOmråde", geoOmråde)
+            );
             if (norg2GeoResponse.getEnhetNr() == null) {
                 log.warn("Fant ikke enhet med geoOmråde {}", geoOmråde);
             }
@@ -51,7 +59,11 @@ public class Norg2Client {
 
     public Norg2OppfølgingResponse hentOppfølgingsEnhet(@Pattern(regexp = "^\\d{4}$", message = "Ugyldig enhetsnummer") String enhetsnummer) {
         try {
-            Norg2OppfølgingResponse norg2OppfølgingResponse = restTemplate.getForObject(norg2OppfølgingProperties.getUrl() + enhetsnummer, Norg2OppfølgingResponse.class);
+            Norg2OppfølgingResponse norg2OppfølgingResponse = restTemplate.getForObject(
+                baseOppfølgingUrl + "{enhetsnummer}",
+                Norg2OppfølgingResponse.class,
+                Map.of("enhetsnummer", enhetsnummer)
+            );
             if (Objects.requireNonNull(norg2OppfølgingResponse).getNavn() == null) {
                 log.warn("Fant ingen enhet: {}", enhetsnummer);
             }

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/featuretoggles/enhet/AxsysService.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/featuretoggles/enhet/AxsysService.java
@@ -33,8 +33,14 @@ public class AxsysService {
     @Cacheable(CacheConfig.AXSYS_CACHE)
     public List<NavEnhet> hentEnheterNavAnsattHarTilgangTil(NavIdent ident) {
         HttpHeaders headers = new HttpHeaders();
-        headers.set("Nav-Call-Id", CorrelationIdSupplier.get());
-        headers.set("Nav-Consumer-Id", navConsumerId);
+        var callId = CorrelationIdSupplier.get();
+        if (callId != null) {
+            headers.set("Nav-Call-Id", callId);
+        }
+        var consumerId = navConsumerId;
+        if (consumerId != null) {
+            headers.set("Nav-Consumer-Id", consumerId);
+        }
 
         try {
             AxsysRespons respons = restTemplate.exchange(

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/infrastruktur/sts/STSClient.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/infrastruktur/sts/STSClient.java
@@ -17,8 +17,8 @@ class STSClient {
     private final RestTemplate noAuthRestTemplate;
     private final String stsUriString;
 
-    public STSClient(StsProperties stsProperties) {
-        this.noAuthRestTemplate = new RestTemplateBuilder()
+    public STSClient(StsProperties stsProperties, RestTemplateBuilder restTemplateBuilder) {
+        this.noAuthRestTemplate = restTemplateBuilder
             .basicAuthentication(stsProperties.getUsername(), stsProperties.getPassword())
             .build();
         this.stsUriString = UriComponentsBuilder.fromUri(stsProperties.getRestUri())

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/infrastruktur/sts/STSClient.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/infrastruktur/sts/STSClient.java
@@ -10,33 +10,29 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 
-import java.net.URI;
-
 @Slf4j
 @Component
 class STSClient {
 
     private final RestTemplate noAuthRestTemplate;
-    private final URI stsUri;
+    private final String stsUriString;
 
     public STSClient(StsProperties stsProperties) {
         this.noAuthRestTemplate = new RestTemplateBuilder()
-                .basicAuthentication(stsProperties.getUsername(), stsProperties.getPassword())
-                .build();
-        this.stsUri = stsProperties.getRestUri();
+            .basicAuthentication(stsProperties.getUsername(), stsProperties.getPassword())
+            .build();
+        this.stsUriString = UriComponentsBuilder.fromUri(stsProperties.getRestUri())
+            .queryParam("grant_type", "client_credentials")
+            .queryParam("scope", "openid")
+            .toUriString();
     }
 
     public STSToken hentSTSToken() {
-        String uriString = UriComponentsBuilder.fromUri(stsUri)
-                .queryParam("grant_type", "client_credentials")
-                .queryParam("scope", "openid")
-                .toUriString();
-
         return noAuthRestTemplate.exchange(
-                uriString,
-                HttpMethod.GET,
-                getRequestEntity(),
-                STSToken.class
+            stsUriString,
+            HttpMethod.GET,
+            getRequestEntity(),
+            STSToken.class
         ).getBody();
 
     }

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/infrastruktur/sts/StsConfiguration.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/infrastruktur/sts/StsConfiguration.java
@@ -8,12 +8,12 @@ import org.springframework.web.client.RestTemplate;
 @Configuration
 class StsConfiguration {
     @Bean
-    public RestTemplate stsRestTemplate(STSClient stsClient) {
-        return new RestTemplateBuilder()
-                .additionalInterceptors((request, body, execution) -> {
-                    request.getHeaders().setBearerAuth(stsClient.hentSTSToken().getAccessToken());
-                    return execution.execute(request, body);
-                })
-                .build();
+    public RestTemplate stsRestTemplate(STSClient stsClient, RestTemplateBuilder restTemplateBuilder) {
+        return restTemplateBuilder
+            .additionalInterceptors((request, body, execution) -> {
+                request.getHeaders().setBearerAuth(stsClient.hentSTSToken().getAccessToken());
+                return execution.execute(request, body);
+            })
+            .build();
     }
 }

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/leader/LeaderPodCheck.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/leader/LeaderPodCheck.java
@@ -61,8 +61,8 @@ public class LeaderPodCheck {
         HttpHeaders headers = new HttpHeaders();
         headers.setAccept(List.of(MediaType.ALL));
         var entity = new HttpEntity<>(headers);
-        ResponseEntity responseEntity = restTemplate.exchange(electorPath, HttpMethod.GET, entity, String.class);
-        return objectMapper.readValue((String) responseEntity.getBody(), Elector.class);
+        ResponseEntity<String> responseEntity = restTemplate.exchange(electorPath, HttpMethod.GET, entity, String.class);
+        return objectMapper.readValue(responseEntity.getBody(), Elector.class);
     }
 
     @Data

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/orgenhet/EregService.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/orgenhet/EregService.java
@@ -1,27 +1,28 @@
 package no.nav.tag.tiltaksgjennomforing.orgenhet;
 
-import lombok.RequiredArgsConstructor;
 import no.nav.tag.tiltaksgjennomforing.avtale.BedriftNr;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
-import org.springframework.web.util.UriComponentsBuilder;
 
-import java.net.URI;
+import java.util.Map;
 
 @Service
-@RequiredArgsConstructor
 public class EregService {
-    private final EregProperties eregProperties;
+    private final String baseUrl;
     private final RestTemplate restTemplate = new RestTemplate();
 
+    public EregService(EregProperties eregProperties) {
+        this.baseUrl = eregProperties.getUri().toString();
+    }
+
     public Organisasjon hentVirksomhet(BedriftNr bedriftNr) {
-        URI uri = UriComponentsBuilder.fromUri(eregProperties.getUri())
-                .pathSegment(bedriftNr.asString())
-                .build()
-                .toUri();
         try {
-            EregEnhet eregEnhet = restTemplate.getForObject(uri, EregEnhet.class);
+            EregEnhet eregEnhet = restTemplate.getForObject(
+                baseUrl + "/{bedriftNr}",
+                EregEnhet.class,
+                Map.of("bedriftNr", bedriftNr.asString())
+            );
             if ("JuridiskEnhet".equals(eregEnhet.type())) {
                 throw new EnhetErJuridiskException();
             }

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/orgenhet/EregService.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/orgenhet/EregService.java
@@ -1,6 +1,7 @@
 package no.nav.tag.tiltaksgjennomforing.orgenhet;
 
 import no.nav.tag.tiltaksgjennomforing.avtale.BedriftNr;
+import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
@@ -10,10 +11,11 @@ import java.util.Map;
 @Service
 public class EregService {
     private final String baseUrl;
-    private final RestTemplate restTemplate = new RestTemplate();
+    private final RestTemplate restTemplate;
 
-    public EregService(EregProperties eregProperties) {
+    public EregService(EregProperties eregProperties, RestTemplateBuilder restTemplateBuilder) {
         this.baseUrl = eregProperties.getUri().toString();
+        this.restTemplate = restTemplateBuilder.build();
     }
 
     public Organisasjon hentVirksomhet(BedriftNr bedriftNr) {


### PR DESCRIPTION
Prometheus-metrikkene våre lagrer url'en som rest-klienten kaller som en "uri-tag" i request-metrikker, som betyr at når vi bygger strings som feks:

http://EREG_URL/12345678

vil det være en linje per bedrift vi slår opp på. I verste fall kan vi også logge fødselsnumre i metrikkene våre.

Vi kan endre til å bruke uri-variabler slik:

http://EREG_URL/{bedriftNr}

og da vil Prometheus logge alle oppslag mot ereg som bare en metrikk.