### PR TITLE
feat. lagre feilmeldinger ved migrering i databasen

### DIFF
--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/arena/models/migration/ArenaAgreementMigration.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/arena/models/migration/ArenaAgreementMigration.java
@@ -35,4 +35,5 @@ public class ArenaAgreementMigration {
     @Enumerated(EnumType.STRING)
     @Convert(converter = ArenaTiltakskode.Convert.class)
     private ArenaTiltakskode tiltakstype;
+    private String error;
 }

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/arena/models/migration/ArenaMigrationAction.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/arena/models/migration/ArenaMigrationAction.java
@@ -11,12 +11,7 @@ public enum ArenaMigrationAction {
     OPPDATER,
     IGNORER,
     ANNULLER,
-    AVSLUTT,
-    KODE_6,
-    FNR_STEMMER_IKKE,
-    VIRKSOMHETSNUMMER_STEMMER_IKKE,
-    MANGLER_FNR,
-    MANGLER_VIRKSOMHETSNUMMER;
+    AVSLUTT;
 
     public static ArenaMigrationAction map(ArenaAgreementAggregate agreementAggregate) {
         Deltakerstatuskode deltakerstatuskode = agreementAggregate.getDeltakerstatuskode();

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/arena/models/migration/ArenaMigrationProcessResult.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/arena/models/migration/ArenaMigrationProcessResult.java
@@ -4,6 +4,6 @@ import no.nav.tag.tiltaksgjennomforing.avtale.Avtale;
 
 public sealed interface ArenaMigrationProcessResult {
     record Ignored() implements ArenaMigrationProcessResult {}
-    record Failed(ArenaMigrationAction action) implements ArenaMigrationProcessResult {}
+    record Failed(String error) implements ArenaMigrationProcessResult {}
     record Completed(ArenaMigrationAction action, Avtale avtale) implements ArenaMigrationProcessResult {}
 }

--- a/src/main/resources/db/migration/common/V126__arena_migrering_feilmelding.sql
+++ b/src/main/resources/db/migration/common/V126__arena_migrering_feilmelding.sql
@@ -1,0 +1,1 @@
+ALTER TABLE arena_event ADD COLUMN error VARCHAR;


### PR DESCRIPTION
Lagre feilmeldinger ved migrering i databasen. Da blir det enklere ved oppslag å se hva som har skjedd og å dra ut statisikk i motsetning til å hente fra loggene i tillegg kan det lagres flere typer feilmelding ved å bruke string istedenfor å bruke ArenaAgreementAction. Actions var aldri ment til bruk for feilmeldinger.