### PR TITLE
feat. la veiledere forkorte avtaler som kommer fra Arena

### DIFF
--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/Avtale.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/Avtale.java
@@ -1345,10 +1345,14 @@ public class Avtale extends AbstractAggregateRoot<Avtale> implements AuditerbarE
     public void forkortAvtale(LocalDate nySluttDato, ForkortetGrunn forkortetGrunn, NavIdent utførtAv) {
         sjekkAtIkkeAvtaleErAnnullertEllerAvbrutt();
 
-        if (!erGodkjentAvVeileder()) {
+        boolean isPabegyntArenaAvtale = !erGodkjentAvVeileder() && Avtaleopphav.ARENA == opphav;
+        if (!isPabegyntArenaAvtale && !erGodkjentAvVeileder()) {
             throw new FeilkodeException(Feilkode.KAN_IKKE_FORKORTE_IKKE_GODKJENT_AVTALE);
         }
-        if (!nySluttDato.isBefore(gjeldendeInnhold.getSluttDato())) {
+        if (!isPabegyntArenaAvtale && !nySluttDato.isBefore(gjeldendeInnhold.getSluttDato())) {
+            throw new FeilkodeException(Feilkode.KAN_IKKE_FORKORTE_ETTER_SLUTTDATO);
+        }
+        if (isPabegyntArenaAvtale && nySluttDato.isAfter(LocalDate.now())) {
             throw new FeilkodeException(Feilkode.KAN_IKKE_FORKORTE_ETTER_SLUTTDATO);
         }
         // Kan ikke forkorte før en utbetalt/sendtkrav tilskuddsperiode


### PR DESCRIPTION
* Endret sjekk på forkorting slik at veiledere kan forkorte avtaler som kommer fra Arena før de har blitt inngått.

* Problemet vi prøver å løse her er å la veiledere velge hva som er korrekt for avtaler som vi leser inn fra Arena når det gjelder personer som har gått ut av oppfølging. Disse personene kan ha vært under oppfølging tidligere og da blir det ikke rett å bare kunne annullere avtalen.