### PR TITLE
fix. ikke generer nye tilskuddsperioder for vtao ved endring av avtale

### DIFF
--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/Avtale.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/Avtale.java
@@ -289,11 +289,14 @@ public class Avtale extends AbstractAggregateRoot<Avtale> implements AuditerbarE
         Avtalerolle utfortAvRolle,
         Identifikator identifikator
     ) {
+        boolean kreverNyeTilskuddsperioder = nyAvtale.kreverNyeTilskuddsperioder(this);
         sjekkAtIkkeAvtaleErAnnullertEllerAvbrutt();
         sjekkOmAvtalenKanEndres();
         sjekkStartOgSluttDato(nyAvtale.getStartDato(), nyAvtale.getSluttDato());
         getGjeldendeInnhold().endreAvtale(nyAvtale);
-        nyeTilskuddsperioder();
+        if (kreverNyeTilskuddsperioder) {
+            nyeTilskuddsperioder();
+        }
         oppdaterKreverOppfolgingFom();
         utforEndring(new AvtaleEndret(this, AvtaleHendelseUtførtAvRolle.fraAvtalerolle(utfortAvRolle), identifikator));
     }

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/EndreAvtale.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/EndreAvtale.java
@@ -8,6 +8,7 @@ import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import static java.util.Optional.ofNullable;
 
@@ -70,6 +71,14 @@ public class EndreAvtale {
     private String mentorTlf;
     private Integer mentorTimelonn;
 
+    public boolean kreverNyeTilskuddsperioder(Avtale eksisterendeAvtale) {
+        AvtaleInnhold innhold = eksisterendeAvtale.getGjeldendeInnhold();
+        return switch (eksisterendeAvtale.getTiltakstype()) {
+            case VTAO ->
+                !Objects.equals(this.startDato, innhold.getStartDato()) || !Objects.equals(this.sluttDato, innhold.getSluttDato());
+            default -> true;
+        };
+    }
 
     public RefusjonKontaktperson getRefusjonKontaktperson() {
         if (refusjonKontaktpersonTlf == null && refusjonKontaktpersonFornavn == null && refusjonKontaktpersonEtternavn == null) {


### PR DESCRIPTION
Ikke generer nye tilskuddsperioder for vtao ved endring av avtale dersom det ikke er nødvendig. Databasetransaksjonen for å skrive disse tar for mye tid i produksjon.