### PR TITLE
fix. ikke oppdater tilskuddsperioder dersom de er uendret

### DIFF
--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/EndreAvtale.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/EndreAvtale.java
@@ -8,7 +8,6 @@ import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 
 import static java.util.Optional.ofNullable;
 
@@ -70,15 +69,6 @@ public class EndreAvtale {
     private Double mentorAntallTimer;
     private String mentorTlf;
     private Integer mentorTimelonn;
-
-    public boolean kreverNyeTilskuddsperioder(Avtale eksisterendeAvtale) {
-        AvtaleInnhold innhold = eksisterendeAvtale.getGjeldendeInnhold();
-        return switch (eksisterendeAvtale.getTiltakstype()) {
-            case VTAO ->
-                !Objects.equals(this.startDato, innhold.getStartDato()) || !Objects.equals(this.sluttDato, innhold.getSluttDato());
-            default -> true;
-        };
-    }
 
     public RefusjonKontaktperson getRefusjonKontaktperson() {
         if (refusjonKontaktpersonTlf == null && refusjonKontaktpersonFornavn == null && refusjonKontaktpersonEtternavn == null) {

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/TilskuddPeriode.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/TilskuddPeriode.java
@@ -34,11 +34,11 @@ import java.util.UUID;
 @Data
 @NoArgsConstructor
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-@EqualsAndHashCode(onlyExplicitlyIncluded = true)
+@EqualsAndHashCode
 public class TilskuddPeriode implements Comparable<TilskuddPeriode> {
 
     @Id
-    @EqualsAndHashCode.Include
+    @EqualsAndHashCode.Exclude
     private UUID id = UUID.randomUUID();
 
     @ManyToOne(fetch = FetchType.LAZY) // Unngå rekursiv query-loop (avtale.gjeldendetilskudd->tilskudd.avtale->...)

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/tilskuddsperiode/beregning/GenerellLonnstilskuddAvtaleBeregningStrategy.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/tilskuddsperiode/beregning/GenerellLonnstilskuddAvtaleBeregningStrategy.java
@@ -11,7 +11,7 @@ import no.nav.tag.tiltaksgjennomforing.utils.Utils;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.time.LocalDate;
-import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import static no.nav.tag.tiltaksgjennomforing.utils.Utils.erIkkeTomme;
@@ -19,31 +19,31 @@ import static no.nav.tag.tiltaksgjennomforing.utils.Utils.fikseLøpenumre;
 
 public class GenerellLonnstilskuddAvtaleBeregningStrategy implements LonnstilskuddAvtaleBeregningStrategy {
 
-    public void genererNyeTilskuddsperioder(Avtale avtale) {
+    public List<TilskuddPeriode> genererNyeTilskuddsperioder(Avtale avtale) {
         if (avtale.erAvtaleInngått()) {
             throw new FeilkodeException(Feilkode.KAN_IKKE_LAGE_NYE_TILSKUDDSPRIODER_INNGAATT_AVTALE);
         }
-        List<TilskuddPeriode> tilskuddsperioder = new ArrayList<>();
-        avtale.getTilskuddPeriode().removeIf(t -> (t.getStatus() == TilskuddPeriodeStatus.UBEHANDLET) || (t.getStatus() == TilskuddPeriodeStatus.BEHANDLET_I_ARENA));
+
         AvtaleInnhold gjeldendeInnhold = avtale.getGjeldendeInnhold();
+        if (Utils.erNoenTomme(gjeldendeInnhold.getStartDato(), gjeldendeInnhold.getSluttDato(), gjeldendeInnhold.getSumLonnstilskudd())) {
+            return Collections.emptyList();
+        }
 
-        if (erIkkeTomme(gjeldendeInnhold.getStartDato(), gjeldendeInnhold.getSluttDato(), gjeldendeInnhold.getSumLonnstilskudd())) {
-            tilskuddsperioder = hentTilskuddsperioderForPeriode(avtale, gjeldendeInnhold.getStartDato(), gjeldendeInnhold.getSluttDato());
-            if (avtale.getArenaRyddeAvtale() != null) {
-                LocalDate standardMigreringsdato = LocalDate.of(2023, 2, 1);
-                LocalDate migreringsdato = avtale.getArenaRyddeAvtale().getMigreringsdato() != null ? avtale.getArenaRyddeAvtale().getMigreringsdato() : standardMigreringsdato;
+        List<TilskuddPeriode> tilskuddsperioder = hentTilskuddsperioderForPeriode(avtale, gjeldendeInnhold.getStartDato(), gjeldendeInnhold.getSluttDato());
+        if (avtale.getArenaRyddeAvtale() != null) {
+            LocalDate standardMigreringsdato = LocalDate.of(2023, 2, 1);
+            LocalDate migreringsdato = avtale.getArenaRyddeAvtale().getMigreringsdato() != null ? avtale.getArenaRyddeAvtale().getMigreringsdato() : standardMigreringsdato;
 
-                tilskuddsperioder.forEach(periode -> {
-                    // Set status BEHANDLET_I_ARENA på tilskuddsperioder før migreringsdato
-                    // Eller skal det være startdato? Er jo den samme datoen som migreringsdato. hmm...
-                    if (periode.getSluttDato().minusDays(1).isBefore(migreringsdato)) {
-                        periode.setStatus(TilskuddPeriodeStatus.BEHANDLET_I_ARENA);
-                    }
-                });
-            }
+            tilskuddsperioder.forEach(periode -> {
+                // Set status BEHANDLET_I_ARENA på tilskuddsperioder før migreringsdato
+                // Eller skal det være startdato? Er jo den samme datoen som migreringsdato. hmm...
+                if (periode.getSluttDato().minusDays(1).isBefore(migreringsdato)) {
+                    periode.setStatus(TilskuddPeriodeStatus.BEHANDLET_I_ARENA);
+                }
+            });
         }
         fikseLøpenumre(tilskuddsperioder, 1);
-        avtale.leggtilNyeTilskuddsperioder(tilskuddsperioder);
+        return tilskuddsperioder;
     }
 
     public void endreBeregning(Avtale avtale, EndreTilskuddsberegning endreTilskuddsberegning) {

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/tilskuddsperiode/beregning/IkkeLonnstilskuddAvtaleBeregningStrategy.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/tilskuddsperiode/beregning/IkkeLonnstilskuddAvtaleBeregningStrategy.java
@@ -8,6 +8,7 @@ import no.nav.tag.tiltaksgjennomforing.exceptions.Feilkode;
 import no.nav.tag.tiltaksgjennomforing.exceptions.FeilkodeException;
 
 import java.time.LocalDate;
+import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 
@@ -15,10 +16,10 @@ import java.util.UUID;
 public class IkkeLonnstilskuddAvtaleBeregningStrategy implements LonnstilskuddAvtaleBeregningStrategy {
 
     @Override
-    public void genererNyeTilskuddsperioder(Avtale avtale) {}
+    public List<TilskuddPeriode> genererNyeTilskuddsperioder(Avtale avtale) { return Collections.emptyList(); }
 
     @Override
-    public List<TilskuddPeriode> hentTilskuddsperioderForPeriode(Avtale avtale, LocalDate startDato, LocalDate sluttDato) {return List.of(); }
+    public List<TilskuddPeriode> hentTilskuddsperioderForPeriode(Avtale avtale, LocalDate startDato, LocalDate sluttDato) {return Collections.emptyList(); }
 
     @Override
     public void endreBeregning(Avtale avtale, EndreTilskuddsberegning endreTilskuddsberegning) {}

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/tilskuddsperiode/beregning/LonnstilskuddAvtaleBeregningStrategy.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/tilskuddsperiode/beregning/LonnstilskuddAvtaleBeregningStrategy.java
@@ -29,7 +29,7 @@ public interface LonnstilskuddAvtaleBeregningStrategy {
     BigDecimal DAGER_I_MÅNED = new BigDecimal("30.4375");
     int ANTALL_MÅNEDER_I_EN_PERIODE = 1;
 
-    void genererNyeTilskuddsperioder(Avtale avtale);
+    List<TilskuddPeriode> genererNyeTilskuddsperioder(Avtale avtale);
     List<TilskuddPeriode> hentTilskuddsperioderForPeriode(Avtale avtale, LocalDate startDato, LocalDate sluttDato);
     void endreBeregning(Avtale avtale, EndreTilskuddsberegning endreTilskuddsberegning);
     void reberegnTotal(Avtale avtale);


### PR DESCRIPTION
Endring gjør at vi sjekker at tilskuddsperiodene vi generere og de vi har fra før av er like. Dersom de er det, så er det ikke vits i å endre de vi allerede har.

`genererNyeTilskuddsperioder` returnerer nå en liste med nye tilskuddsperiode istedenfor å endre tilskuddsperiodene i avtalen. På denne måten kan vi sjekke om det har skjedd en endring før vi legger til de nye.