### PR TITLE
fix. alltid vis løpenummer 1 for besluttere

### DIFF
--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleRepository.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleRepository.java
@@ -134,7 +134,7 @@ public interface AvtaleRepository extends JpaRepository<Avtale, UUID>, JpaSpecif
                a.enhetOppfolging AS enhetOppfolging
         FROM Avtale a
         LEFT JOIN AvtaleInnhold i ON i.id = a.gjeldendeInnhold.id
-        LEFT JOIN TilskuddPeriode t ON (t.avtale.id = a.id AND t.status = :tilskuddsperiodestatus AND t.startDato <= :decisiondate)
+        LEFT JOIN TilskuddPeriode t ON t.avtale.id = a.id
         WHERE a.gjeldendeInnhold.godkjentAvVeileder IS NOT NULL
           AND a.tiltakstype IN (:tiltakstype)
           AND EXISTS (SELECT DISTINCT p.avtale.id, p.status, p.løpenummer, p.startDato FROM TilskuddPeriode p WHERE p.avtale.id = a.id


### PR DESCRIPTION
Vi gjør allerede en sjekk på status og decision date i spørringen, derfor er det ikke nødvendig å gjøre denne ved join. Det ender bare i at løpenummer 1 aldri vises.