### PR TITLE
Legg til logg-destinasjoner

### DIFF
--- a/nais/dev-fss.yaml
+++ b/nais/dev-fss.yaml
@@ -68,6 +68,11 @@ spec:
     autoInstrumentation:
       enabled: true
       runtime: java
+    logging:
+      destinations:
+        - id: elastic
+        - id: team_logs
+        - id: loki
   accessPolicy:
     inbound:
       rules:

--- a/nais/prod-fss.yaml
+++ b/nais/prod-fss.yaml
@@ -70,6 +70,11 @@ spec:
     autoInstrumentation:
       enabled: true
       runtime: java
+    logging:
+      destinations:
+        - id: elastic
+        - id: team_logs
+        - id: loki
   accessPolicy:
     inbound:
       rules:


### PR DESCRIPTION
Vi ønsker å eksportere loggene våre til kibana
selv etter 1. juni!

Nais-plattformen har deprekert elasticsearch, og
derfor må vi eksplisitt legge til elastic til
listen over logg-destinasjoner i nais-yaml'en