### PR TITLE
Fiks feil i GjeldendeTilskuddsperiodeJobb

### DIFF
--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleRepository.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleRepository.java
@@ -68,10 +68,10 @@ public interface AvtaleRepository extends JpaRepository<Avtale, UUID>, JpaSpecif
     @Query(value = """
         select a from Avtale a
             where a.tiltakstype in (:tiltakstyper)
-            and a.gjeldendeTilskuddsperiode is null
+            and a.status in (:aktuelleStatuser)
             and (select count(*) from TilskuddPeriode t where t.aktiv = true and t.avtale = a) > 0
     """)
-    List<Avtale> finnAvtaleHvorGjeldendeTilskuddsperiodeKanSettes(Set<Tiltakstype> tiltakstyper, Limit limit);
+    List<Avtale> finnAvtaleMedAktiveTilskuddsperioder(Set<Tiltakstype> tiltakstyper, Set<Status> aktuelleStatuser);
 
     @Timed(percentiles = {0.5d, 0.75d, 0.9d, 0.99d, 0.999d})
     @Override

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/admin/AdminController.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/admin/AdminController.java
@@ -13,6 +13,7 @@ import no.nav.tag.tiltaksgjennomforing.avtale.TilskuddPeriode;
 import no.nav.tag.tiltaksgjennomforing.avtale.TilskuddPeriodeRepository;
 import no.nav.tag.tiltaksgjennomforing.avtale.TilskuddPeriodeStatus;
 import no.nav.tag.tiltaksgjennomforing.avtale.Tiltakstype;
+import no.nav.tag.tiltaksgjennomforing.avtale.service.GjeldendeTilskuddsperiodeJobbService;
 import no.nav.tag.tiltaksgjennomforing.enhet.Oppfølgingsstatus;
 import no.nav.tag.tiltaksgjennomforing.enhet.veilarboppfolging.VeilarboppfolgingService;
 import no.nav.tag.tiltaksgjennomforing.exceptions.RessursFinnesIkkeException;
@@ -55,6 +56,7 @@ public class AdminController {
     private final TilgangskontrollService tilgangskontrollService;
     private final PersondataService persondataService;
     private final AdminService adminService;
+    private final GjeldendeTilskuddsperiodeJobbService gjeldendeTilskuddsperiodeJobbService;
 
     @PostMapping("reberegn")
     public void reberegnLønnstilskudd(@RequestBody List<UUID> avtaleIder) {
@@ -200,6 +202,11 @@ public class AdminController {
                 }
             }
         }));
+    }
+
+    @PostMapping("/oppdater-gjeldende-tilskuddsperiode-for-avtaler")
+    public void oppdaterGjeldendeTilskuddsperiode() {
+        gjeldendeTilskuddsperiodeJobbService.settGjeldendeTilskuddsperiodeJobb();
     }
 
     @PostMapping("/avtale/{id}/sjekk-tilgang")

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/jobber/GjeldendeTilskuddsperiodeJobb.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/jobber/GjeldendeTilskuddsperiodeJobb.java
@@ -20,7 +20,7 @@ class GjeldendeTilskuddsperiodeJobb {
         this.leaderPodCheck = leaderPodCheck;
     }
 
-    @Scheduled(cron = "0 5/5 1-4 * * *")
+    @Scheduled(cron = "0 30 0 * * *")
     public void settGjeldendeTilskuddsperiodeJobb() {
         if (leaderPodCheck.isLeaderPod()) {
             log.info("Jobb for å oppdatere gjeldedeTilskuddsperiode-felt startet...");

--- a/src/test/resources/admin-kall.http
+++ b/src/test/resources/admin-kall.http
@@ -37,3 +37,9 @@ Authorization: Bearer <TOKEN>
 {
   "avtaleKravTidspunkt": "2025-05-12T10:05:00"
 }
+
+
+### Oppdater gjeldende tilskuddsperiode på alle avtaler
+POST http://localhost:12345/tiltaksgjennomforing-api/utvikler-admin/oppdater-gjeldende-tilskuddsperiode-for-avtaler
+Content-Type: application/json
+Authorization: Bearer <TOKEN>


### PR DESCRIPTION
GjeldendeTilskuddsperiodeJobb hadde en klausul i SQL-spørringen som ekskluderte avtaler som allerede hadde en gjeldende tilskuddsperiode.

Problemet er at ubehandlede tilskuddeperioder frem i tid ikke fanges opp av den nattlige jobben! Jobben vil ignorere avtaler som har "en eller annen tilskuddsperiode" i feltet "gjeldende_tilskuddsperiode".

Dette skaper mismatch mellom hva databasen mener er "gjeldende", og hva avtale-entiteten mener er gjeldende tilskuddsperiode via metoden "finnGjeldendeTilskuddsperiode".