### PR TITLE
feat. ikke rydd bort vtao-avtaler fra Arena før etter sommeren

### DIFF
--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleUtlopHandling.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleUtlopHandling.java
@@ -11,6 +11,7 @@ public enum AvtaleUtlopHandling {
     UTLOP,
     INGEN;
 
+    public static final Instant TIDLIGEST_DATO_FOR_RYDDING_AV_ARENA_VTAO = Instant.parse("2025-09-01T12:00:00.000+01:00");
 
     private static final Duration EN_DAG = Duration.ofDays(1);
     private static final Duration EN_UKE = EN_DAG.multipliedBy(7);
@@ -18,6 +19,12 @@ public enum AvtaleUtlopHandling {
     private static final Duration ELLEVE_UKER = EN_UKE.multipliedBy(11);
 
     public static AvtaleUtlopHandling parse(Avtale avtale) {
+        if (Tiltakstype.VTAO.equals(avtale.getTiltakstype()) && Avtaleopphav.ARENA.equals(avtale.getOpphav())) {
+            var sistEndret = Now.instant().isBefore(TIDLIGEST_DATO_FOR_RYDDING_AV_ARENA_VTAO)
+                ? TIDLIGEST_DATO_FOR_RYDDING_AV_ARENA_VTAO.minus(TOLV_UKER)
+                : avtale.getSistEndret();
+            return parse(sistEndret);
+        }
         return parse(avtale.getSistEndret());
     }
 

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/service/PabegynteAvtalerRyddeServiceTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/service/PabegynteAvtalerRyddeServiceTest.java
@@ -48,8 +48,7 @@ class PabegynteAvtalerRyddeServiceTest {
         Tiltakstype.ARBEIDSTRENING,
         Tiltakstype.SOMMERJOBB,
         Tiltakstype.VARIG_LONNSTILSKUDD,
-        Tiltakstype.MIDLERTIDIG_LONNSTILSKUDD,
-        Tiltakstype.VTAO
+        Tiltakstype.MIDLERTIDIG_LONNSTILSKUDD
     );
 
     private static final List<Avtaleopphav> AVTALEOPPHAV = List.of(


### PR DESCRIPTION
* En del av avtalene vi henter fra Arena kommer til å utgå midt på sommeren. Derfor legger vi inn en sperre slik at disse avtalene ikke blir ryddet før tidligest 1 september.