### PR TITLE
fix. instant og tidssoner

### DIFF
--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/arena/client/ords/ArenaOrdsTokenClient.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/arena/client/ords/ArenaOrdsTokenClient.java
@@ -9,7 +9,7 @@ import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 @Component
 public class ArenaOrdsTokenClient {
@@ -61,11 +61,11 @@ public class ArenaOrdsTokenClient {
             return true;
         }
 
-        LocalDateTime expiresAt = token.getCachedAt()
+        Instant expiresAt = token.getCachedAt()
             .plusSeconds(token.getToken().expiresIn())
             .minusSeconds(expireEarlySeconds);
 
-        return Now.localDateTime().isAfter(expiresAt);
+        return Now.instant().isAfter(expiresAt);
     }
 
 

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/arena/client/ords/CachedOrdsToken.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/arena/client/ords/CachedOrdsToken.java
@@ -4,12 +4,12 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 import no.nav.tag.tiltaksgjennomforing.utils.Now;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 @Getter
 public class CachedOrdsToken {
     private final OrdsToken token;
-    private final LocalDateTime cachedAt = Now.localDateTime();
+    private final Instant cachedAt = Now.instant();
 
     public CachedOrdsToken(OrdsToken token) {
         this.token = token;

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/arena/models/event/ArenaEvent.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/arena/models/event/ArenaEvent.java
@@ -18,6 +18,7 @@ import no.nav.tag.tiltaksgjennomforing.utils.Now;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.type.SqlTypes;
 
+import java.time.Instant;
 import java.time.LocalDateTime;
 import java.util.Optional;
 import java.util.UUID;
@@ -32,7 +33,7 @@ public class ArenaEvent {
     private UUID id;
     private String arenaId;
     private String arenaTable;
-    private LocalDateTime created;
+    private Instant created;
     @Enumerated(EnumType.STRING)
     private ArenaEventStatus status;
     private int retryCount;
@@ -61,7 +62,7 @@ public class ArenaEvent {
             .operationTime(operationTime)
             .currentTs(currentTs)
             .payload(payload)
-            .created(Now.localDateTime())
+            .created(Now.instant())
             .retryCount(0)
             .status(status)
             .pos(pos)

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/arena/models/migration/ArenaAgreementMigration.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/arena/models/migration/ArenaAgreementMigration.java
@@ -11,7 +11,7 @@ import lombok.Builder;
 import lombok.NoArgsConstructor;
 import no.nav.tag.tiltaksgjennomforing.arena.models.arena.ArenaTiltakskode;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.UUID;
 
 @Entity
@@ -30,8 +30,8 @@ public class ArenaAgreementMigration {
     private UUID avtaleId;
     private UUID eksternId;
     @Transient
-    private LocalDateTime created;
-    private LocalDateTime modified;
+    private Instant created;
+    private Instant modified;
     @Enumerated(EnumType.STRING)
     @Convert(converter = ArenaTiltakskode.Convert.class)
     private ArenaTiltakskode tiltakstype;

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/arena/service/ArenaAgreementProcessingService.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/arena/service/ArenaAgreementProcessingService.java
@@ -34,7 +34,8 @@ import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
+import java.time.ZoneId;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -171,7 +172,7 @@ public class ArenaAgreementProcessingService {
                 .action(action)
                 .avtaleId(agreementId)
                 .eksternId(eksternId)
-                .modified(LocalDateTime.now())
+                .modified(Instant.now())
                 .tiltakstype(tiltakskode)
                 .error(error)
                 .build()
@@ -315,7 +316,8 @@ public class ArenaAgreementProcessingService {
         getOppfolgingsenhetnavnFromNorg2(avtale.getEnhetOppfolging()).ifPresent(avtale::setEnhetsnavnOppfolging);
 
         AvtaleInnhold avtaleinnhold = avtale.getGjeldendeInnhold();
-        Optional.ofNullable(agreementAggregate.getRegDato()).ifPresent(avtale::setOpprettetTidspunkt);
+        Optional.ofNullable(agreementAggregate.getRegDato())
+            .ifPresent(regdato -> avtale.setOpprettetTidspunkt(regdato.atZone(ZoneId.systemDefault()).toInstant()));
         agreementAggregate.getAntallDagerPrUke().ifPresent(avtaleinnhold::setAntallDagerPerUke);
         agreementAggregate.getProsentDeltid().ifPresent(avtaleinnhold::setStillingprosent);
         agreementAggregate.findStartdato().ifPresent(avtaleinnhold::setStartDato);

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/arena/service/ArenaAgreementService.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/arena/service/ArenaAgreementService.java
@@ -6,10 +6,10 @@ import no.nav.tag.tiltaksgjennomforing.arena.models.migration.ArenaAgreementAggr
 import no.nav.tag.tiltaksgjennomforing.arena.models.migration.ArenaAgreementMigration;
 import no.nav.tag.tiltaksgjennomforing.arena.models.migration.ArenaAgreementMigrationStatus;
 import no.nav.tag.tiltaksgjennomforing.arena.repository.ArenaAgreementMigrationRepository;
+import no.nav.tag.tiltaksgjennomforing.utils.Now;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
 import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -47,7 +47,7 @@ public class ArenaAgreementService {
                         .tiltakdeltakerId(entry.getValue().getTiltakdeltakerId())
                         .eksternId(entry.getValue().getEksternIdAsUuid().orElse(null))
                         .status(ArenaAgreementMigrationStatus.PROCESSING)
-                        .modified(LocalDateTime.now())
+                        .modified(Now.instant())
                         .tiltakstype(entry.getValue().getTiltakskode())
                         .build()
                 )

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/AlleredeRegistrertAvtale.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/AlleredeRegistrertAvtale.java
@@ -5,8 +5,8 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.time.Instant;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Stream;
@@ -38,9 +38,9 @@ public class AlleredeRegistrertAvtale {
 
     private LocalDate startDato;
     private LocalDate sluttDato;
-    private LocalDateTime godkjentAvVeileder;
-    private LocalDateTime godkjentAvBeslutter;
-    private LocalDateTime avtaleInngått;
+    private Instant godkjentAvVeileder;
+    private Instant godkjentAvBeslutter;
+    private Instant avtaleInngått;
 
     private static List<AlleredeRegistrertAvtale> filtrerAvtaler(Stream<Avtale> avtaler) {
         return avtaler.map(AlleredeRegistrertAvtale::setAvtaleFelter).toList();

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/Avtale.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/Avtale.java
@@ -101,7 +101,6 @@ import org.springframework.data.domain.AbstractAggregateRoot;
 
 import java.time.Instant;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.time.YearMonth;
 import java.time.temporal.ChronoUnit;
 import java.util.Comparator;
@@ -148,7 +147,7 @@ public class Avtale extends AbstractAggregateRoot<Avtale> implements AuditerbarE
     @Column(updatable = false)
     private Tiltakstype tiltakstype;
 
-    private LocalDateTime opprettetTidspunkt;
+    private Instant opprettetTidspunkt;
 
     @Generated(event = EventType.INSERT)
     private Integer avtaleNr;
@@ -219,7 +218,7 @@ public class Avtale extends AbstractAggregateRoot<Avtale> implements AuditerbarE
         }
 
         this.id = UUID.randomUUID();
-        this.opprettetTidspunkt = Now.localDateTime();
+        this.opprettetTidspunkt = Now.instant();
         this.deltakerFnr = opprettAvtale.getDeltakerFnr();
         this.bedriftNr = opprettAvtale.getBedriftNr();
         this.fnrOgBedrift = new FnrOgBedrift(this.deltakerFnr, this.bedriftNr);
@@ -241,7 +240,7 @@ public class Avtale extends AbstractAggregateRoot<Avtale> implements AuditerbarE
         }
 
         this.id = UUID.randomUUID();
-        this.opprettetTidspunkt = Now.localDateTime();
+        this.opprettetTidspunkt = Now.instant();
         this.deltakerFnr = opprettMentorAvtale.getDeltakerFnr();
         this.mentorFnr = opprettMentorAvtale.getMentorFnr();
         this.bedriftNr = opprettMentorAvtale.getBedriftNr();
@@ -343,7 +342,7 @@ public class Avtale extends AbstractAggregateRoot<Avtale> implements AuditerbarE
         }
 
         gjeldendeInnhold = getGjeldendeInnhold().nyGodkjentVersjon(AvtaleInnholdType.ENDRET_AV_ARENA);
-        getGjeldendeInnhold().setIkrafttredelsestidspunkt(Now.localDateTime());
+        getGjeldendeInnhold().setIkrafttredelsestidspunkt(Now.instant());
 
         if (EndreAvtaleArena.Handling.AVSLUTT == action) {
             LocalDate sluttDato = Stream.of(endreAvtaleArena.getSluttdato(), gjeldendeInnhold.getSluttDato())
@@ -473,32 +472,32 @@ public class Avtale extends AbstractAggregateRoot<Avtale> implements AuditerbarE
     }
 
     @JsonProperty
-    public LocalDateTime godkjentAvDeltaker() {
+    public Instant godkjentAvDeltaker() {
         return gjeldendeInnhold.getGodkjentAvDeltaker();
     }
 
     @JsonProperty
-    public LocalDateTime godkjentAvMentor() {
+    public Instant godkjentAvMentor() {
         return gjeldendeInnhold.getGodkjentTaushetserklæringAvMentor();
     }
 
     @JsonProperty
-    public LocalDateTime godkjentAvArbeidsgiver() {
+    public Instant godkjentAvArbeidsgiver() {
         return gjeldendeInnhold.getGodkjentAvArbeidsgiver();
     }
 
     @JsonProperty
-    public LocalDateTime godkjentAvVeileder() {
+    public Instant godkjentAvVeileder() {
         return gjeldendeInnhold.getGodkjentAvVeileder();
     }
 
     @JsonProperty
-    public LocalDateTime godkjentAvBeslutter() {
+    public Instant godkjentAvBeslutter() {
         return gjeldendeInnhold.getGodkjentAvBeslutter();
     }
 
     @JsonProperty
-    private LocalDateTime avtaleInngått() {
+    private Instant avtaleInngått() {
         return gjeldendeInnhold.getAvtaleInngått();
     }
 
@@ -605,7 +604,7 @@ public class Avtale extends AbstractAggregateRoot<Avtale> implements AuditerbarE
         if (erGodkjentAvArbeidsgiver()) {
             throw new FeilkodeException(Feilkode.KAN_IKKE_GODKJENNE_ARBEIDSGIVER_HAR_ALLEREDE_GODKJENT);
         }
-        gjeldendeInnhold.setGodkjentAvArbeidsgiver(Now.localDateTime());
+        gjeldendeInnhold.setGodkjentAvArbeidsgiver(Now.instant());
         utforEndring(new GodkjentAvArbeidsgiver(this, utfortAv));
     }
 
@@ -636,7 +635,7 @@ public class Avtale extends AbstractAggregateRoot<Avtale> implements AuditerbarE
             throw new FeilkodeException(Feilkode.DELTAKER_67_AAR);
         }
 
-        LocalDateTime tidspunkt = Now.localDateTime();
+        Instant tidspunkt = Now.instant();
         gjeldendeInnhold.setGodkjentAvVeileder(tidspunkt);
         gjeldendeInnhold.setGodkjentAvNavIdent(new NavIdent(utfortAv.asString()));
         inngåAvtale(tidspunkt, Avtalerolle.VEILEDER, utfortAv);
@@ -644,7 +643,7 @@ public class Avtale extends AbstractAggregateRoot<Avtale> implements AuditerbarE
         utforEndring(new GodkjentAvVeileder(this, utfortAv));
     }
 
-    private void inngåAvtale(LocalDateTime tidspunkt, Avtalerolle utførtAvRolle, NavIdent utførtAv) {
+    private void inngåAvtale(Instant tidspunkt, Avtalerolle utførtAvRolle, NavIdent utførtAv) {
         if (!utførtAvRolle.erInternBruker()) {
             throw new FeilkodeException(Feilkode.IKKE_TILGANG_TIL_A_INNGAA_AVTALE);
         }
@@ -699,7 +698,7 @@ public class Avtale extends AbstractAggregateRoot<Avtale> implements AuditerbarE
         }
 
         paVegneAvGrunn.valgtMinstEnGrunn();
-        LocalDateTime tidspunkt = Now.localDateTime();
+        Instant tidspunkt = Now.instant();
         gjeldendeInnhold.setGodkjentAvVeileder(tidspunkt);
         gjeldendeInnhold.setGodkjentAvDeltaker(tidspunkt);
         gjeldendeInnhold.setGodkjentPaVegneAv(true);
@@ -738,7 +737,7 @@ public class Avtale extends AbstractAggregateRoot<Avtale> implements AuditerbarE
         }
 
         godkjentPaVegneAvArbeidsgiverGrunn.valgtMinstEnGrunn();
-        LocalDateTime tidspunkt = Now.localDateTime();
+        Instant tidspunkt = Now.instant();
         gjeldendeInnhold.setGodkjentAvVeileder(tidspunkt);
         gjeldendeInnhold.setGodkjentAvArbeidsgiver(tidspunkt);
         gjeldendeInnhold.setGodkjentPaVegneAvArbeidsgiver(true);
@@ -777,7 +776,7 @@ public class Avtale extends AbstractAggregateRoot<Avtale> implements AuditerbarE
         }
 
         paVegneAvDeltakerOgArbeidsgiverGrunn.valgtMinstEnGrunn();
-        LocalDateTime tidspunkt = Now.localDateTime();
+        Instant tidspunkt = Now.instant();
         gjeldendeInnhold.setGodkjentAvVeileder(tidspunkt);
         gjeldendeInnhold.setGodkjentAvDeltaker(tidspunkt);
         gjeldendeInnhold.setGodkjentAvArbeidsgiver(tidspunkt);
@@ -796,7 +795,7 @@ public class Avtale extends AbstractAggregateRoot<Avtale> implements AuditerbarE
         if (erGodkjentAvDeltaker()) {
             throw new FeilkodeException(Feilkode.KAN_IKKE_GODKJENNE_DELTAKER_HAR_ALLEREDE_GODKJENT);
         }
-        gjeldendeInnhold.setGodkjentAvDeltaker(Now.localDateTime());
+        gjeldendeInnhold.setGodkjentAvDeltaker(Now.instant());
         utforEndring(new GodkjentAvDeltaker(this, utfortAv));
     }
 
@@ -804,7 +803,7 @@ public class Avtale extends AbstractAggregateRoot<Avtale> implements AuditerbarE
         if (erGodkjentTaushetserklæringAvMentor()) {
             throw new FeilkodeException(Feilkode.KAN_IKKE_GODKJENNE_MENTOR_HAR_ALLEREDE_GODKJENT);
         }
-        gjeldendeInnhold.setGodkjentTaushetserklæringAvMentor(Now.localDateTime());
+        gjeldendeInnhold.setGodkjentTaushetserklæringAvMentor(Now.instant());
         utforEndring(new SignertAvMentor(this, utfortAv));
     }
 
@@ -951,14 +950,14 @@ public class Avtale extends AbstractAggregateRoot<Avtale> implements AuditerbarE
         Integer resendingsnummer = finnResendingsNummer(gjeldendePeriode);
         gjeldendePeriode.godkjenn(beslutter, enhet);
         if (!erAvtaleInngått()) {
-            LocalDateTime tidspunkt = Now.localDateTime();
+            Instant tidspunkt = Now.instant();
             godkjennForBeslutter(tidspunkt, beslutter);
             inngåAvtale(tidspunkt, Avtalerolle.BESLUTTER, beslutter);
         }
         utforEndring(new TilskuddsperiodeGodkjent(this, gjeldendePeriode, beslutter, resendingsnummer));
     }
 
-    private void godkjennForBeslutter(LocalDateTime tidspunkt, NavIdent beslutter) {
+    private void godkjennForBeslutter(Instant tidspunkt, NavIdent beslutter) {
         gjeldendeInnhold.setGodkjentAvBeslutter(tidspunkt);
         gjeldendeInnhold.setGodkjentAvBeslutterNavIdent(beslutter);
     }
@@ -1448,7 +1447,7 @@ public class Avtale extends AbstractAggregateRoot<Avtale> implements AuditerbarE
         gjeldendeInnhold = getGjeldendeInnhold().nyGodkjentVersjon(AvtaleInnholdType.ENDRE_TILSKUDDSBEREGNING);
         this.hentBeregningStrategi().endreBeregning(this, endreTilskuddsberegning);
         endreBeløpOgProsentITilskuddsperioder();
-        getGjeldendeInnhold().setIkrafttredelsestidspunkt(Now.localDateTime());
+        getGjeldendeInnhold().setIkrafttredelsestidspunkt(Now.instant());
         utforEndring(new TilskuddsberegningEndret(this, utførtAv));
     }
 
@@ -1536,7 +1535,7 @@ public class Avtale extends AbstractAggregateRoot<Avtale> implements AuditerbarE
 
         gjeldendeInnhold = getGjeldendeInnhold().nyGodkjentVersjon(AvtaleInnholdType.ENDRE_KONTAKTINFO);
         getGjeldendeInnhold().endreKontaktInfo(endreKontaktInformasjon);
-        getGjeldendeInnhold().setIkrafttredelsestidspunkt(Now.localDateTime());
+        getGjeldendeInnhold().setIkrafttredelsestidspunkt(Now.instant());
         reaktiverTilskuddsperiodeOgSendTilbakeTilBeslutter();
         utforEndring(new KontaktinformasjonEndret(this, utførtAv));
     }
@@ -1566,7 +1565,7 @@ public class Avtale extends AbstractAggregateRoot<Avtale> implements AuditerbarE
         }
         gjeldendeInnhold = getGjeldendeInnhold().nyGodkjentVersjon(AvtaleInnholdType.ENDRE_STILLING);
         getGjeldendeInnhold().endreStillingsInfo(endreStillingsbeskrivelse);
-        getGjeldendeInnhold().setIkrafttredelsestidspunkt(Now.localDateTime());
+        getGjeldendeInnhold().setIkrafttredelsestidspunkt(Now.instant());
         getGjeldendeInnhold().reberegnLønnstilskudd();
         reaktiverTilskuddsperiodeOgSendTilbakeTilBeslutter();
         utforEndring(new StillingsbeskrivelseEndret(this, utførtAv));
@@ -1590,7 +1589,7 @@ public class Avtale extends AbstractAggregateRoot<Avtale> implements AuditerbarE
         }
         gjeldendeInnhold = gjeldendeInnhold.nyGodkjentVersjon(AvtaleInnholdType.ENDRE_OPPFØLGING_OG_TILRETTELEGGING);
         gjeldendeInnhold.endreOppfølgingOgTilretteleggingInfo(endreOppfølgingOgTilrettelegging);
-        gjeldendeInnhold.setIkrafttredelsestidspunkt(Now.localDateTime());
+        gjeldendeInnhold.setIkrafttredelsestidspunkt(Now.instant());
         reaktiverTilskuddsperiodeOgSendTilbakeTilBeslutter();
         utforEndring(new OppfølgingOgTilretteleggingEndret(this, utførtAv));
     }
@@ -1620,7 +1619,7 @@ public class Avtale extends AbstractAggregateRoot<Avtale> implements AuditerbarE
             .toList();
         getGjeldendeInnhold().getMaal().addAll(nyeMål);
         getGjeldendeInnhold().getMaal().forEach(m -> m.setAvtaleInnhold(getGjeldendeInnhold()));
-        getGjeldendeInnhold().setIkrafttredelsestidspunkt(Now.localDateTime());
+        getGjeldendeInnhold().setIkrafttredelsestidspunkt(Now.instant());
         reaktiverTilskuddsperiodeOgSendTilbakeTilBeslutter();
         utforEndring(new MålEndret(this, utførtAv));
     }
@@ -1663,7 +1662,7 @@ public class Avtale extends AbstractAggregateRoot<Avtale> implements AuditerbarE
 
         getGjeldendeInnhold().getInkluderingstilskuddsutgift().addAll(nyeInkluderingstilskuddsutgifter);
         getGjeldendeInnhold().getInkluderingstilskuddsutgift().forEach(i -> i.setAvtaleInnhold(getGjeldendeInnhold()));
-        getGjeldendeInnhold().setIkrafttredelsestidspunkt(Now.localDateTime());
+        getGjeldendeInnhold().setIkrafttredelsestidspunkt(Now.instant());
         reaktiverTilskuddsperiodeOgSendTilbakeTilBeslutter();
         utforEndring(new InkluderingstilskuddEndret(this, utførtAv));
     }
@@ -1684,7 +1683,7 @@ public class Avtale extends AbstractAggregateRoot<Avtale> implements AuditerbarE
         }
         gjeldendeInnhold = getGjeldendeInnhold().nyGodkjentVersjon(AvtaleInnholdType.ENDRE_OM_MENTOR);
         getGjeldendeInnhold().endreOmMentor(endreOmMentor);
-        getGjeldendeInnhold().setIkrafttredelsestidspunkt(Now.localDateTime());
+        getGjeldendeInnhold().setIkrafttredelsestidspunkt(Now.instant());
         reaktiverTilskuddsperiodeOgSendTilbakeTilBeslutter();
         utforEndring(new OmMentorEndret(this, utførtAv));
     }

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleController.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleController.java
@@ -166,7 +166,7 @@ public class AvtaleController {
         }
 
         filterSok.setAntallGangerSokt(filterSok.getAntallGangerSokt() + 1);
-        filterSok.setSistSoktTidspunkt(Now.localDateTime());
+        filterSok.setSistSoktTidspunkt(Now.instant());
         filterSokRepository.save(filterSok);
         AvtaleQueryParameter avtalePredicate = filterSok.getAvtalePredicate();
 
@@ -216,7 +216,7 @@ public class AvtaleController {
         FilterSok filterSokiDb = filterSokRepository.findFilterSokBySokId(queryParametre.generateHash()).orElse(null);
         if (filterSokiDb != null) {
             filterSokiDb.setAntallGangerSokt(filterSokiDb.getAntallGangerSokt() + 1);
-            filterSokiDb.setSistSoktTidspunkt(Now.localDateTime());
+            filterSokiDb.setSistSoktTidspunkt(Now.instant());
             filterSokRepository.save(filterSokiDb);
             if (!filterSokiDb.erLik(queryParametre)) {
                 log.error("Kollisjon i søkId: {}", filterSokiDb.getSokId());

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleInnhold.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleInnhold.java
@@ -25,8 +25,8 @@ import org.hibernate.annotations.Fetch;
 import org.hibernate.annotations.FetchMode;
 
 import java.math.BigDecimal;
+import java.time.Instant;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -137,13 +137,13 @@ public class AvtaleInnhold {
     }
 
     // Godkjenning
-    private LocalDateTime godkjentAvDeltaker;
-    private LocalDateTime godkjentTaushetserklæringAvMentor;
-    private LocalDateTime godkjentAvArbeidsgiver;
-    private LocalDateTime godkjentAvVeileder;
-    private LocalDateTime godkjentAvBeslutter;
-    private LocalDateTime avtaleInngått;
-    private LocalDateTime ikrafttredelsestidspunkt;
+    private Instant godkjentAvDeltaker;
+    private Instant godkjentTaushetserklæringAvMentor;
+    private Instant godkjentAvArbeidsgiver;
+    private Instant godkjentAvVeileder;
+    private Instant godkjentAvBeslutter;
+    private Instant avtaleInngått;
+    private Instant ikrafttredelsestidspunkt;
     @Convert(converter = NavIdentConverter.class)
     private NavIdent godkjentAvNavIdent;
     @Convert(converter = NavIdentConverter.class)

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/BaseAvtaleInnholdStrategy.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/BaseAvtaleInnholdStrategy.java
@@ -66,6 +66,6 @@ public abstract class BaseAvtaleInnholdStrategy implements AvtaleInnholdStrategy
     @Override
     public void endreSluttDato(LocalDate nySluttDato) {
         avtaleInnhold.setSluttDato(nySluttDato);
-        avtaleInnhold.setIkrafttredelsestidspunkt(Now.localDateTime());
+        avtaleInnhold.setIkrafttredelsestidspunkt(Now.instant());
     }
 }

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/FilterSok.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/FilterSok.java
@@ -11,7 +11,7 @@ import lombok.NoArgsConstructor;
 import lombok.SneakyThrows;
 import no.nav.tag.tiltaksgjennomforing.utils.Now;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 @Data
 @Entity
@@ -19,14 +19,13 @@ import java.time.LocalDateTime;
 public class FilterSok {
     @Id
     private String sokId;
-    private LocalDateTime sistSoktTidspunkt;
+    private Instant sistSoktTidspunkt;
     private String queryParametre;
     private Integer antallGangerSokt;
 
-
     @SneakyThrows
     public FilterSok(AvtaleQueryParameter queryParametre) {
-        this.sistSoktTidspunkt = Now.localDateTime();
+        this.sistSoktTidspunkt = Now.instant();
         this.antallGangerSokt = 1;
         this.sokId = queryParametre.generateHash();
         ObjectMapper mapper = new ObjectMapper();

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/TilskuddPeriode.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/TilskuddPeriode.java
@@ -24,8 +24,8 @@ import no.nav.tag.tiltaksgjennomforing.utils.Now;
 import org.apache.commons.lang3.builder.CompareToBuilder;
 import org.jetbrains.annotations.NotNull;
 
+import java.time.Instant;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.EnumSet;
 import java.util.Optional;
 import java.util.Set;
@@ -59,7 +59,7 @@ public class TilskuddPeriode implements Comparable<TilskuddPeriode> {
     @Convert(converter = NavIdentConverter.class)
     private NavIdent godkjentAvNavIdent;
 
-    private LocalDateTime godkjentTidspunkt;
+    private Instant godkjentTidspunkt;
 
     /**
      * "Enhet" i denne konteksten er oppfølgingsenheten til deltaker;
@@ -81,7 +81,7 @@ public class TilskuddPeriode implements Comparable<TilskuddPeriode> {
     private String avslagsforklaring;
     @Convert(converter = NavIdentConverter.class)
     private NavIdent avslåttAvNavIdent;
-    private LocalDateTime avslåttTidspunkt;
+    private Instant avslåttTidspunkt;
     private Integer løpenummer = 1;
 
     @Enumerated(EnumType.STRING)
@@ -185,7 +185,7 @@ public class TilskuddPeriode implements Comparable<TilskuddPeriode> {
     void godkjenn(NavIdent beslutter, String enhet) {
         sjekkOmKanBehandles();
 
-        setGodkjentTidspunkt(Now.localDateTime());
+        setGodkjentTidspunkt(Now.instant());
         setGodkjentAvNavIdent(beslutter);
         setEnhet(enhet);
         setStatus(TilskuddPeriodeStatus.GODKJENT);
@@ -200,7 +200,7 @@ public class TilskuddPeriode implements Comparable<TilskuddPeriode> {
             throw new FeilkodeException(Feilkode.TILSKUDDSPERIODE_INGEN_AVSLAGSAARSAKER);
         }
 
-        setAvslåttTidspunkt(Now.localDateTime());
+        setAvslåttTidspunkt(Now.instant());
         setAvslåttAvNavIdent(beslutter);
         this.avslagsårsaker.addAll(avslagsårsaker);
         setAvslagsforklaring(avslagsforklaring);

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/Veileder.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/Veileder.java
@@ -97,7 +97,7 @@ public class Veileder extends Avtalepart<NavIdent> implements InternBruker {
         Map<Fnr, Diskresjonskode> diskresjon = isSkalHenteDiskresjonskoder ? persondataService.hentDiskresjonskoder(
             avtaler.getContent().stream().map(Avtale::getDeltakerFnr).collect(Collectors.toSet())
         ) : Map.of();
-
+;
         List<BegrensetAvtale> begrensedeAvtaler = avtaler
             .getContent()
             .stream()

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/admin/AdminService.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/admin/AdminService.java
@@ -9,6 +9,7 @@ import no.nav.tag.tiltaksgjennomforing.avtale.HendelseType;
 import no.nav.tag.tiltaksgjennomforing.avtale.Identifikator;
 import no.nav.tag.tiltaksgjennomforing.avtale.Status;
 import no.nav.tag.tiltaksgjennomforing.datadeling.AvtaleHendelseUtførtAvRolle;
+import no.nav.tag.tiltaksgjennomforing.utils.DatoUtils;
 import no.nav.tag.tiltaksgjennomforing.utils.Now;
 import no.nav.tag.tiltaksgjennomforing.varsel.Varsel;
 import no.nav.tag.tiltaksgjennomforing.varsel.VarselFactory;
@@ -54,7 +55,7 @@ public class AdminService {
 
                 boolean skalBehandles = avtaleGodkjentAvArbeidsgiver != null
                     // arbeidsgiver godkjente før vi endret avtalekravene
-                    && avtaleGodkjentAvArbeidsgiver.isBefore(avtalekravDato)
+                    && DatoUtils.instantTilLocalDateTime(avtaleGodkjentAvArbeidsgiver).isBefore(avtalekravDato)
                     // trenger ikke varsle om endringer i krav på avtaler som er eldre enn 12 uker
                     && !eldreEnn12UkerOgAvsluttet;
 

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/service/AvtalestatusService.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/service/AvtalestatusService.java
@@ -21,7 +21,7 @@ import no.nav.tag.tiltaksgjennomforing.utils.Now;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.UUID;
 
 @Slf4j
@@ -73,7 +73,7 @@ public class AvtalestatusService {
     }
 
     private void sendAvtaleMelding(Avtale avtale) {
-        LocalDateTime tidspunkt = Now.localDateTime();
+        Instant tidspunkt = Now.instant();
         AvtaleMelding avtaleMelding = AvtaleMelding.create(avtale, avtale.getGjeldendeInnhold(), new Identifikator("tiltaksgjennomforing-api"), AvtaleHendelseUtførtAvRolle.SYSTEM, HendelseType.STATUSENDRING);
         try {
             String meldingSomString = objectMapper.writeValueAsString(avtaleMelding);

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/datadeling/AvtaleHendelseLytter.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/datadeling/AvtaleHendelseLytter.java
@@ -42,7 +42,7 @@ import no.nav.tag.tiltaksgjennomforing.utils.Now;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.UUID;
 
 @Component
@@ -213,10 +213,8 @@ public class AvtaleHendelseLytter {
         lagHendelse(avtale, hendelseType, utførtAv, utførtAvRolle, null);
     }
     private void lagHendelse(Avtale avtale, HendelseType hendelseType, Identifikator utførtAv, AvtaleHendelseUtførtAvRolle utførtAvRolle, ForkortetGrunn forkortetGrunn) {
-        LocalDateTime tidspunkt = Now.localDateTime();
+        Instant tidspunkt = Now.instant();
         UUID meldingId = UUID.randomUUID();
-
-
         AvtaleMelding melding = AvtaleMelding.create(avtale, avtale.getGjeldendeInnhold(), utførtAv, utførtAvRolle, hendelseType, forkortetGrunn);
         try {
             String meldingSomString = objectMapper.writeValueAsString(melding);

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/datadeling/AvtaleHendelsePatchService.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/datadeling/AvtaleHendelsePatchService.java
@@ -12,7 +12,7 @@ import no.nav.tag.tiltaksgjennomforing.utils.Now;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -80,7 +80,7 @@ public class AvtaleHendelsePatchService {
     private void lagMelding(Avtale avtale) {
         var melding = AvtaleMelding.create(avtale, avtale.getGjeldendeInnhold(), new Identifikator("tiltaksgjennomforing-api"), AvtaleHendelseUtførtAvRolle.SYSTEM, HendelseType.PATCH);
         UUID meldingId = UUID.randomUUID();
-        LocalDateTime tidspunkt = Now.localDateTime();
+        Instant tidspunkt = Now.instant();
         try {
             String meldingSomString = objectMapper.writeValueAsString(melding);
             AvtaleMeldingEntitet entitet = new AvtaleMeldingEntitet(meldingId, avtale.getId(), tidspunkt, HendelseType.PATCH, avtale.getStatus(), meldingSomString);

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/datadeling/AvtaleMelding.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/datadeling/AvtaleMelding.java
@@ -19,6 +19,7 @@ import no.nav.tag.tiltaksgjennomforing.avtale.TilskuddPeriode;
 import no.nav.tag.tiltaksgjennomforing.avtale.Tiltakstype;
 import no.nav.tag.tiltaksgjennomforing.enhet.Formidlingsgruppe;
 import no.nav.tag.tiltaksgjennomforing.enhet.Kvalifiseringsgruppe;
+import no.nav.tag.tiltaksgjennomforing.utils.DatoUtils;
 
 import java.math.BigDecimal;
 import java.time.Instant;
@@ -155,7 +156,7 @@ public class AvtaleMelding {
         avtaleMelding.setBedriftNr(avtale.getBedriftNr());
         avtaleMelding.setVeilederNavIdent(avtale.getVeilederNavIdent());
         avtaleMelding.setTiltakstype(avtale.getTiltakstype());
-        avtaleMelding.setOpprettetTidspunkt(avtale.getOpprettetTidspunkt());
+        avtaleMelding.setOpprettetTidspunkt(DatoUtils.instantTilLocalDateTime(avtale.getOpprettetTidspunkt()));
         avtaleMelding.setAvtaleId(avtale.getId());
         avtaleMelding.setAvtaleNr(avtale.getAvtaleNr());
         avtaleMelding.setSistEndret(avtale.getSistEndret());
@@ -219,13 +220,13 @@ public class AvtaleMelding {
         avtaleMelding.setStillingstype(avtaleInnhold.getStillingstype());
         avtaleMelding.setInkluderingstilskuddBegrunnelse(avtaleInnhold.getInkluderingstilskuddBegrunnelse());
         avtaleMelding.setInkluderingstilskuddTotalBeløp(avtaleInnhold.inkluderingstilskuddTotalBeløp());
-        avtaleMelding.setGodkjentAvDeltaker(avtaleInnhold.getGodkjentAvDeltaker());
-        avtaleMelding.setGodkjentTaushetserklæringAvMentor(avtaleInnhold.getGodkjentTaushetserklæringAvMentor());
-        avtaleMelding.setGodkjentAvArbeidsgiver(avtaleInnhold.getGodkjentAvArbeidsgiver());
-        avtaleMelding.setGodkjentAvVeileder(avtaleInnhold.getGodkjentAvVeileder());
-        avtaleMelding.setGodkjentAvBeslutter(avtaleInnhold.getGodkjentAvBeslutter());
-        avtaleMelding.setAvtaleInngått(avtaleInnhold.getAvtaleInngått());
-        avtaleMelding.setIkrafttredelsestidspunkt(avtaleInnhold.getIkrafttredelsestidspunkt());
+        avtaleMelding.setGodkjentAvDeltaker(DatoUtils.instantTilLocalDateTime(avtaleInnhold.getGodkjentAvDeltaker()));
+        avtaleMelding.setGodkjentTaushetserklæringAvMentor(DatoUtils.instantTilLocalDateTime(avtaleInnhold.getGodkjentTaushetserklæringAvMentor()));
+        avtaleMelding.setGodkjentAvArbeidsgiver(DatoUtils.instantTilLocalDateTime(avtaleInnhold.getGodkjentAvArbeidsgiver()));
+        avtaleMelding.setGodkjentAvVeileder(DatoUtils.instantTilLocalDateTime(avtaleInnhold.getGodkjentAvVeileder()));
+        avtaleMelding.setGodkjentAvBeslutter(DatoUtils.instantTilLocalDateTime(avtaleInnhold.getGodkjentAvBeslutter()));
+        avtaleMelding.setAvtaleInngått(DatoUtils.instantTilLocalDateTime(avtaleInnhold.getAvtaleInngått()));
+        avtaleMelding.setIkrafttredelsestidspunkt(DatoUtils.instantTilLocalDateTime(avtaleInnhold.getIkrafttredelsestidspunkt()));
         avtaleMelding.setGodkjentAvNavIdent(avtaleInnhold.getGodkjentAvNavIdent());
         avtaleMelding.setGodkjentAvBeslutterNavIdent(avtaleInnhold.getGodkjentAvBeslutterNavIdent());
         avtaleMelding.setEnhetKostnadssted(avtaleInnhold.getEnhetKostnadssted());

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/datadeling/AvtaleMeldingEntitet.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/datadeling/AvtaleMeldingEntitet.java
@@ -11,7 +11,7 @@ import no.nav.tag.tiltaksgjennomforing.avtale.HendelseType;
 import no.nav.tag.tiltaksgjennomforing.avtale.Status;
 import org.springframework.data.domain.AbstractAggregateRoot;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.UUID;
 
 @Entity
@@ -28,12 +28,12 @@ public class AvtaleMeldingEntitet extends AbstractAggregateRoot<AvtaleMeldingEnt
 
     @Enumerated(EnumType.STRING)
     private Status avtaleStatus;
-    private LocalDateTime tidspunkt;
+    private Instant tidspunkt;
     private String json;
     private boolean sendt;
     private boolean sendtCompacted;
 
-    public AvtaleMeldingEntitet(UUID meldingId, UUID avtaleId, LocalDateTime tidspunkt, HendelseType hendelseType, Status avtaleStatus, String meldingAsJson) {
+    public AvtaleMeldingEntitet(UUID meldingId, UUID avtaleId, Instant tidspunkt, HendelseType hendelseType, Status avtaleStatus, String meldingAsJson) {
         this.meldingId = meldingId;
         this.avtaleId = avtaleId;
         this.hendelseType = hendelseType;

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/datavarehus/AvroTiltakHendelseFabrikk.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/datavarehus/AvroTiltakHendelseFabrikk.java
@@ -7,9 +7,6 @@ import no.nav.tag.tiltaksgjennomforing.avtale.ForkortetGrunn;
 import no.nav.tag.tiltaksgjennomforing.avtale.Tiltakstype;
 import no.nav.tag.tiltaksgjennomforing.utils.Now;
 
-import java.time.Instant;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -58,12 +55,12 @@ public class AvroTiltakHendelseFabrikk {
         hendelse.setReservert(avtale.getGjeldendeInnhold().getGodkjentPaVegneGrunn() != null && avtale.getGjeldendeInnhold().getGodkjentPaVegneGrunn().isReservert());
         hendelse.setDigitalKompetanse(avtale.getGjeldendeInnhold().getGodkjentPaVegneGrunn() != null && avtale.getGjeldendeInnhold().getGodkjentPaVegneGrunn().isDigitalKompetanse());
         hendelse.setArenaMigreringDeltaker(avtale.getGjeldendeInnhold().getGodkjentPaVegneGrunn() != null && avtale.getGjeldendeInnhold().getGodkjentPaVegneGrunn().isArenaMigreringDeltaker());
-        hendelse.setGodkjentAvDeltaker(toInstant(avtale.getGjeldendeInnhold().getGodkjentAvDeltaker()));
-        hendelse.setGodkjentAvArbeidsgiver(toInstant(avtale.getGjeldendeInnhold().getGodkjentAvArbeidsgiver()));
-        hendelse.setGodkjentAvArbeidsgiver(toInstant(avtale.getGjeldendeInnhold().getGodkjentAvArbeidsgiver()));
-        hendelse.setGodkjentAvVeileder(toInstant(avtale.getGjeldendeInnhold().getGodkjentAvVeileder()));
-        hendelse.setGodkjentAvBeslutter(toInstant(avtale.getGjeldendeInnhold().getGodkjentAvBeslutter()));
-        hendelse.setAvtaleInngaatt(toInstant(avtale.getGjeldendeInnhold().getAvtaleInngått()));
+        hendelse.setGodkjentAvDeltaker(avtale.getGjeldendeInnhold().getGodkjentAvDeltaker());
+        hendelse.setGodkjentAvArbeidsgiver(avtale.getGjeldendeInnhold().getGodkjentAvArbeidsgiver());
+        hendelse.setGodkjentAvArbeidsgiver(avtale.getGjeldendeInnhold().getGodkjentAvArbeidsgiver());
+        hendelse.setGodkjentAvVeileder(avtale.getGjeldendeInnhold().getGodkjentAvVeileder());
+        hendelse.setGodkjentAvBeslutter(avtale.getGjeldendeInnhold().getGodkjentAvBeslutter());
+        hendelse.setAvtaleInngaatt(avtale.getGjeldendeInnhold().getAvtaleInngått());
         hendelse.setUtfortAv(utførtAv);
         hendelse.setEnhetOppfolging(avtale.getEnhetOppfolging());
         hendelse.setEnhetGeografisk(avtale.getEnhetGeografisk());
@@ -80,12 +77,5 @@ public class AvroTiltakHendelseFabrikk {
             return Boolean.TRUE;
         }
         return Boolean.FALSE;
-    }
-
-    private static Instant toInstant(LocalDateTime tidspunkt) {
-        if (tidspunkt == null) {
-            return null;
-        }
-        return tidspunkt.atZone(ZoneId.systemDefault()).toInstant();
     }
 }

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/datavarehus/DvhMeldingEntitet.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/datavarehus/DvhMeldingEntitet.java
@@ -11,8 +11,7 @@ import no.nav.tag.tiltaksgjennomforing.avtale.Avtale;
 import no.nav.tag.tiltaksgjennomforing.avtale.Status;
 import org.springframework.data.domain.AbstractAggregateRoot;
 
-import java.time.LocalDateTime;
-import java.time.ZoneId;
+import java.time.Instant;
 import java.util.UUID;
 
 @Entity
@@ -23,7 +22,7 @@ public class DvhMeldingEntitet extends AbstractAggregateRoot<DvhMeldingEntitet> 
     @Id
     private UUID meldingId;
     private UUID avtaleId;
-    private LocalDateTime tidspunkt;
+    private Instant tidspunkt;
     @Enumerated(EnumType.STRING)
     private Status tiltakStatus;
     private String json;
@@ -32,7 +31,7 @@ public class DvhMeldingEntitet extends AbstractAggregateRoot<DvhMeldingEntitet> 
     public DvhMeldingEntitet(Avtale avtale, AvroTiltakHendelse avroTiltakHendelse) {
         this.meldingId = UUID.fromString(avroTiltakHendelse.getMeldingId());
         this.avtaleId = avtale.getId();
-        this.tidspunkt = LocalDateTime.ofInstant(avroTiltakHendelse.getTidspunkt(), ZoneId.systemDefault());
+        this.tidspunkt = avroTiltakHendelse.getTidspunkt();
         this.tiltakStatus = avtale.getStatus();
         this.json = avroTiltakHendelse.toString();
         registerEvent(new DvhMeldingOpprettet(this, avroTiltakHendelse));

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/journalfoering/AvtaleTilJournalfoeringMapper.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/journalfoering/AvtaleTilJournalfoeringMapper.java
@@ -7,7 +7,9 @@ import no.nav.tag.tiltaksgjennomforing.avtale.GodkjentPaVegneGrunn;
 import no.nav.tag.tiltaksgjennomforing.avtale.Identifikator;
 import no.nav.tag.tiltaksgjennomforing.avtale.Maal;
 import no.nav.tag.tiltaksgjennomforing.avtale.Tiltakstype;
+import no.nav.tag.tiltaksgjennomforing.utils.DatoUtils;
 
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -32,10 +34,10 @@ public class AvtaleTilJournalfoeringMapper {
         avtaleTilJournalfoering.setMentorOppgaver(avtale.getGjeldendeInnhold().getMentorOppgaver());
         avtaleTilJournalfoering.setMentorAntallTimer(avtale.getGjeldendeInnhold().getMentorAntallTimer());
         avtaleTilJournalfoering.setMentorTimelonn(avtale.getGjeldendeInnhold().getMentorTimelonn());
-        avtaleTilJournalfoering.setGodkjentAvArbeidsgiver(avtaleInnhold.getGodkjentAvArbeidsgiver().toLocalDate());
-        avtaleTilJournalfoering.setGodkjentAvVeileder(avtaleInnhold.getGodkjentAvVeileder().toLocalDate());
-        avtaleTilJournalfoering.setGodkjentAvDeltaker(avtaleInnhold.getGodkjentAvDeltaker().toLocalDate());
-        avtaleTilJournalfoering.setOpprettet(avtale.getOpprettetTidspunkt().toLocalDate());
+        avtaleTilJournalfoering.setGodkjentAvArbeidsgiver(DatoUtils.instantTilLocalDate(avtaleInnhold.getGodkjentAvArbeidsgiver()));
+        avtaleTilJournalfoering.setGodkjentAvVeileder(DatoUtils.instantTilLocalDate(avtaleInnhold.getGodkjentAvVeileder()));
+        avtaleTilJournalfoering.setGodkjentAvDeltaker(DatoUtils.instantTilLocalDate(avtaleInnhold.getGodkjentAvDeltaker()));
+        avtaleTilJournalfoering.setOpprettet(avtale.getOpprettetTidspunkt().atZone(ZoneId.systemDefault()).toLocalDate());
         avtaleTilJournalfoering.setAvtaleId(avtale.getId());
         avtaleTilJournalfoering.setAvtaleVersjonId(avtaleInnhold.getId());
         avtaleTilJournalfoering.setDeltakerFnr(identifikatorAsString(avtale.getDeltakerFnr()));
@@ -56,7 +58,7 @@ public class AvtaleTilJournalfoeringMapper {
         avtaleTilJournalfoering.setOppfolging(avtaleInnhold.getOppfolging());
         avtaleTilJournalfoering.setTilrettelegging(avtaleInnhold.getTilrettelegging());
         avtaleTilJournalfoering.setStartDato(avtaleInnhold.getStartDato());
-        avtaleTilJournalfoering.setOpprettetAar(avtale.getOpprettetTidspunkt().getYear());
+        avtaleTilJournalfoering.setOpprettetAar(avtale.getOpprettetTidspunkt().atZone(ZoneId.systemDefault()).getYear());
         avtaleTilJournalfoering.setSluttDato(avtaleInnhold.getSluttDato());
         avtaleTilJournalfoering.setStillingprosent(avtale.getGjeldendeInnhold().getStillingprosent());
         avtaleTilJournalfoering.setAntallDagerPerUke(avtale.getGjeldendeInnhold().getAntallDagerPerUke());
@@ -82,13 +84,11 @@ public class AvtaleTilJournalfoeringMapper {
             avtaleTilJournalfoering.setAvtalerolle(avtalerolle);
         }
         if (avtaleInnhold.getGodkjentTaushetserklæringAvMentor() != null) {
-            avtaleTilJournalfoering.setGodkjentTaushetserklæringAvMentor(avtaleInnhold.getGodkjentTaushetserklæringAvMentor().toLocalDate());
+            avtaleTilJournalfoering.setGodkjentTaushetserklæringAvMentor(DatoUtils.instantTilLocalDate(avtaleInnhold.getGodkjentTaushetserklæringAvMentor()));
         }
 
         if (avtale.getTiltakstype().equals(Tiltakstype.VTAO)) {
-            avtaleTilJournalfoering.setSumLonnstilskudd(
-                    VTAO_SATS.hentGjeldendeSats(avtale.getOpprettetTidspunkt().toLocalDate())
-            );
+            avtaleTilJournalfoering.setSumLonnstilskudd(VTAO_SATS.hentGjeldendeSats(avtale.getOpprettetTidspunkt()));
         }
 
         return avtaleTilJournalfoering;

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/satser/Sats.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/satser/Sats.java
@@ -1,6 +1,8 @@
 package no.nav.tag.tiltaksgjennomforing.satser;
 
+import java.time.Instant;
 import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
@@ -65,6 +67,10 @@ public class Sats {
 
     public NavigableMap<LocalDate, Integer> getSatsePerioder() {
         return satsePerioder;
+    }
+
+    public Integer hentGjeldendeSats(Instant instant) {
+        return hentGjeldendeSats(instant.atZone(ZoneId.systemDefault()).toLocalDate());
     }
 
     public Integer hentGjeldendeSats(LocalDate dato) {

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/sporingslogg/Sporingslogg.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/sporingslogg/Sporingslogg.java
@@ -10,7 +10,7 @@ import no.nav.tag.tiltaksgjennomforing.avtale.Avtale;
 import no.nav.tag.tiltaksgjennomforing.avtale.HendelseType;
 import no.nav.tag.tiltaksgjennomforing.utils.Now;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.UUID;
 
 @Data
@@ -19,7 +19,7 @@ import java.util.UUID;
 public class Sporingslogg {
     @Id
     private UUID id;
-    private LocalDateTime tidspunkt;
+    private Instant tidspunkt;
     private UUID avtaleId;
     @Enumerated(EnumType.STRING)
     private HendelseType hendelseType;
@@ -27,7 +27,7 @@ public class Sporingslogg {
     public static Sporingslogg nyHendelse(Avtale avtale, HendelseType hendelseType) {
         Sporingslogg sporingslogg = new Sporingslogg();
         sporingslogg.id = UUID.randomUUID();
-        sporingslogg.tidspunkt = Now.localDateTime();
+        sporingslogg.tidspunkt = Now.instant();
         sporingslogg.avtaleId = avtale.getId();
         sporingslogg.hendelseType = hendelseType;
         return sporingslogg;

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/tilskuddsperiode/TilskuddsperiodeGodkjentMelding.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/tilskuddsperiode/TilskuddsperiodeGodkjentMelding.java
@@ -9,6 +9,7 @@ import no.nav.tag.tiltaksgjennomforing.avtale.Identifikator;
 import no.nav.tag.tiltaksgjennomforing.avtale.NavIdent;
 import no.nav.tag.tiltaksgjennomforing.avtale.TilskuddPeriode;
 import no.nav.tag.tiltaksgjennomforing.avtale.Tiltakstype;
+import no.nav.tag.tiltaksgjennomforing.utils.DatoUtils;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -84,7 +85,7 @@ public class TilskuddsperiodeGodkjentMelding {
                 tilskuddsperiode.getGodkjentAvNavIdent(),
                 avtale.getGjeldendeInnhold().getVeilederFornavn(),
                 avtale.getGjeldendeInnhold().getVeilederEtternavn(),
-                tilskuddsperiode.getGodkjentTidspunkt(),
+                DatoUtils.instantTilLocalDateTime(tilskuddsperiode.getGodkjentTidspunkt()),
                 avtale.getGjeldendeInnhold().getArbeidsgiverKontonummer()
         );
     }

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/utils/DatoUtils.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/utils/DatoUtils.java
@@ -2,7 +2,12 @@ package no.nav.tag.tiltaksgjennomforing.utils;
 
 import lombok.experimental.UtilityClass;
 
+import java.time.Instant;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.Optional;
 
 @UtilityClass
 public class DatoUtils {
@@ -12,5 +17,23 @@ public class DatoUtils {
 
     public static LocalDate maksDato(LocalDate date1, LocalDate date2) {
         return date1.isAfter(date2) ? date1 : date2;
+    }
+
+    public static LocalDateTime instantTilLocalDateTime(Instant instant) {
+        return Optional.ofNullable(instant)
+            .map(DatoUtils::instantTilZonedDateTime)
+            .map(ZonedDateTime::toLocalDateTime)
+            .orElse(null);
+    }
+
+    public static LocalDate instantTilLocalDate(Instant instant) {
+        return Optional.ofNullable(instant)
+            .map(DatoUtils::instantTilZonedDateTime)
+            .map(ZonedDateTime::toLocalDate)
+            .orElse(null);
+    }
+
+    private static ZonedDateTime instantTilZonedDateTime(Instant instant) {
+        return instant.atZone(ZoneId.of("Europe/Oslo"));
     }
 }

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/varsel/Sms.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/varsel/Sms.java
@@ -17,7 +17,7 @@ import no.nav.tag.tiltaksgjennomforing.utils.Now;
 import no.nav.tag.tiltaksgjennomforing.varsel.events.SmsSendt;
 import org.springframework.data.domain.AbstractAggregateRoot;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.UUID;
 
 @Slf4j
@@ -34,7 +34,7 @@ public class Sms extends AbstractAggregateRoot<Sms> {
     private Identifikator identifikator;
     private String meldingstekst;
     private UUID avtaleId;
-    private LocalDateTime tidspunkt;
+    private Instant tidspunkt;
     @Enumerated(EnumType.STRING)
     private HendelseType hendelseType;
     private String avsenderApplikasjon;
@@ -50,7 +50,7 @@ public class Sms extends AbstractAggregateRoot<Sms> {
         sms.identifikator = identifikator;
         sms.meldingstekst = meldingstekst;
         sms.hendelseType = hendelseType;
-        sms.tidspunkt = Now.localDateTime();
+        sms.tidspunkt = Now.instant();
         sms.avtaleId = avtaleId;
         sms.avsenderApplikasjon = "tiltaksgjennomforing-api";
         sms.registerEvent(new SmsSendt(sms));

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/varsel/Varsel.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/varsel/Varsel.java
@@ -19,7 +19,7 @@ import no.nav.tag.tiltaksgjennomforing.datadeling.AvtaleHendelseUtførtAvRolle;
 import no.nav.tag.tiltaksgjennomforing.utils.Now;
 import org.springframework.data.domain.AbstractAggregateRoot;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.time.format.DateTimeFormatter;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -42,7 +42,7 @@ public class Varsel extends AbstractAggregateRoot<Varsel> {
     private HendelseType hendelseType;
     private boolean bjelle;
     private UUID avtaleId;
-    private LocalDateTime tidspunkt;
+    private Instant tidspunkt;
     @Enumerated(EnumType.STRING)
     private Avtalerolle mottaker;
     @Enumerated(EnumType.STRING)
@@ -90,7 +90,7 @@ public class Varsel extends AbstractAggregateRoot<Varsel> {
     ) {
         Varsel varsel = new Varsel();
         varsel.id = UUID.randomUUID();
-        varsel.tidspunkt = Now.localDateTime();
+        varsel.tidspunkt = Now.instant();
         varsel.identifikator = identifikator;
         varsel.utførtAvIdentifikator = utførtAvIdentifikator;
         varsel.tekst = lagVarselTekst(avtale, tilskuddPeriode, hendelseType);

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/varsel/VarselRespons.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/varsel/VarselRespons.java
@@ -3,7 +3,7 @@ package no.nav.tag.tiltaksgjennomforing.varsel;
 import no.nav.tag.tiltaksgjennomforing.avtale.Avtalerolle;
 import no.nav.tag.tiltaksgjennomforing.avtale.HendelseType;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.UUID;
 
 public record VarselRespons(
@@ -13,7 +13,7 @@ public record VarselRespons(
         HendelseType hendelseType,
         boolean bjelle,
         UUID avtaleId,
-        LocalDateTime tidspunkt,
+        Instant tidspunkt,
         String utførtAv
 ) {
     public VarselRespons(Varsel varsel, Avtalerolle innloggetPart) {

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/varsel/notifikasjon/ArbeidsgiverNotifikasjon.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/varsel/notifikasjon/ArbeidsgiverNotifikasjon.java
@@ -15,7 +15,7 @@ import no.nav.tag.tiltaksgjennomforing.avtale.BedriftNrConverter;
 import no.nav.tag.tiltaksgjennomforing.avtale.HendelseType;
 import no.nav.tag.tiltaksgjennomforing.utils.Now;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.UUID;
 
 @Data
@@ -27,7 +27,7 @@ public class ArbeidsgiverNotifikasjon {
 
     @Id
     private UUID id;
-    private LocalDateTime tidspunkt;
+    private Instant tidspunkt;
     private UUID avtaleId;
     @Enumerated(EnumType.STRING)
     private HendelseType hendelseType;
@@ -56,7 +56,7 @@ public class ArbeidsgiverNotifikasjon {
 
         ArbeidsgiverNotifikasjon notifikasjon = new ArbeidsgiverNotifikasjon();
         notifikasjon.id = UUID.randomUUID();
-        notifikasjon.tidspunkt = Now.localDateTime();
+        notifikasjon.tidspunkt = Now.instant();
         notifikasjon.avtaleId = avtale.getId();
         notifikasjon.hendelseType = hendelseType;
         notifikasjon.virksomhetsnummer = avtale.getBedriftNr();

--- a/src/main/resources/db/migration/common/V129__tidssoner.sql
+++ b/src/main/resources/db/migration/common/V129__tidssoner.sql
@@ -1,0 +1,80 @@
+alter table arbeidsgiver_notifikasjon alter column tidspunkt type timestamp with time zone
+    using tidspunkt at time zone 'Europe/Oslo';
+
+alter table arena_agreement_migration alter column created type timestamp with time zone
+    using created at time zone 'Europe/Oslo';
+
+alter table arena_agreement_migration alter column modified type timestamp with time zone
+    using modified at time zone 'Europe/Oslo';
+
+alter table arena_event alter column created type timestamp with time zone
+    using created at time zone 'Europe/Oslo';
+
+alter table avtale alter column opprettet_tidspunkt type timestamp with time zone
+    using opprettet_tidspunkt at time zone 'Europe/Oslo';
+
+alter table avtale alter column sist_endret type timestamp with time zone
+    using sist_endret at time zone 'UTC';
+
+alter table avtale alter column annullert_tidspunkt type timestamp with time zone
+    using annullert_tidspunkt at time zone 'UTC';
+
+alter table avtale_forkortet alter column tidspunkt type timestamp with time zone
+    using tidspunkt at time zone 'UTC';
+
+alter table avtale_innhold alter column godkjent_av_deltaker type timestamp with time zone
+    using godkjent_av_deltaker at time zone 'Europe/Oslo';
+
+alter table avtale_innhold alter column godkjent_av_arbeidsgiver type timestamp with time zone
+    using godkjent_av_arbeidsgiver at time zone 'Europe/Oslo';
+
+alter table avtale_innhold alter column godkjent_av_veileder type timestamp with time zone
+    using godkjent_av_veileder at time zone 'Europe/Oslo';
+
+alter table avtale_innhold alter column godkjent_av_beslutter type timestamp with time zone
+    using godkjent_av_beslutter at time zone 'Europe/Oslo';
+
+alter table avtale_innhold alter column godkjent_taushetserklæring_av_mentor type timestamp with time zone
+    using godkjent_taushetserklæring_av_mentor at time zone 'Europe/Oslo';
+
+alter table avtale_innhold alter column avtale_inngått type timestamp with time zone
+    using avtale_inngått at time zone 'Europe/Oslo';
+
+alter table avtale_innhold alter column ikrafttredelsestidspunkt type timestamp with time zone
+    using ikrafttredelsestidspunkt at time zone 'Europe/Oslo';
+
+alter table avtale_melding alter column tidspunkt type timestamp with time zone
+    using tidspunkt at time zone 'Europe/Oslo';
+
+alter table dvh_melding alter column tidspunkt type timestamp with time zone
+    using tidspunkt at time zone 'Europe/Oslo';
+
+alter table filter_sok alter column sist_sokt_tidspunkt type timestamp with time zone
+    using sist_sokt_tidspunkt at time zone 'Europe/Oslo';
+
+alter table inkluderingstilskuddsutgift alter column tidspunkt_lagt_til type timestamp with time zone
+    using tidspunkt_lagt_til at time zone 'Europe/Oslo';
+
+alter table maal alter column opprettet_tidspunkt type timestamp with time zone
+    using opprettet_tidspunkt at time zone 'Europe/Oslo';
+
+alter table maal alter column opprettet_tidspunkt type timestamp with time zone
+    using opprettet_tidspunkt at time zone 'Europe/Oslo';
+
+alter table oppgave alter column opprettet_tidspunkt type timestamp with time zone
+    using opprettet_tidspunkt at time zone 'Europe/Oslo';
+
+alter table sms alter column tidspunkt type timestamp with time zone
+    using tidspunkt at time zone 'Europe/Oslo';
+
+alter table sporingslogg alter column tidspunkt type timestamp with time zone
+    using tidspunkt at time zone 'Europe/Oslo';
+
+alter table tilskudd_periode alter column godkjent_tidspunkt type timestamp with time zone
+    using godkjent_tidspunkt at time zone 'Europe/Oslo';
+
+alter table tilskudd_periode alter column avslått_tidspunkt type timestamp with time zone
+    using avslått_tidspunkt at time zone 'Europe/Oslo';
+
+alter table varsel alter column tidspunkt type timestamp with time zone
+    using tidspunkt at time zone 'Europe/Oslo';

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/LastInnTestData.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/LastInnTestData.java
@@ -49,7 +49,7 @@ public class LastInnTestData implements ApplicationListener<ApplicationReadyEven
         avtaler.add(TestData.enAvtaleMedFlereVersjoner());
         avtaler.add(TestData.enAvtaleKlarForOppstart());
         Avtale lilly = TestData.enMidlertidigLonnstilskuddAvtaleMedAltUtfylt();
-        lilly.getGjeldendeInnhold().setGodkjentAvArbeidsgiver(Now.localDateTime());
+        lilly.getGjeldendeInnhold().setGodkjentAvArbeidsgiver(Now.instant());
         avtaler.add(lilly);
         avtaler.add(TestData.enMidlertidigLonnstilskuddAvtaleGodkjentAvVeileder());
 

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/ArbeidsgiverTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/ArbeidsgiverTest.java
@@ -38,7 +38,7 @@ public class ArbeidsgiverTest {
     @Test
     public void opphevGodkjenninger__kan_oppheve_ved_deltakergodkjenning() {
         Avtale avtale = TestData.enAvtaleMedAltUtfylt();
-        avtale.getGjeldendeInnhold().setGodkjentAvDeltaker(Now.localDateTime());
+        avtale.getGjeldendeInnhold().setGodkjentAvDeltaker(Now.instant());
         Arbeidsgiver arbeidsgiver = TestData.enArbeidsgiver(avtale);
         arbeidsgiver.opphevGodkjenninger(avtale);
         assertThat(avtale.erGodkjentAvDeltaker()).isFalse();
@@ -47,7 +47,7 @@ public class ArbeidsgiverTest {
     @Test
     public void opphevGodkjenninger__kan_ikke_oppheve_veiledergodkjenning() {
         Avtale avtale = TestData.enAvtaleMedAltUtfylt();
-        avtale.getGjeldendeInnhold().setGodkjentAvVeileder(Now.localDateTime());
+        avtale.getGjeldendeInnhold().setGodkjentAvVeileder(Now.instant());
         Arbeidsgiver arbeidsgiver = TestData.enArbeidsgiver(avtale);
         assertThatThrownBy(() -> arbeidsgiver.opphevGodkjenninger(avtale)).isInstanceOf(KanIkkeOppheveException.class);
     }

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleRepositoryTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleRepositoryTest.java
@@ -159,7 +159,7 @@ public class AvtaleRepositoryTest {
     @Test
     public void avtale_godkjent_pa_vegne_av_skal_lagres_med_pa_vegne_av_grunn() {
         Avtale avtale = TestData.enAvtaleMedAltUtfylt();
-        avtale.getGjeldendeInnhold().setGodkjentAvArbeidsgiver(Now.localDateTime());
+        avtale.getGjeldendeInnhold().setGodkjentAvArbeidsgiver(Now.instant());
         GodkjentPaVegneGrunn godkjentPaVegneGrunn = TestData.enGodkjentPaVegneGrunn();
         godkjentPaVegneGrunn.setIkkeBankId(true);
         Veileder veileder = TestData.enVeileder(avtale);
@@ -173,7 +173,7 @@ public class AvtaleRepositoryTest {
     @Test
     public void lagre_pa_vegne_skal_publisere_domainevent() {
         Avtale avtale = TestData.enAvtaleMedAltUtfylt();
-        avtale.getGjeldendeInnhold().setGodkjentAvArbeidsgiver(Now.localDateTime());
+        avtale.getGjeldendeInnhold().setGodkjentAvArbeidsgiver(Now.instant());
         Veileder veileder = TestData.enVeileder(avtale);
         GodkjentPaVegneGrunn godkjentPaVegneGrunn = TestData.enGodkjentPaVegneGrunn();
         veileder.godkjennForVeilederOgDeltaker(godkjentPaVegneGrunn, avtale);
@@ -217,8 +217,8 @@ public class AvtaleRepositoryTest {
     @Test
     public void godkjennForVeileder__skal_publisere_domainevent() {
         Avtale avtale = TestData.enAvtaleMedAltUtfylt();
-        avtale.getGjeldendeInnhold().setGodkjentAvDeltaker(Now.localDateTime());
-        avtale.getGjeldendeInnhold().setGodkjentAvArbeidsgiver(Now.localDateTime());
+        avtale.getGjeldendeInnhold().setGodkjentAvDeltaker(Now.instant());
+        avtale.getGjeldendeInnhold().setGodkjentAvArbeidsgiver(Now.instant());
         TestData.enVeileder(avtale).godkjennAvtale(avtale);
         avtaleRepository.save(avtale);
         verify(metrikkRegistrering).godkjentAvVeileder(any());

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleTest.java
@@ -392,12 +392,12 @@ public class AvtaleTest {
     public void test_riktig_beregning_NEDSATT_ARBEIDSEVNE_Midlertidig_Lonnstilskudd_Avtale_som_varer_i_2_aar() {
         Now.fixedDate(LocalDate.of(2024, 7, 29));
         Avtale avtale = TestData.enMidLonnstilskuddAvtaleMedVarigTilpassetSatsMedAltUtfylt();
-        avtale.getGjeldendeInnhold().setGodkjentAvArbeidsgiver(Now.localDateTime());
-        avtale.getGjeldendeInnhold().setGodkjentAvDeltaker(Now.localDateTime());
-        avtale.getGjeldendeInnhold().setGodkjentAvVeileder(Now.localDateTime());
-        avtale.getGjeldendeInnhold().setAvtaleInngått(Now.localDateTime());
+        avtale.getGjeldendeInnhold().setGodkjentAvArbeidsgiver(Now.instant());
+        avtale.getGjeldendeInnhold().setGodkjentAvDeltaker(Now.instant());
+        avtale.getGjeldendeInnhold().setGodkjentAvVeileder(Now.instant());
+        avtale.getGjeldendeInnhold().setAvtaleInngått(Now.instant());
         avtale.getGjeldendeInnhold().setGodkjentAvNavIdent(TestData.enNavIdent());
-        avtale.getGjeldendeInnhold().setIkrafttredelsestidspunkt(Now.localDateTime());
+        avtale.getGjeldendeInnhold().setIkrafttredelsestidspunkt(Now.instant());
         avtale.getGjeldendeInnhold().setJournalpostId("1");
         double otpSats = 0.048;
         BigDecimal feriepengesats = new BigDecimal("0.166");
@@ -945,10 +945,10 @@ public class AvtaleTest {
         Avtale avtale = TestData.enAvtaleMedAltUtfylt();
         avtale.getGjeldendeInnhold().setStartDato(Now.localDate().minusWeeks(4).minusDays(1));
         avtale.getGjeldendeInnhold().setSluttDato(avtale.getGjeldendeInnhold().getStartDato().plusWeeks(4));
-        avtale.getGjeldendeInnhold().setGodkjentAvArbeidsgiver(Now.localDateTime());
-        avtale.getGjeldendeInnhold().setGodkjentAvDeltaker(Now.localDateTime());
-        avtale.getGjeldendeInnhold().setGodkjentAvVeileder(Now.localDateTime());
-        avtale.getGjeldendeInnhold().setAvtaleInngått(Now.localDateTime());
+        avtale.getGjeldendeInnhold().setGodkjentAvArbeidsgiver(Now.instant());
+        avtale.getGjeldendeInnhold().setGodkjentAvDeltaker(Now.instant());
+        avtale.getGjeldendeInnhold().setGodkjentAvVeileder(Now.instant());
+        avtale.getGjeldendeInnhold().setAvtaleInngått(Now.instant());
         avtale.setStatus(Status.fra(avtale));
         assertThat(avtale.getStatus()).isEqualTo(Status.AVSLUTTET);
     }
@@ -958,10 +958,10 @@ public class AvtaleTest {
         Avtale avtale = TestData.enAvtaleMedAltUtfylt();
         avtale.getGjeldendeInnhold().setStartDato(Now.localDate().minusWeeks(4));
         avtale.getGjeldendeInnhold().setSluttDato(avtale.getGjeldendeInnhold().getStartDato().plusWeeks(4));
-        avtale.getGjeldendeInnhold().setGodkjentAvArbeidsgiver(Now.localDateTime());
-        avtale.getGjeldendeInnhold().setGodkjentAvDeltaker(Now.localDateTime());
-        avtale.getGjeldendeInnhold().setGodkjentAvVeileder(Now.localDateTime());
-        avtale.getGjeldendeInnhold().setAvtaleInngått(Now.localDateTime());
+        avtale.getGjeldendeInnhold().setGodkjentAvArbeidsgiver(Now.instant());
+        avtale.getGjeldendeInnhold().setGodkjentAvDeltaker(Now.instant());
+        avtale.getGjeldendeInnhold().setGodkjentAvVeileder(Now.instant());
+        avtale.getGjeldendeInnhold().setAvtaleInngått(Now.instant());
         avtale.setStatus(Status.fra(avtale));
         assertThat(avtale.getStatus()).isEqualTo(Status.GJENNOMFØRES);
     }
@@ -971,10 +971,10 @@ public class AvtaleTest {
         Avtale avtale = TestData.enAvtaleMedAltUtfylt();
         avtale.getGjeldendeInnhold().setStartDato(Now.localDate());
         avtale.getGjeldendeInnhold().setSluttDato(avtale.getGjeldendeInnhold().getStartDato().plusWeeks(4));
-        avtale.getGjeldendeInnhold().setGodkjentAvArbeidsgiver(Now.localDateTime());
-        avtale.getGjeldendeInnhold().setGodkjentAvDeltaker(Now.localDateTime());
-        avtale.getGjeldendeInnhold().setGodkjentAvVeileder(Now.localDateTime());
-        avtale.getGjeldendeInnhold().setAvtaleInngått(Now.localDateTime());
+        avtale.getGjeldendeInnhold().setGodkjentAvArbeidsgiver(Now.instant());
+        avtale.getGjeldendeInnhold().setGodkjentAvDeltaker(Now.instant());
+        avtale.getGjeldendeInnhold().setGodkjentAvVeileder(Now.instant());
+        avtale.getGjeldendeInnhold().setAvtaleInngått(Now.instant());
         avtale.setStatus(Status.fra(avtale));
         assertThat(avtale.getStatus()).isEqualTo(Status.GJENNOMFØRES);
     }
@@ -984,10 +984,10 @@ public class AvtaleTest {
         Avtale avtale = TestData.enAvtaleMedAltUtfylt();
         avtale.getGjeldendeInnhold().setStartDato(Now.localDate().plusDays(1));
         avtale.getGjeldendeInnhold().setSluttDato(avtale.getGjeldendeInnhold().getStartDato().plusWeeks(4));
-        avtale.getGjeldendeInnhold().setGodkjentAvArbeidsgiver(Now.localDateTime());
-        avtale.getGjeldendeInnhold().setGodkjentAvDeltaker(Now.localDateTime());
-        avtale.getGjeldendeInnhold().setGodkjentAvVeileder(Now.localDateTime());
-        avtale.getGjeldendeInnhold().setAvtaleInngått(Now.localDateTime());
+        avtale.getGjeldendeInnhold().setGodkjentAvArbeidsgiver(Now.instant());
+        avtale.getGjeldendeInnhold().setGodkjentAvDeltaker(Now.instant());
+        avtale.getGjeldendeInnhold().setGodkjentAvVeileder(Now.instant());
+        avtale.getGjeldendeInnhold().setAvtaleInngått(Now.instant());
         avtale.setStatus(Status.fra(avtale));
         assertThat(avtale.getStatus()).isEqualTo(Status.KLAR_FOR_OPPSTART);
     }
@@ -1004,10 +1004,10 @@ public class AvtaleTest {
         Avtale avtale = TestData.enAvtaleMedAltUtfylt();
         avtale.getGjeldendeInnhold().setStartDato(Now.localDate().plusDays(1));
         avtale.getGjeldendeInnhold().setSluttDato(Now.localDate().plusDays(1).plusMonths(1).minusDays(1));
-        avtale.getGjeldendeInnhold().setGodkjentAvArbeidsgiver(Now.localDateTime());
-        avtale.getGjeldendeInnhold().setGodkjentAvDeltaker(Now.localDateTime());
-        avtale.getGjeldendeInnhold().setGodkjentAvVeileder(Now.localDateTime());
-        avtale.getGjeldendeInnhold().setAvtaleInngått(Now.localDateTime());
+        avtale.getGjeldendeInnhold().setGodkjentAvArbeidsgiver(Now.instant());
+        avtale.getGjeldendeInnhold().setGodkjentAvDeltaker(Now.instant());
+        avtale.getGjeldendeInnhold().setGodkjentAvVeileder(Now.instant());
+        avtale.getGjeldendeInnhold().setAvtaleInngått(Now.instant());
         avtale.setStatus(Status.fra(avtale));
         assertThat(avtale.getStatus()).isEqualTo(Status.KLAR_FOR_OPPSTART);
     }
@@ -1019,10 +1019,10 @@ public class AvtaleTest {
         Avtale avtale = TestData.enAvtaleMedAltUtfylt();
         avtale.getGjeldendeInnhold().setStartDato(Now.localDate().minusDays(1));
         avtale.getGjeldendeInnhold().setSluttDato(Now.localDate().minusDays(1).plusMonths(1));
-        avtale.getGjeldendeInnhold().setGodkjentAvArbeidsgiver(Now.localDateTime());
-        avtale.getGjeldendeInnhold().setGodkjentAvDeltaker(Now.localDateTime());
-        avtale.getGjeldendeInnhold().setGodkjentAvVeileder(Now.localDateTime());
-        avtale.getGjeldendeInnhold().setAvtaleInngått(Now.localDateTime());
+        avtale.getGjeldendeInnhold().setGodkjentAvArbeidsgiver(Now.instant());
+        avtale.getGjeldendeInnhold().setGodkjentAvDeltaker(Now.instant());
+        avtale.getGjeldendeInnhold().setGodkjentAvVeileder(Now.instant());
+        avtale.getGjeldendeInnhold().setAvtaleInngått(Now.instant());
         avtale.getGjeldendeInnhold().setDeltakerTlf(null);
         avtale.setStatus(Status.fra(avtale));
         assertThat(avtale.getStatus()).isEqualTo(Status.GJENNOMFØRES);
@@ -1113,7 +1113,7 @@ public class AvtaleTest {
     public void utforEndring__kalles_ved_godkjennForVeilederOgDeltaker() throws InterruptedException {
         Instant førEndringen = Now.instant();
         Avtale avtale = TestData.enAvtaleMedAltUtfylt();
-        avtale.getGjeldendeInnhold().setGodkjentAvArbeidsgiver(Now.localDateTime());
+        avtale.getGjeldendeInnhold().setGodkjentAvArbeidsgiver(Now.instant());
         Thread.sleep(10);
         avtale.godkjennForVeilederOgDeltaker(TestData.enNavIdent(), TestData.enGodkjentPaVegneGrunn());
         assertThat(avtale.getSistEndret()).isAfter(førEndringen);

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtalepartTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtalepartTest.java
@@ -225,8 +225,8 @@ public class AvtalepartTest {
         when(tilgangskontrollService.hentSkrivetilgang(veileder, avtale.getDeltakerFnr())).thenReturn(new Tilgang.Tillat());
         when(eregService.hentVirksomhet(any())).thenReturn(new Organisasjon(TestData.etBedriftNr(), "Arbeidsplass AS"));
 
-        avtale.getGjeldendeInnhold().setGodkjentAvDeltaker(Now.localDateTime());
-        avtale.getGjeldendeInnhold().setGodkjentAvArbeidsgiver(Now.localDateTime());
+        avtale.getGjeldendeInnhold().setGodkjentAvDeltaker(Now.instant());
+        avtale.getGjeldendeInnhold().setGodkjentAvArbeidsgiver(Now.instant());
         veileder.godkjennAvtale(avtale);
         assertThat(avtale.erGodkjentAvArbeidsgiver()).isTrue();
     }
@@ -234,7 +234,7 @@ public class AvtalepartTest {
     @Test
     public void opphevGodkjenninger__veileder_skal_kunne_trekke_tilbake_egen_godkjenning() {
         Avtale avtale = TestData.enAvtaleMedAltUtfylt();
-        avtale.getGjeldendeInnhold().setGodkjentAvVeileder(Now.localDateTime());
+        avtale.getGjeldendeInnhold().setGodkjentAvVeileder(Now.instant());
         Veileder veileder = TestData.enVeileder(avtale);
         veileder.opphevGodkjenninger(avtale);
         assertThat(avtale.erGodkjentAvVeileder()).isFalse();

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/DeltakerAlleredePaTiltakTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/DeltakerAlleredePaTiltakTest.java
@@ -16,8 +16,8 @@ import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 
 import java.sql.Date;
+import java.time.Instant;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 
@@ -67,29 +67,29 @@ public class DeltakerAlleredePaTiltakTest {
                 new Fnr("00000000000"),
                 Now.localDate(),
                 Now.localDate().plusMonths(2),
-                Now.localDateTime()
+                Now.instant()
         );
         settAvtaleInformasjon(
                 TestData.enMentorAvtaleUsignert(),
                 new Fnr("00000000000"),
                 Now.localDate(),
                 Now.localDate().plusMonths(2),
-                Now.localDateTime()
+                Now.instant()
         );
         settAvtaleInformasjon(
                 TestData.enInkluderingstilskuddAvtale(),
                 new Fnr("00000000000"),
                 Now.localDate(),
                 Now.localDate().plusMonths(2),
-                Now.localDateTime()
+                Now.instant()
         );
     }
 
-    private void settAvtaleInformasjon(Avtale avtale, Fnr deltakerFnr, LocalDate startDato, LocalDate sluttDato, LocalDateTime godkjentAvVeileder) {
+    private void settAvtaleInformasjon(Avtale avtale, Fnr deltakerFnr, LocalDate startDato, LocalDate sluttDato, Instant godkjentAvVeileder) {
         avtale.setDeltakerFnr(deltakerFnr);
         avtale.getGjeldendeInnhold().setStartDato(startDato);
         avtale.getGjeldendeInnhold().setSluttDato(sluttDato);
-        if(godkjentAvVeileder != null) {
+        if (godkjentAvVeileder != null) {
             avtale.getGjeldendeInnhold().setGodkjentAvVeileder(godkjentAvVeileder);
         }
         avtaleRepository.save(avtale);
@@ -165,21 +165,21 @@ public class DeltakerAlleredePaTiltakTest {
                 new Fnr("00000000000"),
                 Now.localDate().plusMonths(1).plusDays(1),
                 Now.localDate().plusMonths(3),
-                Now.localDateTime()
+                Now.instant()
         );
         settAvtaleInformasjon(
                 TestData.enMentorAvtaleUsignert(),
                 new Fnr("00000000000"),
                 Now.localDate(),
                 Now.localDate().plusMonths(2),
-                Now.localDateTime()
+                Now.instant()
         );
         settAvtaleInformasjon(
                 TestData.enInkluderingstilskuddAvtale(),
                 new Fnr("00000000000"),
                 Now.localDate(),
                 Now.localDate().plusMonths(2),
-                Now.localDateTime()
+                Now.instant()
         );
         List<AlleredeRegistrertAvtale> treffPaAvtalerSomErUlovligMatch = veileder_z123456.hentAvtaleDeltakerAlleredeErRegistrertPaa(
                 new Fnr("00000000000"),
@@ -200,21 +200,21 @@ public class DeltakerAlleredePaTiltakTest {
                 new Fnr("00000000000"),
                 Now.localDate().plusMonths(1).plusDays(1),
                 Now.localDate().plusMonths(3),
-                Now.localDateTime()
+                Now.instant()
         );
         settAvtaleInformasjon(
                 TestData.enMentorAvtaleUsignert(),
                 new Fnr("00000000000"),
                 Now.localDate(),
                 Now.localDate().plusMonths(2),
-                Now.localDateTime()
+                Now.instant()
         );
         settAvtaleInformasjon(
                 TestData.enInkluderingstilskuddAvtale(),
                 new Fnr("00000000000"),
                 Now.localDate(),
                 Now.localDate().plusMonths(2),
-                Now.localDateTime()
+                Now.instant()
         );
         List<AlleredeRegistrertAvtale> treffPaAvtalerSomErUlovligMatch = veileder_z123456.hentAvtaleDeltakerAlleredeErRegistrertPaa(
                 new Fnr("00000000000"),
@@ -235,7 +235,7 @@ public class DeltakerAlleredePaTiltakTest {
                 new Fnr("00000000000"),
                 Now.localDate().plusMonths(1).plusDays(1),
                 Now.localDate().plusMonths(3),
-                Now.localDateTime()
+                Now.instant()
         );
         settAvtaleInformasjon(
                 TestData.enArbeidstreningAvtale(),
@@ -249,14 +249,14 @@ public class DeltakerAlleredePaTiltakTest {
                 new Fnr("00000000000"),
                 Now.localDate(),
                 Now.localDate().plusMonths(2),
-                Now.localDateTime()
+                Now.instant()
         );
         settAvtaleInformasjon(
                 TestData.enInkluderingstilskuddAvtale(),
                 new Fnr("00000000000"),
                 Now.localDate(),
                 Now.localDate().plusMonths(2),
-                Now.localDateTime()
+                Now.instant()
         );
         List<AlleredeRegistrertAvtale> treffPaAvtalerSomErUlovligMatch = veileder_z123456.hentAvtaleDeltakerAlleredeErRegistrertPaa(
                 new Fnr("00000000000"),

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/TestData.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/TestData.java
@@ -90,7 +90,7 @@ public class TestData {
         NavIdent veilderNavIdent = new NavIdent("Z123456");
         Avtale avtale = Avtale.opprett(lagOpprettAvtale(Tiltakstype.INKLUDERINGSTILSKUDD), Avtaleopphav.VEILEDER, veilderNavIdent);
         avtale.endreAvtale(endringPåAlleInkluderingstilskuddFelter(), Avtalerolle.VEILEDER);
-        avtale.getGjeldendeInnhold().setGodkjentAvArbeidsgiver(Now.localDateTime());
+        avtale.getGjeldendeInnhold().setGodkjentAvArbeidsgiver(Now.instant());
         return avtale;
     }
 
@@ -183,13 +183,13 @@ public class TestData {
 
     public static Avtale enAvtaleMedAltUtfyltGodkjentAvVeileder() {
         Avtale avtale = enAvtaleMedAltUtfylt();
-        avtale.getGjeldendeInnhold().setGodkjentAvArbeidsgiver(Now.localDateTime());
-        avtale.getGjeldendeInnhold().setGodkjentAvDeltaker(Now.localDateTime());
-        avtale.getGjeldendeInnhold().setGodkjentTaushetserklæringAvMentor(Now.localDateTime());
-        avtale.getGjeldendeInnhold().setGodkjentAvVeileder(Now.localDateTime());
-        avtale.getGjeldendeInnhold().setAvtaleInngått(Now.localDateTime());
+        avtale.getGjeldendeInnhold().setGodkjentAvArbeidsgiver(Now.instant());
+        avtale.getGjeldendeInnhold().setGodkjentAvDeltaker(Now.instant());
+        avtale.getGjeldendeInnhold().setGodkjentTaushetserklæringAvMentor(Now.instant());
+        avtale.getGjeldendeInnhold().setGodkjentAvVeileder(Now.instant());
+        avtale.getGjeldendeInnhold().setAvtaleInngått(Now.instant());
         avtale.getGjeldendeInnhold().setGodkjentAvNavIdent(TestData.enNavIdent());
-        avtale.getGjeldendeInnhold().setIkrafttredelsestidspunkt(Now.localDateTime());
+        avtale.getGjeldendeInnhold().setIkrafttredelsestidspunkt(Now.instant());
         avtale.getGjeldendeInnhold().setJournalpostId("1");
         avtale.getGjeldendeInnhold().setRefusjonKontaktperson(new RefusjonKontaktperson("Donald", "Duck", "55555123", true));
         return avtale;
@@ -385,12 +385,12 @@ public class TestData {
 
     public static Avtale enMidlertidigLonnstilskuddAvtaleGodkjentAvVeileder() {
         Avtale avtale = enMidlertidigLonnstilskuddAvtaleMedAltUtfylt();
-        avtale.getGjeldendeInnhold().setGodkjentAvArbeidsgiver(Now.localDateTime());
-        avtale.getGjeldendeInnhold().setGodkjentAvDeltaker(Now.localDateTime());
-        avtale.getGjeldendeInnhold().setGodkjentAvVeileder(Now.localDateTime());
-        avtale.getGjeldendeInnhold().setAvtaleInngått(Now.localDateTime());
+        avtale.getGjeldendeInnhold().setGodkjentAvArbeidsgiver(Now.instant());
+        avtale.getGjeldendeInnhold().setGodkjentAvDeltaker(Now.instant());
+        avtale.getGjeldendeInnhold().setGodkjentAvVeileder(Now.instant());
+        avtale.getGjeldendeInnhold().setAvtaleInngått(Now.instant());
         avtale.getGjeldendeInnhold().setGodkjentAvNavIdent(TestData.enNavIdent());
-        avtale.getGjeldendeInnhold().setIkrafttredelsestidspunkt(Now.localDateTime());
+        avtale.getGjeldendeInnhold().setIkrafttredelsestidspunkt(Now.instant());
         avtale.getGjeldendeInnhold().setJournalpostId("1");
         return avtale;
     }
@@ -410,24 +410,24 @@ public class TestData {
 
     public static Avtale enSommerjobbLonnstilskuddAvtaleGodkjentAvVeileder(int lonnstilskuddProsent) {
         Avtale avtale = enSommerjobbLonnstilskuddAvtaleMedAltUtfylt(lonnstilskuddProsent);
-        avtale.getGjeldendeInnhold().setGodkjentAvArbeidsgiver(Now.localDateTime());
-        avtale.getGjeldendeInnhold().setGodkjentAvDeltaker(Now.localDateTime());
-        avtale.getGjeldendeInnhold().setGodkjentAvVeileder(Now.localDateTime());
-        avtale.getGjeldendeInnhold().setAvtaleInngått(Now.localDateTime());
+        avtale.getGjeldendeInnhold().setGodkjentAvArbeidsgiver(Now.instant());
+        avtale.getGjeldendeInnhold().setGodkjentAvDeltaker(Now.instant());
+        avtale.getGjeldendeInnhold().setGodkjentAvVeileder(Now.instant());
+        avtale.getGjeldendeInnhold().setAvtaleInngått(Now.instant());
         avtale.getGjeldendeInnhold().setGodkjentAvNavIdent(TestData.enNavIdent());
-        avtale.getGjeldendeInnhold().setIkrafttredelsestidspunkt(Now.localDateTime());
+        avtale.getGjeldendeInnhold().setIkrafttredelsestidspunkt(Now.instant());
         avtale.getGjeldendeInnhold().setJournalpostId("1");
         return avtale;
     }
 
     public static Avtale enMidlertidigLonnstilskuddAvtaleMedSpesieltTilpassetInnsatsGodkjentAvVeileder() {
         Avtale avtale = enMidlertidigLonnstilskuddAvtaleMedSpesieltTilpassetInnsatsOgAltUtfylt(Tiltakstype.MIDLERTIDIG_LONNSTILSKUDD);
-        avtale.getGjeldendeInnhold().setGodkjentAvArbeidsgiver(Now.localDateTime());
-        avtale.getGjeldendeInnhold().setGodkjentAvDeltaker(Now.localDateTime());
-        avtale.getGjeldendeInnhold().setGodkjentAvVeileder(Now.localDateTime());
-        avtale.getGjeldendeInnhold().setAvtaleInngått(Now.localDateTime());
+        avtale.getGjeldendeInnhold().setGodkjentAvArbeidsgiver(Now.instant());
+        avtale.getGjeldendeInnhold().setGodkjentAvDeltaker(Now.instant());
+        avtale.getGjeldendeInnhold().setGodkjentAvVeileder(Now.instant());
+        avtale.getGjeldendeInnhold().setAvtaleInngått(Now.instant());
         avtale.getGjeldendeInnhold().setGodkjentAvNavIdent(TestData.enNavIdent());
-        avtale.getGjeldendeInnhold().setIkrafttredelsestidspunkt(Now.localDateTime());
+        avtale.getGjeldendeInnhold().setIkrafttredelsestidspunkt(Now.instant());
         avtale.getGjeldendeInnhold().setJournalpostId("1");
         return avtale;
     }
@@ -435,12 +435,12 @@ public class TestData {
     public static Avtale enLonnstilskuddAvtaleGodkjentAvVeilederUtenTilskuddsperioder() {
         Avtale avtale = enMidlertidigLonnstilskuddAvtaleMedAltUtfyltUtenTilskuddsperioder();
         avtale.setKvalifiseringsgruppe(Kvalifiseringsgruppe.VARIG_TILPASSET_INNSATS);
-        avtale.getGjeldendeInnhold().setGodkjentAvArbeidsgiver(Now.localDateTime());
-        avtale.getGjeldendeInnhold().setGodkjentAvDeltaker(Now.localDateTime());
-        avtale.getGjeldendeInnhold().setGodkjentAvVeileder(Now.localDateTime());
-        avtale.getGjeldendeInnhold().setAvtaleInngått(Now.localDateTime());
+        avtale.getGjeldendeInnhold().setGodkjentAvArbeidsgiver(Now.instant());
+        avtale.getGjeldendeInnhold().setGodkjentAvDeltaker(Now.instant());
+        avtale.getGjeldendeInnhold().setGodkjentAvVeileder(Now.instant());
+        avtale.getGjeldendeInnhold().setAvtaleInngått(Now.instant());
         avtale.getGjeldendeInnhold().setGodkjentAvNavIdent(TestData.enNavIdent());
-        avtale.getGjeldendeInnhold().setIkrafttredelsestidspunkt(Now.localDateTime());
+        avtale.getGjeldendeInnhold().setIkrafttredelsestidspunkt(Now.instant());
         avtale.getGjeldendeInnhold().setJournalpostId("1");
         return avtale;
     }
@@ -449,12 +449,12 @@ public class TestData {
         Avtale avtale = enMidlertidigLonnstilskuddAvtaleMedAltUtfylt();
         avtale.getGjeldendeInnhold().setDeltakerFornavn("Geir");
         avtale.getGjeldendeInnhold().setDeltakerEtternavn("Geirsen");
-        avtale.getGjeldendeInnhold().setGodkjentAvArbeidsgiver(Now.localDateTime());
-        avtale.getGjeldendeInnhold().setGodkjentAvDeltaker(Now.localDateTime());
-        avtale.getGjeldendeInnhold().setGodkjentAvVeileder(Now.localDateTime());
-        avtale.getGjeldendeInnhold().setAvtaleInngått(Now.localDateTime());
+        avtale.getGjeldendeInnhold().setGodkjentAvArbeidsgiver(Now.instant());
+        avtale.getGjeldendeInnhold().setGodkjentAvDeltaker(Now.instant());
+        avtale.getGjeldendeInnhold().setGodkjentAvVeileder(Now.instant());
+        avtale.getGjeldendeInnhold().setAvtaleInngått(Now.instant());
         avtale.getGjeldendeInnhold().setGodkjentAvNavIdent(TestData.enNavIdent());
-        avtale.getGjeldendeInnhold().setIkrafttredelsestidspunkt(Now.localDateTime());
+        avtale.getGjeldendeInnhold().setIkrafttredelsestidspunkt(Now.instant());
         avtale.getGjeldendeInnhold().setStartDato(Now.localDate().minusMonths(3));
         avtale.getGjeldendeInnhold().setSluttDato(Now.localDate().plusMonths(1));
         avtale.getGjeldendeInnhold().setJournalpostId("1");
@@ -471,9 +471,9 @@ public class TestData {
         endreAvtale.setStartDato(LocalDate.of(2021, 6, 1));
         endreAvtale.setSluttDato(LocalDate.of(2021, 6, 1).plusWeeks(4).minusDays(1));
         avtale.endreAvtale(endreAvtale, Avtalerolle.VEILEDER);
-        avtale.getGjeldendeInnhold().setGodkjentAvArbeidsgiver(Now.localDateTime());
-        avtale.getGjeldendeInnhold().setGodkjentAvDeltaker(Now.localDateTime());
-        avtale.getGjeldendeInnhold().setGodkjentAvVeileder(Now.localDateTime());
+        avtale.getGjeldendeInnhold().setGodkjentAvArbeidsgiver(Now.instant());
+        avtale.getGjeldendeInnhold().setGodkjentAvDeltaker(Now.instant());
+        avtale.getGjeldendeInnhold().setGodkjentAvVeileder(Now.instant());
         NavIdent veileder = TestData.enNavIdent();
         avtale.getGjeldendeInnhold().setGodkjentAvNavIdent(veileder);
         avtale.setVeilederNavIdent(veileder);
@@ -491,12 +491,12 @@ public class TestData {
         endreAvtale.setStartDato(LocalDate.of(2021, 6, 1));
         endreAvtale.setSluttDato(LocalDate.of(2021, 6, 1).plusWeeks(4).minusDays(1));
         avtale.endreAvtale(endreAvtale, Avtalerolle.VEILEDER);
-        avtale.getGjeldendeInnhold().setGodkjentAvArbeidsgiver(Now.localDateTime());
-        avtale.getGjeldendeInnhold().setGodkjentAvDeltaker(Now.localDateTime());
-        avtale.getGjeldendeInnhold().setGodkjentAvVeileder(Now.localDateTime());
-        avtale.getGjeldendeInnhold().setGodkjentAvBeslutter(Now.localDateTime());
-        avtale.getGjeldendeInnhold().setAvtaleInngått(Now.localDateTime());
-        avtale.getGjeldendeInnhold().setIkrafttredelsestidspunkt(Now.localDateTime());
+        avtale.getGjeldendeInnhold().setGodkjentAvArbeidsgiver(Now.instant());
+        avtale.getGjeldendeInnhold().setGodkjentAvDeltaker(Now.instant());
+        avtale.getGjeldendeInnhold().setGodkjentAvVeileder(Now.instant());
+        avtale.getGjeldendeInnhold().setGodkjentAvBeslutter(Now.instant());
+        avtale.getGjeldendeInnhold().setAvtaleInngått(Now.instant());
+        avtale.getGjeldendeInnhold().setIkrafttredelsestidspunkt(Now.instant());
         avtale.getGjeldendeInnhold().setGodkjentAvNavIdent(TestData.enNavIdent());
         avtale.getGjeldendeInnhold().setRefusjonKontaktperson(null);
         return avtale;
@@ -512,8 +512,8 @@ public class TestData {
         endreAvtale.setStartDato(LocalDate.of(2021, 6, 1));
         endreAvtale.setSluttDato(LocalDate.of(2021, 6, 1).plusWeeks(4).minusDays(1));
         avtale.endreAvtale(endreAvtale, Avtalerolle.VEILEDER);
-        avtale.getGjeldendeInnhold().setGodkjentAvArbeidsgiver(Now.localDateTime());
-        avtale.getGjeldendeInnhold().setGodkjentAvDeltaker(Now.localDateTime());
+        avtale.getGjeldendeInnhold().setGodkjentAvArbeidsgiver(Now.instant());
+        avtale.getGjeldendeInnhold().setGodkjentAvDeltaker(Now.instant());
         return avtale;
     }
 
@@ -534,9 +534,9 @@ public class TestData {
         setOppfølgingPåAvtale(avtale);
         EndreAvtale endreAvtale = endringPåAlleVTAOFelter();
         avtale.endreAvtale(endreAvtale, Avtalerolle.VEILEDER);
-        avtale.getGjeldendeInnhold().setGodkjentAvVeileder(Now.localDateTime());
-        avtale.getGjeldendeInnhold().setGodkjentAvArbeidsgiver(Now.localDateTime());
-        avtale.getGjeldendeInnhold().setGodkjentAvDeltaker(Now.localDateTime());
+        avtale.getGjeldendeInnhold().setGodkjentAvVeileder(Now.instant());
+        avtale.getGjeldendeInnhold().setGodkjentAvArbeidsgiver(Now.instant());
+        avtale.getGjeldendeInnhold().setGodkjentAvDeltaker(Now.instant());
         return avtale;
     }
 
@@ -545,9 +545,9 @@ public class TestData {
         setOppfølgingPåAvtale(avtale);
         EndreAvtale endreAvtale = endringPåAlleVTAOFelter();
         avtale.endreAvtale(endreAvtale, Avtalerolle.VEILEDER);
-        avtale.getGjeldendeInnhold().setGodkjentAvVeileder(Now.localDateTime());
-        avtale.getGjeldendeInnhold().setGodkjentAvArbeidsgiver(Now.localDateTime());
-        avtale.getGjeldendeInnhold().setGodkjentAvDeltaker(Now.localDateTime());
+        avtale.getGjeldendeInnhold().setGodkjentAvVeileder(Now.instant());
+        avtale.getGjeldendeInnhold().setGodkjentAvArbeidsgiver(Now.instant());
+        avtale.getGjeldendeInnhold().setGodkjentAvDeltaker(Now.instant());
         avtale.getGjeldendeTilskuddsperiode().avslå(TestData.enNavIdent2(),EnumSet.of(Avslagsårsak.FEIL_I_PROSENTSATS), "Feil i prosentsats");
         return avtale;
     }
@@ -565,9 +565,9 @@ public class TestData {
         avtale.setEnhetsnavnOppfolging("Vinstra");
         EndreAvtale endreAvtale = endringPåAlleVTAOFelter();
         avtale.endreAvtale(endreAvtale, Avtalerolle.VEILEDER);
-        avtale.getGjeldendeInnhold().setGodkjentAvVeileder(Now.localDateTime());
-        avtale.getGjeldendeInnhold().setGodkjentAvArbeidsgiver(Now.localDateTime());
-        avtale.getGjeldendeInnhold().setGodkjentAvDeltaker(Now.localDateTime());
+        avtale.getGjeldendeInnhold().setGodkjentAvVeileder(Now.instant());
+        avtale.getGjeldendeInnhold().setGodkjentAvArbeidsgiver(Now.instant());
+        avtale.getGjeldendeInnhold().setGodkjentAvDeltaker(Now.instant());
         avtale.getGjeldendeInnhold().setGodkjentAvNavIdent(avtale.getVeilederNavIdent());
         return avtale;
     }
@@ -581,9 +581,9 @@ public class TestData {
         endreAvtale.setDeltakerEtternavn("Testesen");
         endreAvtale.setStartDato(Now.localDate().minusMonths(12));
         avtale.endreAvtale(endreAvtale, Avtalerolle.VEILEDER);
-        avtale.getGjeldendeInnhold().setGodkjentAvVeileder(Now.localDateTime());
-        avtale.getGjeldendeInnhold().setGodkjentAvArbeidsgiver(Now.localDateTime());
-        avtale.getGjeldendeInnhold().setGodkjentAvDeltaker(Now.localDateTime());
+        avtale.getGjeldendeInnhold().setGodkjentAvVeileder(Now.instant());
+        avtale.getGjeldendeInnhold().setGodkjentAvArbeidsgiver(Now.instant());
+        avtale.getGjeldendeInnhold().setGodkjentAvDeltaker(Now.instant());
         avtale.getGjeldendeInnhold().setGodkjentAvNavIdent(avtale.getVeilederNavIdent());
         return avtale;
     }
@@ -593,8 +593,8 @@ public class TestData {
         setOppfølgingPåAvtale(avtale);
         EndreAvtale endreAvtale = endringPåAlleVTAOFelter();
         avtale.endreAvtale(endreAvtale, Avtalerolle.VEILEDER);
-        avtale.getGjeldendeInnhold().setGodkjentAvArbeidsgiver(Now.localDateTime());
-        avtale.getGjeldendeInnhold().setGodkjentAvDeltaker(Now.localDateTime());
+        avtale.getGjeldendeInnhold().setGodkjentAvArbeidsgiver(Now.instant());
+        avtale.getGjeldendeInnhold().setGodkjentAvDeltaker(Now.instant());
         return avtale;
     }
 
@@ -1008,12 +1008,12 @@ public class TestData {
         Avtale avtale = enAvtaleMedAltUtfylt();
         avtale.getGjeldendeInnhold().setStartDato(Now.localDate().plusDays(7));
         avtale.getGjeldendeInnhold().setSluttDato(avtale.getGjeldendeInnhold().getStartDato().plusMonths(1));
-        avtale.getGjeldendeInnhold().setGodkjentAvArbeidsgiver(Now.localDateTime());
-        avtale.getGjeldendeInnhold().setGodkjentAvDeltaker(Now.localDateTime());
-        avtale.getGjeldendeInnhold().setGodkjentAvVeileder(Now.localDateTime());
-        avtale.getGjeldendeInnhold().setAvtaleInngått(Now.localDateTime());
+        avtale.getGjeldendeInnhold().setGodkjentAvArbeidsgiver(Now.instant());
+        avtale.getGjeldendeInnhold().setGodkjentAvDeltaker(Now.instant());
+        avtale.getGjeldendeInnhold().setGodkjentAvVeileder(Now.instant());
+        avtale.getGjeldendeInnhold().setAvtaleInngått(Now.instant());
         avtale.getGjeldendeInnhold().setGodkjentAvNavIdent(TestData.enNavIdent());
-        avtale.getGjeldendeInnhold().setIkrafttredelsestidspunkt(Now.localDateTime());
+        avtale.getGjeldendeInnhold().setIkrafttredelsestidspunkt(Now.instant());
         avtale.getGjeldendeInnhold().setJournalpostId("1");
         return avtale;
     }
@@ -1098,11 +1098,11 @@ public class TestData {
 
     public static Avtale enArbeidstreningAvtaleGodkjentAvVeileder() {
         Avtale avtale = enArbeidstreningAvtaleMedAltUtfylt();
-        avtale.getGjeldendeInnhold().setGodkjentAvArbeidsgiver(Now.localDateTime());
-        avtale.getGjeldendeInnhold().setGodkjentAvDeltaker(Now.localDateTime());
-        avtale.getGjeldendeInnhold().setGodkjentAvVeileder(Now.localDateTime());
-        avtale.getGjeldendeInnhold().setAvtaleInngått(Now.localDateTime());
-        avtale.getGjeldendeInnhold().setIkrafttredelsestidspunkt(Now.localDateTime());
+        avtale.getGjeldendeInnhold().setGodkjentAvArbeidsgiver(Now.instant());
+        avtale.getGjeldendeInnhold().setGodkjentAvDeltaker(Now.instant());
+        avtale.getGjeldendeInnhold().setGodkjentAvVeileder(Now.instant());
+        avtale.getGjeldendeInnhold().setAvtaleInngått(Now.instant());
+        avtale.getGjeldendeInnhold().setIkrafttredelsestidspunkt(Now.instant());
         avtale.getGjeldendeInnhold().setJournalpostId("1");
         return avtale;
     }

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/VeilederTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/VeilederTest.java
@@ -79,8 +79,8 @@ public class VeilederTest {
         // GITT
         Avtale avtale = TestData.enVarigLonnstilskuddAvtaleMedAltUtfylt();
         avtale.setKvalifiseringsgruppe(Kvalifiseringsgruppe.SITUASJONSBESTEMT_INNSATS);
-        avtale.getGjeldendeInnhold().setGodkjentAvDeltaker(Now.localDateTime());
-        avtale.getGjeldendeInnhold().setGodkjentAvArbeidsgiver(Now.localDateTime());
+        avtale.getGjeldendeInnhold().setGodkjentAvDeltaker(Now.instant());
+        avtale.getGjeldendeInnhold().setGodkjentAvArbeidsgiver(Now.instant());
 
         VeilarboppfolgingService veilarboppfolgingService = mock(VeilarboppfolgingService.class);
         TilgangskontrollService tilgangskontrollService = mock(TilgangskontrollService.class);
@@ -118,7 +118,7 @@ public class VeilederTest {
         // GITT
         Avtale avtale = TestData.enVarigLonnstilskuddAvtaleMedAltUtfylt();
         avtale.setKvalifiseringsgruppe(Kvalifiseringsgruppe.SITUASJONSBESTEMT_INNSATS);
-        avtale.getGjeldendeInnhold().setGodkjentAvArbeidsgiver(Now.localDateTime());
+        avtale.getGjeldendeInnhold().setGodkjentAvArbeidsgiver(Now.instant());
         VeilarboppfolgingService veilarboppfolgingService = mock(VeilarboppfolgingService.class);
 
         TilgangskontrollService tilgangskontrollService = mock(TilgangskontrollService.class);
@@ -191,7 +191,7 @@ public class VeilederTest {
         Avtale avtale = TestData.enVarigLonnstilskuddAvtaleMedAltUtfylt();
         avtale.setOpphav(Avtaleopphav.ARENA);
         avtale.setKvalifiseringsgruppe(Kvalifiseringsgruppe.SITUASJONSBESTEMT_INNSATS);
-        avtale.getGjeldendeInnhold().setGodkjentAvDeltaker(Now.localDateTime());
+        avtale.getGjeldendeInnhold().setGodkjentAvDeltaker(Now.instant());
         VeilarboppfolgingService veilarboppfolgingService = mock(VeilarboppfolgingService.class);
         TilgangskontrollService tilgangskontrollService = mock(TilgangskontrollService.class);
         PersondataService persondataService = mock(PersondataService.class);
@@ -226,8 +226,8 @@ public class VeilederTest {
     @Test
     public void godkjennAvtale__kan_ikke_godkjenne_kode6_med_togglet_adressesperresjekk() {
         Avtale avtale = TestData.enAvtaleMedAltUtfylt();
-        avtale.getGjeldendeInnhold().setGodkjentAvDeltaker(Now.localDateTime());
-        avtale.getGjeldendeInnhold().setGodkjentAvArbeidsgiver(Now.localDateTime());
+        avtale.getGjeldendeInnhold().setGodkjentAvDeltaker(Now.instant());
+        avtale.getGjeldendeInnhold().setGodkjentAvArbeidsgiver(Now.instant());
         when(featureToggleService.isEnabled(FeatureToggle.KODE_6_SPERRE)).thenReturn(true);
         PersondataService persondataService = mock(PersondataService.class);
         when(persondataService.hentDiskresjonskode(avtale.getDeltakerFnr())).thenReturn(Diskresjonskode.STRENGT_FORTROLIG);
@@ -258,8 +258,8 @@ public class VeilederTest {
     @Test
     public void godkjennAvtale__kan_godkjenne_kode6_uten_togglet_adressesperresjekk() {
         Avtale avtale = TestData.enAvtaleMedAltUtfylt();
-        avtale.getGjeldendeInnhold().setGodkjentAvDeltaker(Now.localDateTime());
-        avtale.getGjeldendeInnhold().setGodkjentAvArbeidsgiver(Now.localDateTime());
+        avtale.getGjeldendeInnhold().setGodkjentAvDeltaker(Now.instant());
+        avtale.getGjeldendeInnhold().setGodkjentAvArbeidsgiver(Now.instant());
         when(featureToggleService.isEnabled(FeatureToggle.KODE_6_SPERRE)).thenReturn(false);
         PersondataService persondataService = mock(PersondataService.class);
         when(persondataService.hentDiskresjonskode(avtale.getDeltakerFnr())).thenReturn(Diskresjonskode.STRENGT_FORTROLIG);
@@ -291,7 +291,7 @@ public class VeilederTest {
     @Test
     public void godkjennForVeilederOgDeltaker__kan_ikke_godkjenne_kode6_med_togglet_adressesperresjekk() {
         Avtale avtale = TestData.enAvtaleMedAltUtfylt();
-        avtale.getGjeldendeInnhold().setGodkjentAvArbeidsgiver(Now.localDateTime());
+        avtale.getGjeldendeInnhold().setGodkjentAvArbeidsgiver(Now.instant());
         when(featureToggleService.isEnabled(FeatureToggle.KODE_6_SPERRE)).thenReturn(true);
         PersondataService persondataService = mock(PersondataService.class);
         when(persondataService.hentDiskresjonskode(avtale.getDeltakerFnr())).thenReturn(Diskresjonskode.STRENGT_FORTROLIG);
@@ -319,7 +319,7 @@ public class VeilederTest {
     public void godkjennForVeilederOgDeltaker__kan_godkjenne_kode6_uten_togglet_adressesperresjekk() {
         Avtale avtale = TestData.enAvtaleMedAltUtfylt();
         when(featureToggleService.isEnabled(FeatureToggle.KODE_6_SPERRE)).thenReturn(false);
-        avtale.getGjeldendeInnhold().setGodkjentAvArbeidsgiver(Now.localDateTime());
+        avtale.getGjeldendeInnhold().setGodkjentAvArbeidsgiver(Now.instant());
         TilgangskontrollService tilgangskontrollService = mock(TilgangskontrollService.class);
         PersondataService persondataService = mock(PersondataService.class);
         when(persondataService.hentDiskresjonskode(avtale.getDeltakerFnr())).thenReturn(Diskresjonskode.STRENGT_FORTROLIG);
@@ -346,10 +346,10 @@ public class VeilederTest {
     @Test
     public void opphevGodkjenninger__kan_ikke_oppheve_godkjenninger_når_avtale_er_inngått() {
         Avtale avtale = TestData.enAvtaleMedAltUtfylt();
-        avtale.getGjeldendeInnhold().setGodkjentAvVeileder(Now.localDateTime());
-        avtale.getGjeldendeInnhold().setGodkjentAvDeltaker(Now.localDateTime());
-        avtale.getGjeldendeInnhold().setGodkjentAvArbeidsgiver(Now.localDateTime());
-        avtale.getGjeldendeInnhold().setAvtaleInngått(Now.localDateTime());
+        avtale.getGjeldendeInnhold().setGodkjentAvVeileder(Now.instant());
+        avtale.getGjeldendeInnhold().setGodkjentAvDeltaker(Now.instant());
+        avtale.getGjeldendeInnhold().setGodkjentAvArbeidsgiver(Now.instant());
+        avtale.getGjeldendeInnhold().setAvtaleInngått(Now.instant());
         Veileder veileder = TestData.enVeileder(avtale);
         assertFeilkode(
                 Feilkode.KAN_IKKE_OPPHEVE_GODKJENNINGER_VED_INNGAATT_AVTALE,
@@ -470,9 +470,9 @@ public class VeilederTest {
     @Test
     public void annullerAvtale__kan_annuller_avtale_etter_veiledergodkjenning() {
         Avtale avtale = TestData.enAvtaleMedAltUtfylt();
-        avtale.getGjeldendeInnhold().setGodkjentAvVeileder(Now.localDateTime());
-        avtale.getGjeldendeInnhold().setGodkjentAvDeltaker(Now.localDateTime());
-        avtale.getGjeldendeInnhold().setGodkjentAvArbeidsgiver(Now.localDateTime());
+        avtale.getGjeldendeInnhold().setGodkjentAvVeileder(Now.instant());
+        avtale.getGjeldendeInnhold().setGodkjentAvDeltaker(Now.instant());
+        avtale.getGjeldendeInnhold().setGodkjentAvArbeidsgiver(Now.instant());
         Veileder veileder = TestData.enVeileder(avtale);
         veileder.annullerAvtale("enGrunn", avtale);
         assertThat(avtale.getAnnullertTidspunkt()).isNotNull();
@@ -482,8 +482,8 @@ public class VeilederTest {
     @Test
     public void annullerAvtale__kan_annullere_avtale_foer_veiledergodkjenning() {
         Avtale avtale = TestData.enAvtaleMedAltUtfylt();
-        avtale.getGjeldendeInnhold().setGodkjentAvDeltaker(Now.localDateTime());
-        avtale.getGjeldendeInnhold().setGodkjentAvArbeidsgiver(Now.localDateTime());
+        avtale.getGjeldendeInnhold().setGodkjentAvDeltaker(Now.instant());
+        avtale.getGjeldendeInnhold().setGodkjentAvArbeidsgiver(Now.instant());
         Veileder veileder = TestData.enVeileder(avtale);
         veileder.annullerAvtale("enGrunn", avtale);
         assertThat(avtale.getAnnullertTidspunkt()).isNotNull();

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/journalfoering/AvtaleTilJournalfoeringMapperTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/journalfoering/AvtaleTilJournalfoeringMapperTest.java
@@ -7,11 +7,13 @@ import no.nav.tag.tiltaksgjennomforing.avtale.Maal;
 import no.nav.tag.tiltaksgjennomforing.avtale.MaalKategori;
 import no.nav.tag.tiltaksgjennomforing.avtale.Stillingstype;
 import no.nav.tag.tiltaksgjennomforing.avtale.TestData;
+import no.nav.tag.tiltaksgjennomforing.utils.DatoUtils;
 import no.nav.tag.tiltaksgjennomforing.utils.Now;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.time.ZoneId;
 import java.util.Arrays;
 import java.util.UUID;
 
@@ -48,7 +50,7 @@ public class AvtaleTilJournalfoeringMapperTest {
         final UUID avtaleId = UUID.randomUUID();
         avtale.setId(avtaleId);
         avtale.getGjeldendeInnhold().setGodkjentPaVegneAv(true);
-        avtale.setOpprettetTidspunkt(Now.localDateTime());
+        avtale.setOpprettetTidspunkt(Now.instant());
         avtale.getGjeldendeInnhold().setStillingstype(Stillingstype.FAST);
 
         tilJournalfoering = tilJournalfoering(avtaleInnhold, null);
@@ -58,7 +60,7 @@ public class AvtaleTilJournalfoeringMapperTest {
         assertEquals(avtale.getDeltakerFnr().asString(), tilJournalfoering.getDeltakerFnr());
         assertEquals(avtale.getBedriftNr().asString(), tilJournalfoering.getBedriftNr());
         assertEquals(avtale.getVeilederNavIdent().asString(), tilJournalfoering.getVeilederNavIdent());
-        assertEquals(avtale.getOpprettetTidspunkt().toLocalDate(), tilJournalfoering.getOpprettet());
+        assertEquals(avtale.getOpprettetTidspunkt().atZone(ZoneId.systemDefault()).toLocalDate(), tilJournalfoering.getOpprettet());
         assertEquals(avtale.getGjeldendeInnhold().getDeltakerFornavn(), tilJournalfoering.getDeltakerFornavn());
         assertEquals(avtale.getGjeldendeInnhold().getDeltakerEtternavn(), tilJournalfoering.getDeltakerEtternavn());
         assertEquals(avtale.getGjeldendeInnhold().getDeltakerTlf(), tilJournalfoering.getDeltakerTlf());
@@ -75,9 +77,9 @@ public class AvtaleTilJournalfoeringMapperTest {
         assertEquals(avtale.getGjeldendeInnhold().getSluttDato(), tilJournalfoering.getSluttDato());
         assertEquals(avtale.getGjeldendeInnhold().getStillingprosent(), tilJournalfoering.getStillingprosent());
         assertEquals(avtale.getGjeldendeInnhold().getAntallDagerPerUke(), tilJournalfoering.getAntallDagerPerUke());
-        assertEquals(avtale.getGjeldendeInnhold().getGodkjentAvDeltaker().toLocalDate(), tilJournalfoering.getGodkjentAvDeltaker());
-        assertEquals(avtale.getGjeldendeInnhold().getGodkjentAvArbeidsgiver().toLocalDate(), tilJournalfoering.getGodkjentAvArbeidsgiver());
-        assertEquals(avtale.getGjeldendeInnhold().getGodkjentAvVeileder().toLocalDate(), tilJournalfoering.getGodkjentAvVeileder());
+        assertEquals(DatoUtils.instantTilLocalDate(avtale.getGjeldendeInnhold().getGodkjentAvDeltaker()), tilJournalfoering.getGodkjentAvDeltaker());
+        assertEquals(DatoUtils.instantTilLocalDate(avtale.getGjeldendeInnhold().getGodkjentAvArbeidsgiver()), tilJournalfoering.getGodkjentAvArbeidsgiver());
+        assertEquals(DatoUtils.instantTilLocalDate(avtale.getGjeldendeInnhold().getGodkjentAvVeileder()), tilJournalfoering.getGodkjentAvVeileder());
         assertEquals(avtale.getGjeldendeInnhold().isGodkjentPaVegneAv(), tilJournalfoering.isGodkjentPaVegneAv());
         assertEquals(avtale.getGjeldendeInnhold().getVersjon(), tilJournalfoering.getVersjon());
         assertEquals(avtale.getTiltakstype(), tilJournalfoering.getTiltakstype());

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/journalfoering/InternalAvtaleControllerTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/journalfoering/InternalAvtaleControllerTest.java
@@ -105,10 +105,10 @@ public class InternalAvtaleControllerTest {
         Avtale avtale = TestData.enAvtaleMedAltUtfyltGodkjentAvVeileder();
         avtale.setId(AVTALE_ID_1);
         Avtale avtale2 = TestData.enAvtaleMedFlereVersjoner();
-        avtale2.getGjeldendeInnhold().setGodkjentAvVeileder(Now.localDateTime());
+        avtale2.getGjeldendeInnhold().setGodkjentAvVeileder(Now.instant());
         avtale2.setId(AVTALE_ID_2);
         Avtale avtale3 = TestData.enAvtaleMedFlereVersjoner();
-        avtale3.getGjeldendeInnhold().setGodkjentAvVeileder(Now.localDateTime());
+        avtale3.getGjeldendeInnhold().setGodkjentAvVeileder(Now.instant());
         avtale3.setId(AVTALE_ID_3);
 
         return Arrays.asList(avtale, avtale2, avtale3);
@@ -116,9 +116,8 @@ public class InternalAvtaleControllerTest {
 
     private static List<Avtale> enAvtaleMedTilskudsPerioderSomSkalJournalføres() {
         Avtale avtale4 = TestData.enMidlertidigLønnstilskuddsAvtaleMedStartOgSluttGodkjentAvAlleParter(Now.localDate(), Now.localDate());
-        avtale4.getGjeldendeInnhold().setGodkjentAvVeileder(Now.localDateTime());
+        avtale4.getGjeldendeInnhold().setGodkjentAvVeileder(Now.instant());
         avtale4.setId(AVTALE_ID_3);
         return Arrays.asList(avtale4);
     }
 }
-


### PR DESCRIPTION
De fleste feltene i databasen er timestamp uten tidssone. Dette fungerer forsåvidt greit når vi bruker LocalDateTime siden LocalDateTime er en timestamp uten tidssone. Men når vi bruker Instant, som er er et UTC-timestamp blir det problemer om databasefeltet ikke er en timestamp med tidssone. Dette gjelder blant annet for siste_endret på en avtale.

Denne PR'en prøver å fikse problemet ved å gå over til å bruke timestamp med tidssone for alle felt i databasen som er et timestamp og ikke bare en dato.
Å bruke tidssone er det mest korrekte når vi skal si at noe har skjedd på en viss tid. For eksempel en avtale ble godkjent. Avtalen ble da godkjent på et visst tidspunkt i en viss tidssone. Den ble ikke godkjent kl 2 i London og kl 2 i Oslo. Derfor blir ogsa Instant brukt mer enn LocalDateTime, siden Instant har tidssone.