### PR TITLE
fix. instant og tidssoner for timestamp i avtale-melding og dvh-melding

### DIFF
--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/service/AvtalestatusService.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/service/AvtalestatusService.java
@@ -21,7 +21,7 @@ import no.nav.tag.tiltaksgjennomforing.utils.Now;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.UUID;
 
 @Slf4j
@@ -73,7 +73,7 @@ public class AvtalestatusService {
     }
 
     private void sendAvtaleMelding(Avtale avtale) {
-        LocalDateTime tidspunkt = Now.localDateTime();
+        Instant tidspunkt = Now.instant();
         AvtaleMelding avtaleMelding = AvtaleMelding.create(avtale, avtale.getGjeldendeInnhold(), new Identifikator("tiltaksgjennomforing-api"), AvtaleHendelseUtførtAvRolle.SYSTEM, HendelseType.STATUSENDRING);
         try {
             String meldingSomString = objectMapper.writeValueAsString(avtaleMelding);

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/datadeling/AvtaleHendelseLytter.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/datadeling/AvtaleHendelseLytter.java
@@ -42,7 +42,7 @@ import no.nav.tag.tiltaksgjennomforing.utils.Now;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.UUID;
 
 @Component
@@ -212,11 +212,10 @@ public class AvtaleHendelseLytter {
     private void lagHendelse(Avtale avtale, HendelseType hendelseType, Identifikator utførtAv, AvtaleHendelseUtførtAvRolle utførtAvRolle) {
         lagHendelse(avtale, hendelseType, utførtAv, utførtAvRolle, null);
     }
+
     private void lagHendelse(Avtale avtale, HendelseType hendelseType, Identifikator utførtAv, AvtaleHendelseUtførtAvRolle utførtAvRolle, ForkortetGrunn forkortetGrunn) {
-        LocalDateTime tidspunkt = Now.localDateTime();
+        Instant tidspunkt = Now.instant();
         UUID meldingId = UUID.randomUUID();
-
-
         AvtaleMelding melding = AvtaleMelding.create(avtale, avtale.getGjeldendeInnhold(), utførtAv, utførtAvRolle, hendelseType, forkortetGrunn);
         try {
             String meldingSomString = objectMapper.writeValueAsString(melding);

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/datadeling/AvtaleHendelsePatchService.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/datadeling/AvtaleHendelsePatchService.java
@@ -12,7 +12,7 @@ import no.nav.tag.tiltaksgjennomforing.utils.Now;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -80,7 +80,7 @@ public class AvtaleHendelsePatchService {
     private void lagMelding(Avtale avtale) {
         var melding = AvtaleMelding.create(avtale, avtale.getGjeldendeInnhold(), new Identifikator("tiltaksgjennomforing-api"), AvtaleHendelseUtførtAvRolle.SYSTEM, HendelseType.PATCH);
         UUID meldingId = UUID.randomUUID();
-        LocalDateTime tidspunkt = Now.localDateTime();
+        Instant tidspunkt = Now.instant();
         try {
             String meldingSomString = objectMapper.writeValueAsString(melding);
             AvtaleMeldingEntitet entitet = new AvtaleMeldingEntitet(meldingId, avtale.getId(), tidspunkt, HendelseType.PATCH, avtale.getStatus(), meldingSomString);

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/datadeling/AvtaleMeldingEntitet.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/datadeling/AvtaleMeldingEntitet.java
@@ -11,7 +11,7 @@ import no.nav.tag.tiltaksgjennomforing.avtale.HendelseType;
 import no.nav.tag.tiltaksgjennomforing.avtale.Status;
 import org.springframework.data.domain.AbstractAggregateRoot;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.UUID;
 
 @Entity
@@ -28,12 +28,12 @@ public class AvtaleMeldingEntitet extends AbstractAggregateRoot<AvtaleMeldingEnt
 
     @Enumerated(EnumType.STRING)
     private Status avtaleStatus;
-    private LocalDateTime tidspunkt;
+    private Instant tidspunkt;
     private String json;
     private boolean sendt;
     private boolean sendtCompacted;
 
-    public AvtaleMeldingEntitet(UUID meldingId, UUID avtaleId, LocalDateTime tidspunkt, HendelseType hendelseType, Status avtaleStatus, String meldingAsJson) {
+    public AvtaleMeldingEntitet(UUID meldingId, UUID avtaleId, Instant tidspunkt, HendelseType hendelseType, Status avtaleStatus, String meldingAsJson) {
         this.meldingId = meldingId;
         this.avtaleId = avtaleId;
         this.hendelseType = hendelseType;

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/datavarehus/DvhMeldingEntitet.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/datavarehus/DvhMeldingEntitet.java
@@ -11,8 +11,7 @@ import no.nav.tag.tiltaksgjennomforing.avtale.Avtale;
 import no.nav.tag.tiltaksgjennomforing.avtale.Status;
 import org.springframework.data.domain.AbstractAggregateRoot;
 
-import java.time.LocalDateTime;
-import java.time.ZoneId;
+import java.time.Instant;
 import java.util.UUID;
 
 @Entity
@@ -23,7 +22,7 @@ public class DvhMeldingEntitet extends AbstractAggregateRoot<DvhMeldingEntitet> 
     @Id
     private UUID meldingId;
     private UUID avtaleId;
-    private LocalDateTime tidspunkt;
+    private Instant tidspunkt;
     @Enumerated(EnumType.STRING)
     private Status tiltakStatus;
     private String json;
@@ -32,7 +31,7 @@ public class DvhMeldingEntitet extends AbstractAggregateRoot<DvhMeldingEntitet> 
     public DvhMeldingEntitet(Avtale avtale, AvroTiltakHendelse avroTiltakHendelse) {
         this.meldingId = UUID.fromString(avroTiltakHendelse.getMeldingId());
         this.avtaleId = avtale.getId();
-        this.tidspunkt = LocalDateTime.ofInstant(avroTiltakHendelse.getTidspunkt(), ZoneId.systemDefault());
+        this.tidspunkt = avroTiltakHendelse.getTidspunkt();
         this.tiltakStatus = avtale.getStatus();
         this.json = avroTiltakHendelse.toString();
         registerEvent(new DvhMeldingOpprettet(this, avroTiltakHendelse));

--- a/src/main/resources/db/migration/common/V133__tidssoner_meldinger.sql
+++ b/src/main/resources/db/migration/common/V133__tidssoner_meldinger.sql
@@ -1,0 +1,5 @@
+alter table avtale_melding alter column tidspunkt type timestamp with time zone
+    using tidspunkt at time zone 'Europe/Oslo';
+
+alter table dvh_melding alter column tidspunkt type timestamp with time zone
+    using tidspunkt at time zone 'Europe/Oslo';


### PR DESCRIPTION
De fleste feltene i databasen er timestamp uten tidssone. Dette fungerer forsåvidt greit når vi bruker LocalDateTime siden LocalDateTime er en timestamp uten tidssone. Men når vi bruker Instant, som er er et UTC-timestamp blir det problemer om databasefeltet ikke er en timestamp med tidssone. Dette gjelder blant annet for siste_endret på en avtale.

Denne PR'en prøver å fikse problemet ved å gå over til å bruke timestamp med tidssone for alle felt i databasen som er et timestamp og ikke bare en dato.
Å bruke tidssone er det mest korrekte når vi skal si at noe har skjedd på en viss tid. For eksempel en avtale ble godkjent. Avtalen ble da godkjent på et visst tidspunkt i en viss tidssone. Den ble ikke godkjent kl 2 i London og kl 2 i Oslo. Derfor blir ogsa Instant brukt mer enn LocalDateTime, siden Instant har tidssone.