### PR TITLE
fix. instant og tidssoner for inkl.tilskuddutgifter og mål

### DIFF
--- a/src/main/resources/db/migration/common/V134__tidssoner_inkl_tilskudd_og_maal.sql
+++ b/src/main/resources/db/migration/common/V134__tidssoner_inkl_tilskudd_og_maal.sql
@@ -1,0 +1,5 @@
+alter table inkluderingstilskuddsutgift alter column tidspunkt_lagt_til type timestamp with time zone
+    using tidspunkt_lagt_til at time zone 'Europe/Oslo';
+
+alter table maal alter column opprettet_tidspunkt type timestamp with time zone
+    using opprettet_tidspunkt at time zone 'Europe/Oslo';


### PR DESCRIPTION
De fleste feltene i databasen er timestamp uten tidssone. Dette fungerer forsåvidt greit når vi bruker LocalDateTime siden LocalDateTime er en timestamp uten tidssone. Men når vi bruker Instant, som er er et UTC-timestamp blir det problemer om databasefeltet ikke er en timestamp med tidssone. Dette gjelder blant annet for siste_endret på en avtale.

Denne PR'en prøver å fikse problemet ved å gå over til å bruke timestamp med tidssone for alle felt i databasen som er et timestamp og ikke bare en dato.
Å bruke tidssone er det mest korrekte når vi skal si at noe har skjedd på en viss tid. For eksempel en avtale ble godkjent. Avtalen ble da godkjent på et visst tidspunkt i en viss tidssone. Den ble ikke godkjent kl 2 i London og kl 2 i Oslo. Derfor blir ogsa Instant brukt mer enn LocalDateTime, siden Instant har tidssone.