### PR TITLE
fix. instant og tidssoner for tilskuddsperioder

### DIFF
--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/TilskuddPeriode.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/TilskuddPeriode.java
@@ -24,8 +24,8 @@ import no.nav.tag.tiltaksgjennomforing.utils.Now;
 import org.apache.commons.lang3.builder.CompareToBuilder;
 import org.jetbrains.annotations.NotNull;
 
+import java.time.Instant;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.EnumSet;
 import java.util.Optional;
 import java.util.Set;
@@ -59,7 +59,7 @@ public class TilskuddPeriode implements Comparable<TilskuddPeriode> {
     @Convert(converter = NavIdentConverter.class)
     private NavIdent godkjentAvNavIdent;
 
-    private LocalDateTime godkjentTidspunkt;
+    private Instant godkjentTidspunkt;
 
     /**
      * "Enhet" i denne konteksten er oppfølgingsenheten til deltaker;
@@ -81,7 +81,7 @@ public class TilskuddPeriode implements Comparable<TilskuddPeriode> {
     private String avslagsforklaring;
     @Convert(converter = NavIdentConverter.class)
     private NavIdent avslåttAvNavIdent;
-    private LocalDateTime avslåttTidspunkt;
+    private Instant avslåttTidspunkt;
     private Integer løpenummer = 1;
 
     @Enumerated(EnumType.STRING)
@@ -185,7 +185,7 @@ public class TilskuddPeriode implements Comparable<TilskuddPeriode> {
     void godkjenn(NavIdent beslutter, String enhet) {
         sjekkOmKanBehandles();
 
-        setGodkjentTidspunkt(Now.localDateTime());
+        setGodkjentTidspunkt(Now.instant());
         setGodkjentAvNavIdent(beslutter);
         setEnhet(enhet);
         setStatus(TilskuddPeriodeStatus.GODKJENT);
@@ -200,7 +200,7 @@ public class TilskuddPeriode implements Comparable<TilskuddPeriode> {
             throw new FeilkodeException(Feilkode.TILSKUDDSPERIODE_INGEN_AVSLAGSAARSAKER);
         }
 
-        setAvslåttTidspunkt(Now.localDateTime());
+        setAvslåttTidspunkt(Now.instant());
         setAvslåttAvNavIdent(beslutter);
         this.avslagsårsaker.addAll(avslagsårsaker);
         setAvslagsforklaring(avslagsforklaring);

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/tilskuddsperiode/TilskuddsperiodeGodkjentMelding.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/tilskuddsperiode/TilskuddsperiodeGodkjentMelding.java
@@ -9,6 +9,7 @@ import no.nav.tag.tiltaksgjennomforing.avtale.Identifikator;
 import no.nav.tag.tiltaksgjennomforing.avtale.NavIdent;
 import no.nav.tag.tiltaksgjennomforing.avtale.TilskuddPeriode;
 import no.nav.tag.tiltaksgjennomforing.avtale.Tiltakstype;
+import no.nav.tag.tiltaksgjennomforing.utils.DatoUtils;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -84,7 +85,7 @@ public class TilskuddsperiodeGodkjentMelding {
                 tilskuddsperiode.getGodkjentAvNavIdent(),
                 avtale.getGjeldendeInnhold().getVeilederFornavn(),
                 avtale.getGjeldendeInnhold().getVeilederEtternavn(),
-                tilskuddsperiode.getGodkjentTidspunkt(),
+                DatoUtils.instantTilLocalDateTime(tilskuddsperiode.getGodkjentTidspunkt()),
                 avtale.getGjeldendeInnhold().getArbeidsgiverKontonummer()
         );
     }

--- a/src/main/resources/db/migration/common/V135__tidssoner_tilskuddsperioder.sql
+++ b/src/main/resources/db/migration/common/V135__tidssoner_tilskuddsperioder.sql
@@ -1,0 +1,5 @@
+alter table tilskudd_periode alter column godkjent_tidspunkt type timestamp with time zone
+    using godkjent_tidspunkt at time zone 'Europe/Oslo';
+
+alter table tilskudd_periode alter column avslått_tidspunkt type timestamp with time zone
+    using avslått_tidspunkt at time zone 'Europe/Oslo';


### PR DESCRIPTION
De fleste feltene i databasen er timestamp uten tidssone. Dette fungerer forsåvidt greit når vi bruker LocalDateTime siden LocalDateTime er en timestamp uten tidssone. Men når vi bruker Instant, som er er et UTC-timestamp blir det problemer om databasefeltet ikke er en timestamp med tidssone. Dette gjelder blant annet for siste_endret på en avtale.

Denne PR'en prøver å fikse problemet ved å gå over til å bruke timestamp med tidssone for alle felt i databasen som er et timestamp og ikke bare en dato.
Å bruke tidssone er det mest korrekte når vi skal si at noe har skjedd på en viss tid. For eksempel en avtale ble godkjent. Avtalen ble da godkjent på et visst tidspunkt i en viss tidssone. Den ble ikke godkjent kl 2 i London og kl 2 i Oslo. Derfor blir ogsa Instant brukt mer enn LocalDateTime, siden Instant har tidssone.