### PR TITLE
fix. instant og tidssoner for sms

### DIFF
--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/varsel/Sms.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/varsel/Sms.java
@@ -17,7 +17,7 @@ import no.nav.tag.tiltaksgjennomforing.utils.Now;
 import no.nav.tag.tiltaksgjennomforing.varsel.events.SmsSendt;
 import org.springframework.data.domain.AbstractAggregateRoot;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.UUID;
 
 @Slf4j
@@ -34,23 +34,25 @@ public class Sms extends AbstractAggregateRoot<Sms> {
     private Identifikator identifikator;
     private String meldingstekst;
     private UUID avtaleId;
-    private LocalDateTime tidspunkt;
+    private Instant tidspunkt;
     @Enumerated(EnumType.STRING)
     private HendelseType hendelseType;
     private String avsenderApplikasjon;
 
-    public static Sms nyttVarsel(String telefonnummer,
-                                 Identifikator identifikator,
-                                 String meldingstekst,
-                                 HendelseType hendelseType,
-                                 UUID avtaleId) {
+    public static Sms nyttVarsel(
+        String telefonnummer,
+         Identifikator identifikator,
+         String meldingstekst,
+         HendelseType hendelseType,
+         UUID avtaleId
+    ) {
         Sms sms = new Sms();
         sms.smsVarselId = UUID.randomUUID();
         sms.telefonnummer = telefonnummer;
         sms.identifikator = identifikator;
         sms.meldingstekst = meldingstekst;
         sms.hendelseType = hendelseType;
-        sms.tidspunkt = Now.localDateTime();
+        sms.tidspunkt = Now.instant();
         sms.avtaleId = avtaleId;
         sms.avsenderApplikasjon = "tiltaksgjennomforing-api";
         sms.registerEvent(new SmsSendt(sms));

--- a/src/main/resources/db/migration/common/V137__tidssoner_sms.sql
+++ b/src/main/resources/db/migration/common/V137__tidssoner_sms.sql
@@ -1,0 +1,2 @@
+alter table sms alter column tidspunkt type timestamp with time zone
+    using tidspunkt at time zone 'Europe/Oslo';


### PR DESCRIPTION
De fleste feltene i databasen er timestamp uten tidssone. Dette fungerer forsåvidt greit når vi bruker LocalDateTime siden LocalDateTime er en timestamp uten tidssone. Men når vi bruker Instant, som er er et UTC-timestamp blir det problemer om databasefeltet ikke er en timestamp med tidssone. Dette gjelder blant annet for siste_endret på en avtale.

Denne PR'en prøver å fikse problemet ved å gå over til å bruke timestamp med tidssone for alle felt i databasen som er et timestamp og ikke bare en dato.
Å bruke tidssone er det mest korrekte når vi skal si at noe har skjedd på en viss tid. For eksempel en avtale ble godkjent. Avtalen ble da godkjent på et visst tidspunkt i en viss tidssone. Den ble ikke godkjent kl 2 i London og kl 2 i Oslo. Derfor blir ogsa Instant brukt mer enn LocalDateTime, siden Instant har tidssone.