### PR TITLE
fix. instant og tidssoner for sporingslogg

### DIFF
--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/sporingslogg/Sporingslogg.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/sporingslogg/Sporingslogg.java
@@ -10,7 +10,7 @@ import no.nav.tag.tiltaksgjennomforing.avtale.Avtale;
 import no.nav.tag.tiltaksgjennomforing.avtale.HendelseType;
 import no.nav.tag.tiltaksgjennomforing.utils.Now;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.UUID;
 
 @Data
@@ -19,7 +19,7 @@ import java.util.UUID;
 public class Sporingslogg {
     @Id
     private UUID id;
-    private LocalDateTime tidspunkt;
+    private Instant tidspunkt;
     private UUID avtaleId;
     @Enumerated(EnumType.STRING)
     private HendelseType hendelseType;
@@ -27,7 +27,7 @@ public class Sporingslogg {
     public static Sporingslogg nyHendelse(Avtale avtale, HendelseType hendelseType) {
         Sporingslogg sporingslogg = new Sporingslogg();
         sporingslogg.id = UUID.randomUUID();
-        sporingslogg.tidspunkt = Now.localDateTime();
+        sporingslogg.tidspunkt = Now.instant();
         sporingslogg.avtaleId = avtale.getId();
         sporingslogg.hendelseType = hendelseType;
         return sporingslogg;

--- a/src/main/resources/db/migration/common/V138__tidssoner_sporingslogg.sql
+++ b/src/main/resources/db/migration/common/V138__tidssoner_sporingslogg.sql
@@ -1,0 +1,2 @@
+alter table sporingslogg alter column tidspunkt type timestamp with time zone
+    using tidspunkt at time zone 'Europe/Oslo';


### PR DESCRIPTION
De fleste feltene i databasen er timestamp uten tidssone. Dette fungerer forsåvidt greit når vi bruker LocalDateTime siden LocalDateTime er en timestamp uten tidssone. Men når vi bruker Instant, som er er et UTC-timestamp blir det problemer om databasefeltet ikke er en timestamp med tidssone. Dette gjelder blant annet for siste_endret på en avtale.

Denne PR'en prøver å fikse problemet ved å gå over til å bruke timestamp med tidssone for alle felt i databasen som er et timestamp og ikke bare en dato.
Å bruke tidssone er det mest korrekte når vi skal si at noe har skjedd på en viss tid. For eksempel en avtale ble godkjent. Avtalen ble da godkjent på et visst tidspunkt i en viss tidssone. Den ble ikke godkjent kl 2 i London og kl 2 i Oslo. Derfor blir ogsa Instant brukt mer enn LocalDateTime, siden Instant har tidssone.