### PR TITLE
fix. instant og tidssoner for varsel

### DIFF
--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/varsel/Varsel.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/varsel/Varsel.java
@@ -19,7 +19,7 @@ import no.nav.tag.tiltaksgjennomforing.datadeling.AvtaleHendelseUtførtAvRolle;
 import no.nav.tag.tiltaksgjennomforing.utils.Now;
 import org.springframework.data.domain.AbstractAggregateRoot;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.time.format.DateTimeFormatter;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -42,7 +42,7 @@ public class Varsel extends AbstractAggregateRoot<Varsel> {
     private HendelseType hendelseType;
     private boolean bjelle;
     private UUID avtaleId;
-    private LocalDateTime tidspunkt;
+    private Instant tidspunkt;
     @Enumerated(EnumType.STRING)
     private Avtalerolle mottaker;
     @Enumerated(EnumType.STRING)
@@ -90,7 +90,7 @@ public class Varsel extends AbstractAggregateRoot<Varsel> {
     ) {
         Varsel varsel = new Varsel();
         varsel.id = UUID.randomUUID();
-        varsel.tidspunkt = Now.localDateTime();
+        varsel.tidspunkt = Now.instant();
         varsel.identifikator = identifikator;
         varsel.utførtAvIdentifikator = utførtAvIdentifikator;
         varsel.tekst = lagVarselTekst(avtale, tilskuddPeriode, hendelseType);

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/varsel/VarselRespons.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/varsel/VarselRespons.java
@@ -3,7 +3,7 @@ package no.nav.tag.tiltaksgjennomforing.varsel;
 import no.nav.tag.tiltaksgjennomforing.avtale.Avtalerolle;
 import no.nav.tag.tiltaksgjennomforing.avtale.HendelseType;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.UUID;
 
 public record VarselRespons(
@@ -13,7 +13,7 @@ public record VarselRespons(
         HendelseType hendelseType,
         boolean bjelle,
         UUID avtaleId,
-        LocalDateTime tidspunkt,
+        Instant tidspunkt,
         String utførtAv
 ) {
     public VarselRespons(Varsel varsel, Avtalerolle innloggetPart) {

--- a/src/main/resources/db/migration/common/V139__tidssoner_varsel.sql
+++ b/src/main/resources/db/migration/common/V139__tidssoner_varsel.sql
@@ -1,0 +1,2 @@
+alter table varsel alter column tidspunkt type timestamp with time zone
+    using tidspunkt at time zone 'Europe/Oslo';


### PR DESCRIPTION
De fleste feltene i databasen er timestamp uten tidssone. Dette fungerer forsåvidt greit når vi bruker LocalDateTime siden LocalDateTime er en timestamp uten tidssone. Men når vi bruker Instant, som er er et UTC-timestamp blir det problemer om databasefeltet ikke er en timestamp med tidssone. Dette gjelder blant annet for siste_endret på en avtale.

Denne PR'en prøver å fikse problemet ved å gå over til å bruke timestamp med tidssone for alle felt i databasen som er et timestamp og ikke bare en dato.
Å bruke tidssone er det mest korrekte når vi skal si at noe har skjedd på en viss tid. For eksempel en avtale ble godkjent. Avtalen ble da godkjent på et visst tidspunkt i en viss tidssone. Den ble ikke godkjent kl 2 i London og kl 2 i Oslo. Derfor blir ogsa Instant brukt mer enn LocalDateTime, siden Instant har tidssone.