### PR TITLE
fix. instant og tidssoner for filtersøk

### DIFF
--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleController.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleController.java
@@ -166,7 +166,7 @@ public class AvtaleController {
         }
 
         filterSok.setAntallGangerSokt(filterSok.getAntallGangerSokt() + 1);
-        filterSok.setSistSoktTidspunkt(Now.localDateTime());
+        filterSok.setSistSoktTidspunkt(Now.instant());
         filterSokRepository.save(filterSok);
         AvtaleQueryParameter avtalePredicate = filterSok.getAvtalePredicate();
 
@@ -216,7 +216,7 @@ public class AvtaleController {
         FilterSok filterSokiDb = filterSokRepository.findFilterSokBySokId(queryParametre.generateHash()).orElse(null);
         if (filterSokiDb != null) {
             filterSokiDb.setAntallGangerSokt(filterSokiDb.getAntallGangerSokt() + 1);
-            filterSokiDb.setSistSoktTidspunkt(Now.localDateTime());
+            filterSokiDb.setSistSoktTidspunkt(Now.instant());
             filterSokRepository.save(filterSokiDb);
             if (!filterSokiDb.erLik(queryParametre)) {
                 log.error("Kollisjon i søkId: {}", filterSokiDb.getSokId());

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/FilterSok.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/FilterSok.java
@@ -11,7 +11,7 @@ import lombok.NoArgsConstructor;
 import lombok.SneakyThrows;
 import no.nav.tag.tiltaksgjennomforing.utils.Now;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 @Data
 @Entity
@@ -19,14 +19,13 @@ import java.time.LocalDateTime;
 public class FilterSok {
     @Id
     private String sokId;
-    private LocalDateTime sistSoktTidspunkt;
+    private Instant sistSoktTidspunkt;
     private String queryParametre;
     private Integer antallGangerSokt;
 
-
     @SneakyThrows
     public FilterSok(AvtaleQueryParameter queryParametre) {
-        this.sistSoktTidspunkt = Now.localDateTime();
+        this.sistSoktTidspunkt = Now.instant();
         this.antallGangerSokt = 1;
         this.sokId = queryParametre.generateHash();
         ObjectMapper mapper = new ObjectMapper();

--- a/src/main/resources/db/migration/common/V136__tidssoner_filter_sok.sql
+++ b/src/main/resources/db/migration/common/V136__tidssoner_filter_sok.sql
@@ -1,0 +1,2 @@
+alter table filter_sok alter column sist_sokt_tidspunkt type timestamp with time zone
+    using sist_sokt_tidspunkt at time zone 'Europe/Oslo';


### PR DESCRIPTION
De fleste feltene i databasen er timestamp uten tidssone. Dette fungerer forsåvidt greit når vi bruker LocalDateTime siden LocalDateTime er en timestamp uten tidssone. Men når vi bruker Instant, som er er et UTC-timestamp blir det problemer om databasefeltet ikke er en timestamp med tidssone. Dette gjelder blant annet for siste_endret på en avtale.

Denne PR'en prøver å fikse problemet ved å gå over til å bruke timestamp med tidssone for alle felt i databasen som er et timestamp og ikke bare en dato.
Å bruke tidssone er det mest korrekte når vi skal si at noe har skjedd på en viss tid. For eksempel en avtale ble godkjent. Avtalen ble da godkjent på et visst tidspunkt i en viss tidssone. Den ble ikke godkjent kl 2 i London og kl 2 i Oslo. Derfor blir ogsa Instant brukt mer enn LocalDateTime, siden Instant har tidssone.