### PR TITLE
fix. ikke hent eldre avtaler for min-side-arbeidsgiver

### DIFF
--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleController.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleController.java
@@ -363,7 +363,7 @@ public class AvtaleController {
     @GetMapping("/min-side-arbeidsgiver")
     public List<Avtale> hentAlleAvtalerForMinSideArbeidsgiver(@RequestParam("bedriftNr") BedriftNr bedriftNr) {
         Arbeidsgiver arbeidsgiver = innloggingService.hentArbeidsgiver();
-        return arbeidsgiver.hentAvtalerForMinsideArbeidsgiver(avtaleRepository, bedriftNr);
+        return arbeidsgiver.hentAvtalerForMinSideArbeidsgiver(avtaleRepository, bedriftNr);
     }
 
     @GetMapping(path = "/{avtaleId}/kontonummer-arbeidsgiver")

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleRepository.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleRepository.java
@@ -32,19 +32,15 @@ public interface AvtaleRepository extends JpaRepository<Avtale, UUID>, JpaSpecif
     List<Avtale> findAllById(Iterable<UUID> ids);
 
     @Timed(percentiles = {0.5d, 0.75d, 0.9d, 0.99d, 0.999d})
-    List<Avtale> findAllByBedriftNrAndFeilregistrertIsFalse(BedriftNr bedriftNr);
-
-    @Timed(percentiles = {0.5d, 0.75d, 0.9d, 0.99d, 0.999d})
     @Query("""
         SELECT a
         FROM Avtale a
         WHERE a.bedriftNr IN :bedriftNrList
           AND a.feilregistrert = false
-          AND (a.gjeldendeInnhold.godkjentAvVeileder IS NULL OR a.gjeldendeInnhold.sluttDato > :dato12UkerFraIdag)
+          AND (a.gjeldendeInnhold.godkjentAvVeileder IS NULL OR a.gjeldendeInnhold.sluttDato > current_date - 84 day)
         """)
     Page<Avtale> findAllByBedriftNr(
-        @Param("bedriftNrList") Set<BedriftNr> bedriftNrList,
-        @Param("dato12UkerFraIdag") LocalDate dato12UkerFraIdag,
+        Set<BedriftNr> bedriftNrList,
         Pageable pageable
     );
 
@@ -55,12 +51,11 @@ public interface AvtaleRepository extends JpaRepository<Avtale, UUID>, JpaSpecif
         WHERE a.bedriftNr IN :bedriftNrList
           AND a.tiltakstype = :tiltakstype
           AND a.feilregistrert = false
-          AND (a.gjeldendeInnhold.godkjentAvVeileder IS NULL OR a.gjeldendeInnhold.sluttDato > :dato12UkerFraIdag)
+          AND (a.gjeldendeInnhold.godkjentAvVeileder IS NULL OR a.gjeldendeInnhold.sluttDato > current_date - 84 day)
         """)
-    Page<Avtale> findAllByBedriftNrInAndTiltakstype(
-        @Param("bedriftNrList") Set<BedriftNr> bedriftNrList,
-        @Param("tiltakstype") Tiltakstype tiltakstype,
-        @Param("dato12UkerFraIdag") LocalDate dato12UkerFraIdag,
+    Page<Avtale> findAllByBedriftNrAndTiltakstype(
+        Set<BedriftNr> bedriftNrList,
+        Tiltakstype tiltakstype,
         Pageable pageable
     );
 
@@ -76,9 +71,9 @@ public interface AvtaleRepository extends JpaRepository<Avtale, UUID>, JpaSpecif
         FROM Avtale a
         WHERE a.mentorFnr = :mentorFnr
           AND a.feilregistrert = false
-          AND (a.gjeldendeInnhold.godkjentAvVeileder IS NULL OR a.gjeldendeInnhold.sluttDato > :dato12UkerFraIdag)
+          AND (a.gjeldendeInnhold.godkjentAvVeileder IS NULL OR a.gjeldendeInnhold.sluttDato > current_date - 84 day)
         """)
-    Page<Avtale> findAllByMentorFnr(Fnr mentorFnr, LocalDate dato12UkerFraIdag, Pageable pageable);
+    Page<Avtale> findAllByMentorFnr(Fnr mentorFnr, Pageable pageable);
 
     @Timed(percentiles = {0.5d, 0.75d, 0.9d, 0.99d, 0.999d})
     Page<Avtale> findAllByAvtaleNrAndFeilregistrertIsFalse(Integer avtaleNr, Pageable pageable);

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/Mentor.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/Mentor.java
@@ -61,10 +61,8 @@ public class Mentor extends Avtalepart<Fnr> {
 
     @Override
     Page<Avtale> hentAlleAvtalerMedMuligTilgang(AvtaleRepository avtaleRepository, AvtaleQueryParameter queryParametre, Pageable pageable) {
-        final LocalDate dato12UkerTilbakeFraNå = Now.localDate().minusWeeks(12);
         Page<Avtale> avtaler = avtaleRepository.findAllByMentorFnr(
             getIdentifikator(),
-            dato12UkerTilbakeFraNå,
             pageable
         );
         return avtaler;

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/InnloggetArbeidsgiverTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/InnloggetArbeidsgiverTest.java
@@ -11,12 +11,14 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
@@ -55,8 +57,8 @@ public class InnloggetArbeidsgiverTest {
 
         Arbeidsgiver arbeidsgiver = TestData.enArbeidsgiver(avtale);
 
-        when(avtaleRepository.findAllByBedriftNrAndFeilregistrertIsFalse(eq(avtale.getBedriftNr()))).thenReturn(Arrays.asList(avtale));
-        List<Avtale> hentetAvtaler = arbeidsgiver.hentAvtalerForMinsideArbeidsgiver(avtaleRepository, avtale.getBedriftNr());
+        when(avtaleRepository.findAllByBedriftNr(eq(Set.of(avtale.getBedriftNr())), any())).thenReturn(new PageImpl<>(List.of(avtale)));
+        List<Avtale> hentetAvtaler = arbeidsgiver.hentAvtalerForMinSideArbeidsgiver(avtaleRepository, avtale.getBedriftNr());
         assertThat(hentetAvtaler.get(0).getAnnullertGrunn()).isNull();
     }
 }

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/ArbeidsgiverOgMentorAvtalerEldreEnn12UkerIntegrasjonTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/ArbeidsgiverOgMentorAvtalerEldreEnn12UkerIntegrasjonTest.java
@@ -74,7 +74,7 @@ class ArbeidsgiverOgMentorAvtalerEldreEnn12UkerIntegrasjonTest {
     public void skal_returnere_avtale_som_er_i_db() {
         Avtale avtale = avtaleRepository.save(TestData.enArbeidstreningAvtale());
         Arbeidsgiver arbeidsgiver = TestData.enArbeidsgiver(avtale);
-        List<Avtale> arbeidsgiverList = arbeidsgiver.hentAvtalerForMinsideArbeidsgiver(
+        List<Avtale> arbeidsgiverList = arbeidsgiver.hentAvtalerForMinSideArbeidsgiver(
             avtaleRepository,
             avtale.getBedriftNr()
         );
@@ -100,7 +100,7 @@ class ArbeidsgiverOgMentorAvtalerEldreEnn12UkerIntegrasjonTest {
             queryParameter,
             pageable
         );
-        List<Avtale> avtalerFiltrertBasertPaaRiktigTilgang = arbeidsgiver.hentAvtalerForMinsideArbeidsgiver(
+        List<Avtale> avtalerFiltrertBasertPaaRiktigTilgang = arbeidsgiver.hentAvtalerForMinSideArbeidsgiver(
             avtaleRepository,
             avtaleLagret.getBedriftNr()
         );

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/ArbeidsgiverTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/ArbeidsgiverTest.java
@@ -254,7 +254,7 @@ public class ArbeidsgiverTest {
         Avtale avtale = TestData.enAvtaleMedAltUtfylt();
         avtale.setBedriftNr(TestData.etBedriftNr());
 
-        when(avtaleRepository.findAllByBedriftNr(any(), any(), any())).thenReturn(new PageImpl<>(List.of(avtale)));
+        when(avtaleRepository.findAllByBedriftNr(any(), any())).thenReturn(new PageImpl<>(List.of(avtale)));
 
         // PDL Adressepserre og navn mock
         PersondataService persondataService = mock(PersondataService.class);

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleRepositoryTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleRepositoryTest.java
@@ -305,9 +305,8 @@ public class AvtaleRepositoryTest {
     }
 
     @Test
-    public void findAllByBedriftNrInAndTiltakstype_skal_kunne_hente_avtale_som_ikke_er_FEIL_REGISTRERT() {
+    public void findAllByBedriftNrAndTiltakstype_skal_kunne_hente_avtale_som_ikke_er_FEIL_REGISTRERT() {
         Pageable pageable = PageRequest.of(0, 100);
-        final LocalDate Dato12UkerTilbakeFraNå = Now.localDate().minusWeeks(12);
         Avtale lagretAvtale = TestData.enArbeidstreningAvtaleGodkjentAvVeileder();
         lagretAvtale.setFeilregistrert(true);
         lagretAvtale.setBedriftNr(new BedriftNr("123456789"));
@@ -327,10 +326,9 @@ public class AvtaleRepositoryTest {
         Set<BedriftNr> bedriftNrSet = Set.of(lagretAvtale3.getBedriftNr(), lagretAvtale2.getBedriftNr(), lagretAvtale.getBedriftNr());
 
         Page<Avtale> avtalerFunnet = avtaleRepository
-            .findAllByBedriftNrInAndTiltakstype(
+            .findAllByBedriftNrAndTiltakstype(
                 bedriftNrSet,
                 lagretAvtale.getTiltakstype(),
-                Dato12UkerTilbakeFraNå,
                 pageable
             );
 
@@ -362,7 +360,7 @@ public class AvtaleRepositoryTest {
         Set<BedriftNr> bedriftNrSet = Set.of(lagretAvtale3.getBedriftNr(), lagretAvtale2.getBedriftNr(), lagretAvtale.getBedriftNr());
 
         Page<Avtale> avtalerFunnet = avtaleRepository
-            .findAllByBedriftNr(bedriftNrSet, dato12UkerTilbakeFraNå, pageable);
+            .findAllByBedriftNr(bedriftNrSet, pageable);
 
         assertThat(avtalerFunnet.getContent()).isNotEmpty();
         assertThat(avtalerFunnet.getTotalElements()).isEqualTo(1);
@@ -372,7 +370,6 @@ public class AvtaleRepositoryTest {
     @Test
     public void findAllByMentorFnr_skal_kunne_hente_avtale_som_ikke_er_FEIL_REGISTRERT() {
         Pageable pageable = PageRequest.of(0, 100);
-        final LocalDate Dato12UkerTilbakeFraNå = Now.localDate().minusWeeks(12);
         final Fnr mentorFnr = Fnr.generer(1976, 12, 28);
         Avtale lagretAvtale = TestData.enMentorAvtaleSignert();
         lagretAvtale.setFeilregistrert(false);
@@ -387,8 +384,7 @@ public class AvtaleRepositoryTest {
         avtaleRepository.save(lagretAvtale2);
 
 
-        Page<Avtale> avtalerFunnet = avtaleRepository
-            .findAllByMentorFnr(mentorFnr, Dato12UkerTilbakeFraNå, pageable);
+        Page<Avtale> avtalerFunnet = avtaleRepository.findAllByMentorFnr(mentorFnr, pageable);
 
         assertThat(avtalerFunnet.getContent()).isNotEmpty();
         assertThat(avtalerFunnet.getTotalElements()).isEqualTo(1);

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/MentorTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/MentorTest.java
@@ -65,7 +65,7 @@ public class MentorTest {
         Mentor mentor = TestData.enMentor(avtaleSignert);
 
         // NÅR
-        when(avtaleRepository.findAllByMentorFnr(any(), any(), any())).thenReturn(new PageImpl<>(List.of(
+        when(avtaleRepository.findAllByMentorFnr(any(), any())).thenReturn(new PageImpl<>(List.of(
             avtaleUsignert,
             avtaleSignert
         )));
@@ -124,11 +124,7 @@ public class MentorTest {
         Mentor mentor = TestData.enMentor(avtale);
         AvtaleQueryParameter avtalePredicate = new AvtaleQueryParameter();
         // NÅR
-        when(avtaleRepository.findAllByMentorFnr(
-            any(),
-            any(),
-            eq(pageable)
-        )).thenReturn(new PageImpl<>(List.of(avtale)));
+        when(avtaleRepository.findAllByMentorFnr(any(), eq(pageable))).thenReturn(new PageImpl<>(List.of(avtale)));
         List<BegrensetAvtale> avtalerMinimal  = mentor
             .hentBegrensedeAvtalerMedLesetilgang(avtaleRepository, avtalePredicate, pageable)
             .getContent();


### PR DESCRIPTION
* For en del bedrifter tar det alt for lang tid å hente avtalene som vises på min-side-arbeidsigver.
En av grunnene er at vi ikke har hatt noe begrensning på henting av eldre avtaler. Derfor er det lurt å ha samme begrensning som vi har for oversikten.