### PR TITLE
feat. deprecate redusert lonnstilskudd

### DIFF
--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/Avtale.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/Avtale.java
@@ -93,6 +93,7 @@ import no.nav.tag.tiltaksgjennomforing.satser.Sats;
 import no.nav.tag.tiltaksgjennomforing.tilskuddsperiode.beregning.BeregningStrategy;
 import no.nav.tag.tiltaksgjennomforing.tilskuddsperiode.beregning.EndreTilskuddsberegning;
 import no.nav.tag.tiltaksgjennomforing.utils.Now;
+import no.nav.tag.tiltaksgjennomforing.utils.Periode;
 import no.nav.tag.tiltaksgjennomforing.utils.TelefonnummerValidator;
 import no.nav.tag.tiltaksgjennomforing.utils.Utils;
 import no.nav.team_tiltak.felles.persondata.pdl.domene.Navn;
@@ -1069,7 +1070,7 @@ public class Avtale extends AbstractAggregateRoot<Avtale> implements AuditerbarE
         tilskuddPeriode.stream().filter(t -> t.getStatus() == TilskuddPeriodeStatus.UBEHANDLET)
             .forEach(t -> {
                 t.setBeløp(beregnTilskuddsbeløpForPeriode(t.getStartDato(), t.getSluttDato()));
-                t.setLonnstilskuddProsent(beregnTilskuddsprosentForPeriode(t.getSluttDato()));
+                t.setLonnstilskuddProsent(beregnTilskuddsprosentForPeriode(t.getStartDato(), t.getSluttDato()));
             });
     }
 
@@ -1089,17 +1090,12 @@ public class Avtale extends AbstractAggregateRoot<Avtale> implements AuditerbarE
         }
     }
 
-    protected Integer beregnTilskuddsprosentForPeriode(LocalDate sluttDato) {
-        return BeregningStrategy.tilskuddprosentForPeriode(
-            sluttDato,
-            tiltakstype,
-            gjeldendeInnhold.getDatoForRedusertProsent(),
-            gjeldendeInnhold.getLonnstilskuddProsent()
-        );
+    Integer beregnTilskuddsprosentForPeriode(LocalDate startdato, LocalDate sluttdato) {
+        return this.hentBeregningStrategi().getProsentForPeriode(this, Periode.av(startdato, sluttdato));
     }
 
-    protected Integer beregnTilskuddsbeløpForPeriode(LocalDate startDato, LocalDate sluttDato) {
-        return this.hentBeregningStrategi().beregnTilskuddsbeløpForPeriode(this, startDato, sluttDato);
+    Integer beregnTilskuddsbeløpForPeriode(LocalDate startdato, LocalDate sluttdato) {
+        return this.hentBeregningStrategi().getBeløpForPeriode(this, Periode.av(startdato, sluttdato));
     }
 
     private void nyeTilskuddsperioder() {
@@ -1235,8 +1231,7 @@ public class Avtale extends AbstractAggregateRoot<Avtale> implements AuditerbarE
         if (Tiltakstype.VTAO.equals(tiltakstype)) {
             Optional.ofNullable(Sats.VTAO_SATS.hentGjeldendeSats(nyUbehandletPeriode.getStartDato()))
                 .ifPresent(sats -> nyUbehandletPeriode.setBeløp(BeregningStrategy.beløpForPeriode(
-                    nyUbehandletPeriode.getStartDato(),
-                    nyUbehandletPeriode.getSluttDato(),
+                    nyUbehandletPeriode.getPeriode(),
                     sats
                 )));
         }
@@ -1422,30 +1417,6 @@ public class Avtale extends AbstractAggregateRoot<Avtale> implements AuditerbarE
             gjeldendeInnhold.getOtpSats()
         )) {
             getGjeldendeInnhold().reberegnLønnstilskudd();
-            return;
-        }
-        throw new FeilkodeException(Feilkode.KAN_IKKE_REBEREGNE);
-    }
-
-    public void reUtregnRedusert() {
-        sjekkAtIkkeAvtaleErAnnullert();
-        krevEnAvTiltakstyper(
-            Tiltakstype.MIDLERTIDIG_LONNSTILSKUDD,
-            Tiltakstype.VARIG_LONNSTILSKUDD,
-            Tiltakstype.SOMMERJOBB
-        );
-        if (Utils.erIkkeTomme(
-            gjeldendeInnhold.getStartDato(),
-            gjeldendeInnhold.getSluttDato(),
-            gjeldendeInnhold.getSumLonnstilskudd(),
-            gjeldendeInnhold.getLonnstilskuddProsent(),
-            gjeldendeInnhold.getArbeidsgiveravgift(),
-            gjeldendeInnhold.getFeriepengesats(),
-            gjeldendeInnhold.getManedslonn(),
-            gjeldendeInnhold.getOtpSats()
-        )) {
-
-            getGjeldendeInnhold().reberegnRedusertProsentOgRedusertLonnstilskudd();
             return;
         }
         throw new FeilkodeException(Feilkode.KAN_IKKE_REBEREGNE);

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleInnhold.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleInnhold.java
@@ -111,7 +111,9 @@ public class AvtaleInnhold {
     private Integer sumLonnsutgifter;
     private Integer sumLonnstilskudd;
     private Integer manedslonn100pst;
+    @Deprecated
     private Integer sumLønnstilskuddRedusert;
+    @Deprecated
     private LocalDate datoForRedusertProsent;
     @Enumerated(EnumType.STRING)
     private Stillingstype stillingstype;
@@ -202,11 +204,7 @@ public class AvtaleInnhold {
     }
 
     void endreAvtale(EndreAvtale nyAvtale) {
-        if (tiltakstypeHarFastsattLonnstilskuddsprosentsatsUtIfraKvalifiseringsgruppe()) {
-            innholdStrategi().endreAvtaleInnholdMedKvalifiseringsgruppe(nyAvtale, avtale.getKvalifiseringsgruppe());
-        } else {
-            innholdStrategi().endre(nyAvtale);
-        }
+        innholdStrategi().endre(nyAvtale);
     }
 
     public Set<String> felterSomIkkeErFyltUt() {
@@ -221,25 +219,12 @@ public class AvtaleInnhold {
         return AvtaleInnholdStrategyFactory.create(this, avtale.getTiltakstype());
     }
 
-    private boolean tiltakstypeHarFastsattLonnstilskuddsprosentsatsUtIfraKvalifiseringsgruppe() {
-        // Midlertidig skrudd av utleding av lønnstilskuddprosent for Sommerjobb fra kvalifiseringsgruppe for å åpne for etterregistrering.
-        return avtale.getTiltakstype() == Tiltakstype.MIDLERTIDIG_LONNSTILSKUDD;
-    }
-
-    public boolean skalJournalfores() {
-        return this.godkjentAvVeileder != null && this.getJournalpostId() == null;
-    }
-
     public void endreTilskuddsberegning(EndreTilskuddsberegning tilskuddsberegning) {
         innholdStrategi().endreTilskuddsberegning(tilskuddsberegning);
     }
 
     public void reberegnLønnstilskudd() {
         avtale.hentBeregningStrategi().reberegnTotal(avtale);
-    }
-
-    public void reberegnRedusertProsentOgRedusertLonnstilskudd() {
-        innholdStrategi().reUtregnRedusertProsentOgSum();
     }
 
     public void endreKontaktInfo(EndreKontaktInformasjon endreKontaktInformasjon) {

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleInnholdStrategy.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleInnholdStrategy.java
@@ -1,6 +1,5 @@
 package no.nav.tag.tiltaksgjennomforing.avtale;
 
-import no.nav.tag.tiltaksgjennomforing.enhet.Kvalifiseringsgruppe;
 import no.nav.tag.tiltaksgjennomforing.tilskuddsperiode.beregning.EndreTilskuddsberegning;
 
 import java.time.LocalDate;
@@ -11,9 +10,7 @@ public interface AvtaleInnholdStrategy {
     default void endreTilskuddsberegning(EndreTilskuddsberegning endreTilskuddsberegning) {
         throw new RuntimeException("Ikke implementert");
     }
-    default void endreAvtaleInnholdMedKvalifiseringsgruppe(EndreAvtale endreAvtale, Kvalifiseringsgruppe kvalifiseringsgruppe) {}
 
-    default void reUtregnRedusertProsentOgSum() {}
     Map<String, Object> alleFelterSomMåFyllesUt();
 
     void endreSluttDato(LocalDate nySluttDato);

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleRepository.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleRepository.java
@@ -82,9 +82,6 @@ public interface AvtaleRepository extends JpaRepository<Avtale, UUID>, JpaSpecif
     List<Avtale> findAllByTiltakstype(Tiltakstype tiltakstype);
 
     @Timed(percentiles = {0.5d, 0.75d, 0.9d, 0.99d, 0.999d})
-    List<Avtale> findAllByTiltakstypeAndGjeldendeInnhold_DatoForRedusertProsentNullAndGjeldendeInnhold_AvtaleInngåttNotNull(Tiltakstype tiltakstype);
-
-    @Timed(percentiles = {0.5d, 0.75d, 0.9d, 0.99d, 0.999d})
     @Override
     List<Avtale> findAll();
 

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/FirearigLonnstilskuddAvtaleInnholdStrategy.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/FirearigLonnstilskuddAvtaleInnholdStrategy.java
@@ -9,8 +9,8 @@ public class FirearigLonnstilskuddAvtaleInnholdStrategy extends LonnstilskuddAvt
 
     @Override
     public void endre(EndreAvtale endreAvtale) {
-        Integer lonstilskuddprosentVedStart = beregningStrategy.getProsentForForstePeriode();
-        avtaleInnhold.setLonnstilskuddProsent(lonstilskuddprosentVedStart);
+        Integer lonnstilskuddprosentVedStart = beregningStrategy.getProsentForForstePeriode();
+        avtaleInnhold.setLonnstilskuddProsent(lonnstilskuddprosentVedStart);
         super.endre(endreAvtale);
     }
 }

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/FirearigLonnstilskuddAvtaleInnholdStrategy.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/FirearigLonnstilskuddAvtaleInnholdStrategy.java
@@ -6,4 +6,11 @@ public class FirearigLonnstilskuddAvtaleInnholdStrategy extends LonnstilskuddAvt
     public FirearigLonnstilskuddAvtaleInnholdStrategy(AvtaleInnhold avtaleInnhold) {
         super(avtaleInnhold, new FirearigLonnstilskuddBeregningStrategy());
     }
+
+    @Override
+    public void endre(EndreAvtale endreAvtale) {
+        Integer lonstilskuddprosentVedStart = beregningStrategy.getProsentForForstePeriode();
+        avtaleInnhold.setLonnstilskuddProsent(lonstilskuddprosentVedStart);
+        super.endre(endreAvtale);
+    }
 }

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/MidlertidigLonnstilskuddAvtaleInnholdStrategy.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/MidlertidigLonnstilskuddAvtaleInnholdStrategy.java
@@ -1,12 +1,6 @@
 package no.nav.tag.tiltaksgjennomforing.avtale;
 
-import no.nav.tag.tiltaksgjennomforing.enhet.Kvalifiseringsgruppe;
-import no.nav.tag.tiltaksgjennomforing.exceptions.FeilLonnstilskuddsprosentException;
 import no.nav.tag.tiltaksgjennomforing.tilskuddsperiode.beregning.MidlertidigLonnstilskuddAvtaleBeregningStrategy;
-
-import java.time.LocalDate;
-
-import static no.nav.tag.tiltaksgjennomforing.tilskuddsperiode.beregning.MidlertidigLonnstilskuddAvtaleBeregningStrategy.TILSKUDDSPROSENT_TILPASSET;
 
 public class MidlertidigLonnstilskuddAvtaleInnholdStrategy extends LonnstilskuddAvtaleInnholdStrategy<MidlertidigLonnstilskuddAvtaleBeregningStrategy> {
     public MidlertidigLonnstilskuddAvtaleInnholdStrategy(AvtaleInnhold avtaleInnhold) {
@@ -14,54 +8,11 @@ public class MidlertidigLonnstilskuddAvtaleInnholdStrategy extends Lonnstilskudd
     }
 
     @Override
-    public void endreAvtaleInnholdMedKvalifiseringsgruppe(EndreAvtale endreAvtale, Kvalifiseringsgruppe kvalifiseringsgruppe) {
-        if (kvalifiseringsgruppe != null) {
-            settTilskuddsprosentSats(kvalifiseringsgruppe);
-            this.endre(endreAvtale);
-        } else {
-            sjekktilskuddsprosentSats(endreAvtale);
-            super.endre(endreAvtale);
-        }
-    }
-
-    @Override
     public void endre(EndreAvtale endreAvtale) {
-        sjekktilskuddsprosentSats(endreAvtale);
+        Avtale avtale = avtaleInnhold.getAvtale();
+        Integer lonstilskuddprosentVedStart = beregningStrategy.getProsentForForstePeriode(avtale);
+        avtaleInnhold.setLonnstilskuddProsent(lonstilskuddprosentVedStart);
         super.endre(endreAvtale);
     }
 
-    @Override
-    public void regnUtTotalLonnstilskudd() {
-        Avtale avtale = this.avtaleInnhold.getAvtale();
-        beregningStrategy.reberegnTotal(avtale);
-    }
-
-    private void sjekktilskuddsprosentSats(EndreAvtale endreAvtale) {
-        Integer lonnstilskuddProsent = endreAvtale.getLonnstilskuddProsent();
-        if (lonnstilskuddProsent == null) {
-            return;
-        }
-        if (lonnstilskuddProsent != MidlertidigLonnstilskuddAvtaleBeregningStrategy.TILSKUDDSPROSENT && lonnstilskuddProsent != TILSKUDDSPROSENT_TILPASSET) {
-            throw new FeilLonnstilskuddsprosentException();
-        }
-    }
-
-    private void settTilskuddsprosentSats(Kvalifiseringsgruppe kvalifiseringsgruppe) {
-        final Integer sats = kvalifiseringsgruppe.finnLonntilskuddProsentsatsUtifraKvalifiseringsgruppe(40, 60);
-        avtaleInnhold.setLonnstilskuddProsent(sats);
-    }
-
-    private void regnUtDatoOgSumRedusert() {
-        Avtale avtale = avtaleInnhold.getAvtale();
-        LocalDate datoForRedusertProsent = beregningStrategy.getDatoerForReduksjon(avtale).stream().findFirst().orElse(null);
-        avtaleInnhold.setDatoForRedusertProsent(datoForRedusertProsent);
-        Integer sumLønnstilskuddRedusert = beregningStrategy.regnUtRedusertLønnstilskudd(avtale);
-        avtaleInnhold.setSumLønnstilskuddRedusert(sumLønnstilskuddRedusert);
-    }
-
-    @Override
-    public void endreSluttDato(LocalDate nySluttDato) {
-        super.endreSluttDato(nySluttDato);
-        regnUtDatoOgSumRedusert();
-    }
 }

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/MidlertidigLonnstilskuddAvtaleInnholdStrategy.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/MidlertidigLonnstilskuddAvtaleInnholdStrategy.java
@@ -10,8 +10,8 @@ public class MidlertidigLonnstilskuddAvtaleInnholdStrategy extends Lonnstilskudd
     @Override
     public void endre(EndreAvtale endreAvtale) {
         Avtale avtale = avtaleInnhold.getAvtale();
-        Integer lonstilskuddprosentVedStart = beregningStrategy.getProsentForForstePeriode(avtale);
-        avtaleInnhold.setLonnstilskuddProsent(lonstilskuddprosentVedStart);
+        Integer lonnstilskuddprosentVedStart = beregningStrategy.getProsentForForstePeriode(avtale);
+        avtaleInnhold.setLonnstilskuddProsent(lonnstilskuddprosentVedStart);
         super.endre(endreAvtale);
     }
 

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/SommerjobbAvtaleInnholdStrategy.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/SommerjobbAvtaleInnholdStrategy.java
@@ -1,8 +1,13 @@
 package no.nav.tag.tiltaksgjennomforing.avtale;
 
-import no.nav.tag.tiltaksgjennomforing.enhet.Kvalifiseringsgruppe;
 import no.nav.tag.tiltaksgjennomforing.exceptions.FeilLonnstilskuddsprosentException;
 import no.nav.tag.tiltaksgjennomforing.tilskuddsperiode.beregning.SommerjobbLonnstilskuddAvtaleBeregningStrategy;
+
+import java.util.Map;
+
+import static no.nav.tag.tiltaksgjennomforing.tilskuddsperiode.beregning.SommerjobbLonnstilskuddAvtaleBeregningStrategy.TILSKUDDSPROSENT_MAKS;
+import static no.nav.tag.tiltaksgjennomforing.tilskuddsperiode.beregning.SommerjobbLonnstilskuddAvtaleBeregningStrategy.TILSKUDDSPROSENT_MIN;
+
 
 public class SommerjobbAvtaleInnholdStrategy extends LonnstilskuddAvtaleInnholdStrategy<SommerjobbLonnstilskuddAvtaleBeregningStrategy> {
     public SommerjobbAvtaleInnholdStrategy(AvtaleInnhold avtaleInnhold) {
@@ -10,35 +15,30 @@ public class SommerjobbAvtaleInnholdStrategy extends LonnstilskuddAvtaleInnholdS
     }
 
     @Override
-    public void endreAvtaleInnholdMedKvalifiseringsgruppe(EndreAvtale endreAvtale, Kvalifiseringsgruppe kvalifiseringsgruppe) {
-        if (kvalifiseringsgruppe != null) {
-            final EndreAvtale endreAvtaleMedOppdatertProsentsats = settTilskuddsprosentSats(endreAvtale, kvalifiseringsgruppe);
-            super.endre(endreAvtaleMedOppdatertProsentsats);
-        } else {
-            sjekkSommerjobbProsentsats(endreAvtale);
-            super.endre(endreAvtale);
-        }
+    public Map<String, Object> alleFelterSomMåFyllesUt() {
+        Map<String, Object> felterSomMåFyllesUt = super.alleFelterSomMåFyllesUt();
+        felterSomMåFyllesUt.put(AvtaleInnhold.Fields.lonnstilskuddProsent, avtaleInnhold.getLonnstilskuddProsent());
+        return felterSomMåFyllesUt;
     }
 
     @Override
     public void endre(EndreAvtale endreAvtale) {
+        Integer lonnstilskuddProsent = endreAvtale.getLonnstilskuddProsent();
         endreAvtale.setStillingstype(Stillingstype.MIDLERTIDIG);
-        sjekkSommerjobbProsentsats(endreAvtale);
-        avtaleInnhold.setLonnstilskuddProsent(endreAvtale.getLonnstilskuddProsent());
+
+        if (!erTilskuddsprosentGyldig(lonnstilskuddProsent)) {
+            throw new FeilLonnstilskuddsprosentException();
+        }
+
+        avtaleInnhold.setLonnstilskuddProsent(lonnstilskuddProsent);
         super.endre(endreAvtale);
     }
 
-    private void sjekkSommerjobbProsentsats(EndreAvtale endreAvtale) {
-        Integer lonnstilskuddProsent = endreAvtale.getLonnstilskuddProsent();
-        if (lonnstilskuddProsent != null && !(lonnstilskuddProsent == 75 || lonnstilskuddProsent == 50)) {
-            throw new FeilLonnstilskuddsprosentException();
+    private boolean erTilskuddsprosentGyldig(Integer prosent) {
+        if (prosent == null) {
+            return true;
         }
-    }
-
-    private EndreAvtale settTilskuddsprosentSats(EndreAvtale endreAvtale, Kvalifiseringsgruppe kvalifiseringsgruppe) {
-        final Integer sats = kvalifiseringsgruppe.finnLonntilskuddProsentsatsUtifraKvalifiseringsgruppe(50, 75);
-        endreAvtale.setLonnstilskuddProsent(sats);
-        return endreAvtale;
+        return prosent == TILSKUDDSPROSENT_MAKS || prosent == TILSKUDDSPROSENT_MIN;
     }
 
 }

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/TilskuddPeriode.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/TilskuddPeriode.java
@@ -21,6 +21,7 @@ import lombok.ToString;
 import no.nav.tag.tiltaksgjennomforing.exceptions.Feilkode;
 import no.nav.tag.tiltaksgjennomforing.exceptions.FeilkodeException;
 import no.nav.tag.tiltaksgjennomforing.utils.Now;
+import no.nav.tag.tiltaksgjennomforing.utils.Periode;
 import org.apache.commons.lang3.builder.CompareToBuilder;
 import org.jetbrains.annotations.NotNull;
 
@@ -281,6 +282,10 @@ public class TilskuddPeriode implements Comparable<TilskuddPeriode> {
 
     public boolean erRefusjonGodkjent() {
         return refusjonStatus == RefusjonStatus.SENDT_KRAV || refusjonStatus == RefusjonStatus.GODKJENT_MINUSBELØP || refusjonStatus == RefusjonStatus.GODKJENT_NULLBELØP;
+    }
+
+    public Periode getPeriode() {
+        return Periode.av(startDato, sluttDato);
     }
 
 }

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/VarigLonnstilskuddAvtaleInnholdStrategy.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/VarigLonnstilskuddAvtaleInnholdStrategy.java
@@ -5,6 +5,8 @@ import no.nav.tag.tiltaksgjennomforing.tilskuddsperiode.beregning.VarigLonnstils
 
 import java.util.Map;
 
+import static no.nav.tag.tiltaksgjennomforing.tilskuddsperiode.beregning.VarigLonnstilskuddAvtaleBeregningStrategy.TILSKUDDSPROSENT_MAKS;
+
 public class VarigLonnstilskuddAvtaleInnholdStrategy extends LonnstilskuddAvtaleInnholdStrategy<VarigLonnstilskuddAvtaleBeregningStrategy> {
     public VarigLonnstilskuddAvtaleInnholdStrategy(AvtaleInnhold avtaleInnhold) {
         super(avtaleInnhold, new VarigLonnstilskuddAvtaleBeregningStrategy());
@@ -19,27 +21,21 @@ public class VarigLonnstilskuddAvtaleInnholdStrategy extends LonnstilskuddAvtale
 
     @Override
     public void endre(EndreAvtale endreAvtale) {
-        if (endreAvtale.getLonnstilskuddProsent() != null && (
-            endreAvtale.getLonnstilskuddProsent() < 0 || endreAvtale.getLonnstilskuddProsent() > 75)) {
+        Integer lonnstilskuddProsent = endreAvtale.getLonnstilskuddProsent();
+
+        if (!erTilskuddsprosentGyldig(lonnstilskuddProsent)) {
             throw new FeilLonnstilskuddsprosentException();
         }
-        avtaleInnhold.setLonnstilskuddProsent(endreAvtale.getLonnstilskuddProsent());
+
+        avtaleInnhold.setLonnstilskuddProsent(lonnstilskuddProsent);
         super.endre(endreAvtale);
     }
 
-    @Override
-    public void regnUtTotalLonnstilskudd() {
-        Avtale avtale = avtaleInnhold.getAvtale();
-        beregningStrategy.reberegnTotal(avtale);
-    }
-
-    @Override
-    public void reUtregnRedusertProsentOgSum() {
-        regnUtDatoOgSumRedusert();
-    }
-
-    private void regnUtDatoOgSumRedusert() {
-        beregningStrategy.regnUtDatoOgSumRedusert(avtaleInnhold.getAvtale());
+    private boolean erTilskuddsprosentGyldig(Integer prosent) {
+        if (prosent == null) {
+            return true;
+        }
+        return prosent >= 0 && prosent <= TILSKUDDSPROSENT_MAKS;
     }
 
 }

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/admin/AdminController.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/admin/AdminController.java
@@ -57,7 +57,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
 import static no.nav.tag.tiltaksgjennomforing.satser.Sats.VTAO_SATS;
@@ -85,53 +84,6 @@ public class AdminController {
             avtale.reberegnLønnstilskudd();
             avtaleRepository.save(avtale);
         }
-    }
-
-    @PostMapping("/reberegn-mangler-dato-for-redusert-prosent/{migreringsDato}")
-    @Transactional
-    public void reberegnVarigLønnstilskuddSomIkkeHarRedusertDato(@PathVariable @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate migreringsDato) {
-        log.info("Starter jobb for å fikse manglende redusert prosent og redusert sum");
-        // 1. Generer dato for redusert prosent og sumRedusert
-        List<Avtale> varigeLønnstilskudd = avtaleRepository.findAllByTiltakstypeAndGjeldendeInnhold_DatoForRedusertProsentNullAndGjeldendeInnhold_AvtaleInngåttNotNull(
-            Tiltakstype.VARIG_LONNSTILSKUDD);
-        log.info("Fant {} varige lønnstilskudd avtaler som mangler redusert prosent til fiksing.", varigeLønnstilskudd.size());
-        AtomicInteger antallUnder67 = new AtomicInteger();
-        varigeLønnstilskudd.forEach(avtale -> {
-            LocalDate startDato = avtale.getGjeldendeInnhold().getStartDato();
-            LocalDate sluttDato = avtale.getGjeldendeInnhold().getSluttDato();
-            if (avtale.getGjeldendeInnhold().getLonnstilskuddProsent() > 67
-                    && startDato.isBefore(sluttDato.minusMonths(12))
-                    && !Status.ANNULLERT.equals(avtale.getStatus())
-                    && avtale.getGjeldendeInnhold().getSumLonnstilskudd() != null) {
-
-                avtale.reUtregnRedusert();
-                avtale.nyeTilskuddsperioderEtterMigreringFraArena(migreringsDato);
-                avtaleRepository.save(avtale);
-                antallUnder67.getAndIncrement();
-            }
-        });
-        log.info("Ferdig kjørt reberegning av fiks for manglende redusert prosent og redusert sum på {} avtaler", antallUnder67);
-    }
-
-    @PostMapping("/reberegn-mangler-dato-for-redusert-prosent-dry-run/{migreringsDato}")
-    public void reberegnVarigLønnstilskuddSomIkkeHarRedusertDatoDryRun(@PathVariable @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate migreringsDato) {
-        log.info("DRY-RUN: Starter DRY-RUN jobb for å fikse manglende redusert prosent og redusert sum");
-        // 1. Generer dato for redusert prosent og sumRedusert
-        List<Avtale> varigeLønnstilskudd = avtaleRepository.findAllByTiltakstypeAndGjeldendeInnhold_DatoForRedusertProsentNullAndGjeldendeInnhold_AvtaleInngåttNotNull(Tiltakstype.VARIG_LONNSTILSKUDD);
-        log.info("DRY-RUN: Fant {} varige lønnstilskudd avtaler som mangler redusert prosent til fiksing.", varigeLønnstilskudd.size());
-        AtomicInteger antallUnder67 = new AtomicInteger();
-        varigeLønnstilskudd.forEach(avtale -> {
-            LocalDate startDato = avtale.getGjeldendeInnhold().getStartDato();
-            LocalDate sluttDato = avtale.getGjeldendeInnhold().getSluttDato();
-
-            if (avtale.getGjeldendeInnhold().getLonnstilskuddProsent() > 67
-                    && startDato.isBefore(sluttDato.minusMonths(12))
-                    && !Status.ANNULLERT.equals(avtale.getStatus())
-                    && avtale.getGjeldendeInnhold().getSumLonnstilskudd() != null) {
-                antallUnder67.getAndIncrement();
-            }
-        });
-        log.info("DRY-RUN: Fant {} avtaler som vil bli kjørt fiksing av redusert sum og sats på", antallUnder67.get());
     }
 
     @PostMapping("/annuller-tilskuddsperiode/{tilskuddsperiodeId}")
@@ -330,13 +282,10 @@ public class AdminController {
             kjenteVtaoSatsAar
         );
 
-        perioderUtenBelop.forEach(tp -> {
-            tp.setBeløp(BeregningStrategy.beløpForPeriode(
-                tp.getStartDato(),
-                tp.getSluttDato(),
-                VTAO_SATS.hentGjeldendeSats(tp.getStartDato())
-            ));
-        });
+        perioderUtenBelop.forEach(tp -> tp.setBeløp(BeregningStrategy.beløpForPeriode(
+            tp.getPeriode(),
+            VTAO_SATS.hentGjeldendeSats(tp.getStartDato())
+        )));
         tilskuddPeriodeRepository.saveAll(perioderUtenBelop);
     }
 

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/transportlag/AvtaleInnholdDTO.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/transportlag/AvtaleInnholdDTO.java
@@ -75,8 +75,6 @@ public record AvtaleInnholdDTO(
     Integer sumLonnsutgifter,
     Integer sumLonnstilskudd,
     Integer manedslonn100pst,
-    Integer sumLønnstilskuddRedusert,
-    LocalDate datoForRedusertProsent,
     Stillingstype stillingstype,
     List<TilskuddstrinnDTO> tilskuddstrinn,
 
@@ -158,8 +156,6 @@ public record AvtaleInnholdDTO(
             dbEntitet.getSumLonnsutgifter(),
             dbEntitet.getSumLonnstilskudd(),
             dbEntitet.getManedslonn100pst(),
-            dbEntitet.getSumLønnstilskuddRedusert(),
-            dbEntitet.getDatoForRedusertProsent(),
             dbEntitet.getStillingstype(),
             TilskuddstrinnDTO.map(dbEntitet),
             MaalDTO.map(dbEntitet),

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/datadeling/AvtaleMelding.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/datadeling/AvtaleMelding.java
@@ -110,7 +110,9 @@ public class AvtaleMelding {
     Integer sumLonnsutgifter;
     Integer sumLonnstilskudd;
     Integer manedslonn100pst;
+    @Deprecated
     Integer sumLønnstilskuddRedusert;
+    @Deprecated
     LocalDate datoForRedusertProsent;
     Stillingstype stillingstype;
 
@@ -216,8 +218,8 @@ public class AvtaleMelding {
         avtaleMelding.setSumLonnsutgifter(avtaleInnhold.getSumLonnsutgifter());
         avtaleMelding.setSumLonnstilskudd(avtaleInnhold.getSumLonnstilskudd());
         avtaleMelding.setManedslonn100pst(avtaleInnhold.getManedslonn100pst());
-        avtaleMelding.setSumLønnstilskuddRedusert(avtaleInnhold.getSumLønnstilskuddRedusert());
-        avtaleMelding.setDatoForRedusertProsent(avtaleInnhold.getDatoForRedusertProsent());
+        avtaleMelding.setSumLønnstilskuddRedusert(null);
+        avtaleMelding.setDatoForRedusertProsent(null);
         avtaleMelding.setStillingstype(avtaleInnhold.getStillingstype());
         avtaleMelding.setInkluderingstilskuddBegrunnelse(avtaleInnhold.getInkluderingstilskuddBegrunnelse());
         avtaleMelding.setInkluderingstilskuddTotalBeløp(avtaleInnhold.inkluderingstilskuddTotalBeløp());

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/datavarehus/AvroTiltakHendelseFabrikk.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/datavarehus/AvroTiltakHendelseFabrikk.java
@@ -48,8 +48,8 @@ public class AvroTiltakHendelseFabrikk {
         hendelse.setOtpBelop(avtale.getGjeldendeInnhold().getOtpBelop());
         hendelse.setSumLonnsutgifter(avtale.getGjeldendeInnhold().getSumLonnsutgifter());
         hendelse.setSumLonnstilskudd(avtale.getGjeldendeInnhold().getSumLonnstilskudd());
-        hendelse.setSumLonnstilskuddRedusert(avtale.getGjeldendeInnhold().getSumLønnstilskuddRedusert());
-        hendelse.setDatoForRedusertProsent(avtale.getGjeldendeInnhold().getDatoForRedusertProsent());
+        hendelse.setSumLonnstilskuddRedusert(null);
+        hendelse.setDatoForRedusertProsent(null);
         hendelse.setGodkjentPaVegneAv(avtale.getGjeldendeInnhold().isGodkjentPaVegneAv());
         hendelse.setIkkeBankId(avtale.getGjeldendeInnhold().getGodkjentPaVegneGrunn() != null && avtale.getGjeldendeInnhold().getGodkjentPaVegneGrunn().isIkkeBankId());
         hendelse.setReservert(avtale.getGjeldendeInnhold().getGodkjentPaVegneGrunn() != null && avtale.getGjeldendeInnhold().getGodkjentPaVegneGrunn().isReservert());

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/tilskuddsperiode/beregning/BeregningStrategy.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/tilskuddsperiode/beregning/BeregningStrategy.java
@@ -11,7 +11,6 @@ import java.math.MathContext;
 import java.math.RoundingMode;
 import java.time.LocalDate;
 import java.time.Period;
-import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
@@ -23,9 +22,7 @@ import static no.nav.tag.tiltaksgjennomforing.utils.Utils.erIkkeTomme;
 import static no.nav.tag.tiltaksgjennomforing.utils.Utils.fikseLøpenumre;
 
 public interface BeregningStrategy {
-
     BigDecimal DAGER_I_MÅNED = new BigDecimal("30.4375");
-    int ANTALL_MÅNEDER_I_EN_PERIODE = 1;
 
     List<TilskuddPeriode> genererNyeTilskuddsperioder(Avtale avtale);
     void endreBeregning(Avtale avtale, EndreTilskuddsberegning endreTilskuddsberegning);
@@ -41,7 +38,7 @@ public interface BeregningStrategy {
             case MIDLERTIDIG_LONNSTILSKUDD -> new MidlertidigLonnstilskuddAvtaleBeregningStrategy();
             case VARIG_LONNSTILSKUDD -> new VarigLonnstilskuddAvtaleBeregningStrategy();
             case SOMMERJOBB -> new SommerjobbLonnstilskuddAvtaleBeregningStrategy();
-            case VTAO -> new VTAOLonnstilskuddAvtaleBeregningStrategy();
+            case VTAO -> new VTAOAvtaleBeregningStrategy();
             case FIREARIG_LONNSTILSKUDD -> new FirearigLonnstilskuddBeregningStrategy();
         };
     }
@@ -73,14 +70,12 @@ public interface BeregningStrategy {
         }
     }
 
-    default Integer beregnTilskuddsbeløpForPeriode(Avtale avtale, LocalDate startDato, LocalDate sluttDato) {
-        return beløpForPeriode(
-                startDato,
-                sluttDato,
-                avtale.getGjeldendeInnhold().getDatoForRedusertProsent(),
-                avtale.getGjeldendeInnhold().getSumLonnstilskudd(),
-                avtale.getGjeldendeInnhold().getSumLønnstilskuddRedusert()
-        );
+    default Integer getBeløpForPeriode(Avtale avtale, Periode periode) {
+        return 0;
+    }
+
+    default Integer getProsentForPeriode(Avtale avtale, Periode periode) {
+        return null;
     }
 
     static BigDecimal getFeriepengerBelop(BigDecimal feriepengersats, Integer manedslonn) {
@@ -89,24 +84,28 @@ public interface BeregningStrategy {
         }
         return null;
     }
+
     static BigDecimal getFeriepengerBelop(BigDecimal feriepengersats, Double manedslonn) {
         if (erIkkeTomme(feriepengersats, manedslonn)) {
             return (feriepengersats.multiply(BigDecimal.valueOf(manedslonn)));
         }
         return null;
     }
+
     static BigDecimal getBeregnetOtpBelop(BigDecimal optSats, Integer manedslonn, BigDecimal feriepenger) {
         if (erIkkeTomme(optSats, manedslonn, feriepenger)) {
             return (optSats.multiply(BigDecimal.valueOf(manedslonn).add(feriepenger)));
         }
         return null;
     }
+
     static BigDecimal getBeregnetOtpBelop(BigDecimal optSats, Double manedslonn, BigDecimal feriepenger) {
         if (erIkkeTomme(optSats, manedslonn, feriepenger)) {
             return (optSats.multiply(BigDecimal.valueOf(manedslonn).add(feriepenger)));
         }
         return null;
     }
+
     static BigDecimal getArbeidsgiverAvgift(
         Integer manedslonn,
         BigDecimal feriepengerBelop,
@@ -167,72 +166,12 @@ public interface BeregningStrategy {
         return (int) Math.round(sumLonnsutgifter * lonnstilskuddProsentSomDecimal);
     }
 
-     static Integer tilskuddprosentForPeriode(LocalDate datoTilOgMed, Tiltakstype tiltakstype, LocalDate datoForRedusertProsent, Integer lonnstilskuddprosent) {
-        if (datoForRedusertProsent == null || datoTilOgMed.isBefore(datoForRedusertProsent)) {
-            return lonnstilskuddprosent;
-        }
-        return getRedusertLonnstilskuddprosent(tiltakstype, lonnstilskuddprosent);
-    }
-
-    static int getRedusertLonnstilskuddprosent(Tiltakstype tiltakstype, Integer lonnstilskuddprosent) {
-        if (!Tiltakstype.VARIG_LONNSTILSKUDD.equals(tiltakstype)){
-            return lonnstilskuddprosent - 10;
-        }
-        if (lonnstilskuddprosent > VarigLonnstilskuddAvtaleBeregningStrategy.TILSKUDDSPROSENT_REDUSERT_MAKS) {
-            return VarigLonnstilskuddAvtaleBeregningStrategy.TILSKUDDSPROSENT_REDUSERT_MAKS;
-        }
-        return lonnstilskuddprosent;
-    }
-
-    static Integer beløpForPeriode(LocalDate datoFraOgMed, LocalDate datoTilOgMed, LocalDate datoForRedusertProsent, Integer tilskuddPerMåned, Integer sumLønnstilskuddPerMånedRedusert) {
-        if (datoForRedusertProsent == null || datoTilOgMed.isBefore(datoForRedusertProsent)) {
-            return beløpForPeriode(datoFraOgMed, datoTilOgMed, tilskuddPerMåned);
-        } else {
-            return beløpForPeriode(datoFraOgMed, datoTilOgMed, sumLønnstilskuddPerMånedRedusert);
-        }
-    }
-
-    static Integer beløpForPeriode(LocalDate fra, LocalDate til, Integer tilskuddPerMåned) {
-        Period period = Period.between(fra, til.plusDays(1));
+    static Integer beløpForPeriode(Periode periode, Integer tilskuddPerMåned) {
+        Period period = Period.between(periode.getStart(), periode.getSlutt().plusDays(1));
         Integer sumHeleMåneder = period.getMonths() * tilskuddPerMåned;
         BigDecimal dagsats = new BigDecimal(tilskuddPerMåned).divide(DAGER_I_MÅNED, 10, RoundingMode.HALF_UP);
         Integer sumEnkeltdager = dagsats.multiply(BigDecimal.valueOf(period.getDays()), MathContext.UNLIMITED).setScale(0, RoundingMode.HALF_UP).intValue();
         return sumHeleMåneder + sumEnkeltdager;
-    }
-
-    static List<Periode> lagPeriode(LocalDate datoFraOgMed, LocalDate datoTilOgMed) {
-        if (datoFraOgMed.isAfter(datoTilOgMed)) {
-            return List.of();
-        }
-        List<LocalDate> startDatoer = datoFraOgMed.datesUntil(datoTilOgMed.plusDays(1), Period.ofMonths(ANTALL_MÅNEDER_I_EN_PERIODE)).toList();
-        ArrayList<Periode> datoPar = new ArrayList<>();
-        for (LocalDate localDate : startDatoer) {
-            // fra: Hvis startdato er lik datoFraOgMed, bruk denne, hvis ikke, bruk første datoen i mnd.
-            LocalDate fra = localDate.equals(datoFraOgMed) ? localDate : førsteDatoIMnd(localDate);
-            // til: Hvis siste dag i mnd. er mindre enn datoTilOgMed, bruk siste dag i mnd, ellers bruk datoTilOgMed
-            LocalDate til = sisteDatoIMnd(localDate).isBefore(datoTilOgMed) ? sisteDatoIMnd(localDate) : datoTilOgMed;
-
-            datoPar.addAll(splittHvisNyttÅr(fra, til));
-        }
-        // Legg til siste periode hvis den ikke kom med i loopen
-        if (datoPar.getLast().getSlutt() != datoTilOgMed) {
-            datoPar.addAll(splittHvisNyttÅr(førsteDatoIMnd(datoTilOgMed), datoTilOgMed));
-        }
-        return datoPar;
-    }
-
-    private static LocalDate førsteDatoIMnd(LocalDate dato) {
-        return LocalDate.of(dato.getYear(), dato.getMonth(), 1);
-    }
-
-    private static List<Periode> splittHvisNyttÅr (LocalDate fraDato, LocalDate tilDato) {
-        if (fraDato.getYear() != tilDato.getYear()) { //TODO IKKE I BRUK i Koden (også før refatktorisering)
-            Periode datoPar1 = new Periode(fraDato, fraDato.withMonth(12).withDayOfMonth(31)); //TODO IKKE TESTET
-            Periode datoPar2 = new Periode(tilDato.withMonth(1).withDayOfMonth(1), tilDato); //TODO IKKE TESTET
-            return List.of(datoPar1, datoPar2);//TODO IKKE TESTET
-        } else {
-            return List.of(new Periode(fraDato, tilDato));
-        }
     }
 
     static void settBehandletIArena(LocalDate migreringsdato, List<TilskuddPeriode> tilskuddPeriode) {

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/tilskuddsperiode/beregning/FirearigLonnstilskuddBeregningStrategy.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/tilskuddsperiode/beregning/FirearigLonnstilskuddBeregningStrategy.java
@@ -8,15 +8,19 @@ import java.util.Collections;
 import java.util.List;
 
 public class FirearigLonnstilskuddBeregningStrategy extends GenerellLonnstilskuddAvtaleBeregningStrategy {
-    private static final int TILSKUDDSPROSENT_FORSTE_AAR = 70;
-    private static final int TILSKUDDSPROSENT_ANDRE_AAR = 60;
-    private static final int TILSKUDDSPROSENT_TREDJE_AAR = 50;
-    private static final int TILSKUDDSPROSENT_FJERDE_AAR = 35;
+    public static final int TILSKUDDSPROSENT_FORSTE_AAR = 70;
+    public static final int TILSKUDDSPROSENT_ANDRE_AAR = 60;
+    public static final int TILSKUDDSPROSENT_TREDJE_AAR = 50;
+    public static final int TILSKUDDSPROSENT_FJERDE_AAR = 35;
+
+    public Integer getProsentForForstePeriode() {
+        return TILSKUDDSPROSENT_FORSTE_AAR;
+    }
 
     @Override
-    public Integer getProsentForPeriode(Avtale avtale, Periode tilskuddsperiode) {
+    public Integer getProsentForPeriode(Avtale avtale, Periode periode) {
         LocalDate avtaleStart = avtale.getGjeldendeInnhold().getStartDato();
-        LocalDate tilskuddSlutt = tilskuddsperiode.getSlutt();
+        LocalDate tilskuddSlutt = periode.getSlutt();
 
         if (tilskuddSlutt.isBefore(avtaleStart.plusYears(1))) {
             return TILSKUDDSPROSENT_FORSTE_AAR;

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/tilskuddsperiode/beregning/FirearigLonnstilskuddBeregningStrategy.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/tilskuddsperiode/beregning/FirearigLonnstilskuddBeregningStrategy.java
@@ -8,10 +8,10 @@ import java.util.Collections;
 import java.util.List;
 
 public class FirearigLonnstilskuddBeregningStrategy extends GenerellLonnstilskuddAvtaleBeregningStrategy {
-    public static final int TILSKUDDSPROSENT_FORSTE_AAR = 70;
-    public static final int TILSKUDDSPROSENT_ANDRE_AAR = 60;
-    public static final int TILSKUDDSPROSENT_TREDJE_AAR = 50;
-    public static final int TILSKUDDSPROSENT_FJERDE_AAR = 35;
+    private static final int TILSKUDDSPROSENT_FORSTE_AAR = 70;
+    private static final int TILSKUDDSPROSENT_ANDRE_AAR = 60;
+    private static final int TILSKUDDSPROSENT_TREDJE_AAR = 50;
+    private static final int TILSKUDDSPROSENT_FJERDE_AAR = 35;
 
     public Integer getProsentForForstePeriode() {
         return TILSKUDDSPROSENT_FORSTE_AAR;

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/tilskuddsperiode/beregning/GenerellLonnstilskuddAvtaleBeregningStrategy.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/tilskuddsperiode/beregning/GenerellLonnstilskuddAvtaleBeregningStrategy.java
@@ -38,9 +38,9 @@ public abstract class GenerellLonnstilskuddAvtaleBeregningStrategy implements Be
         );
         if (avtale.getArenaRyddeAvtale() != null) {
             LocalDate standardMigreringsdato = LocalDate.of(2023, 2, 1);
-            LocalDate migreringsdato = avtale.getArenaRyddeAvtale()
-                .getMigreringsdato() != null ? avtale.getArenaRyddeAvtale()
-                .getMigreringsdato() : standardMigreringsdato;
+            LocalDate migreringsdato = avtale.getArenaRyddeAvtale().getMigreringsdato() != null
+                ? avtale.getArenaRyddeAvtale().getMigreringsdato()
+                : standardMigreringsdato;
 
             BeregningStrategy.settBehandletIArena(migreringsdato, tilskuddsperioder);
         }
@@ -141,9 +141,13 @@ public abstract class GenerellLonnstilskuddAvtaleBeregningStrategy implements Be
     @Override
     public Integer getBeløpForPeriode(Avtale avtale, Periode periode) {
         Integer prosentForPeriode = getProsentForPeriode(avtale, periode);
+        return getBeløpForPeriode(avtale, prosentForPeriode, periode);
+    }
+
+    private Integer getBeløpForPeriode(Avtale avtale, Integer prosent, Periode periode) {
         Integer lonnstilskudd = BeregningStrategy.getSumLonnstilskudd(
             avtale.getGjeldendeInnhold().getSumLonnsutgifter(),
-            prosentForPeriode
+            prosent
         );
         return BeregningStrategy.beløpForPeriode(periode, lonnstilskudd);
     }
@@ -174,8 +178,8 @@ public abstract class GenerellLonnstilskuddAvtaleBeregningStrategy implements Be
     }
 
     TilskuddPeriode lagTilskuddsperiode(Avtale avtale, Periode periode) {
-        Integer beløp = getBeløpForPeriode(avtale, periode);
         Integer prosent = getProsentForPeriode(avtale, periode);
+        Integer beløp = getBeløpForPeriode(avtale, prosent, periode);
         TilskuddPeriode tilskuddsperiode = new TilskuddPeriode(
             beløp,
             periode.getStart(),

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/tilskuddsperiode/beregning/GenerellLonnstilskuddAvtaleBeregningStrategy.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/tilskuddsperiode/beregning/GenerellLonnstilskuddAvtaleBeregningStrategy.java
@@ -18,7 +18,6 @@ import static no.nav.tag.tiltaksgjennomforing.utils.Utils.fikseLøpenumre;
 import static no.nav.tag.tiltaksgjennomforing.utils.Utils.toBigDecimal;
 
 public abstract class GenerellLonnstilskuddAvtaleBeregningStrategy implements BeregningStrategy {
-    public abstract Integer getProsentForPeriode(Avtale avtale, Periode periode);
     public abstract List<LocalDate> getDatoerForReduksjon(Avtale avtale);
 
     @Override
@@ -32,10 +31,16 @@ public abstract class GenerellLonnstilskuddAvtaleBeregningStrategy implements Be
             return Collections.emptyList();
         }
 
-        List<TilskuddPeriode> tilskuddsperioder = beregnTilskuddsperioderForAvtale(avtale, gjeldendeInnhold.getStartDato(), gjeldendeInnhold.getSluttDato());
+        List<TilskuddPeriode> tilskuddsperioder = beregnTilskuddsperioderForAvtale(
+            avtale,
+            gjeldendeInnhold.getStartDato(),
+            gjeldendeInnhold.getSluttDato()
+        );
         if (avtale.getArenaRyddeAvtale() != null) {
             LocalDate standardMigreringsdato = LocalDate.of(2023, 2, 1);
-            LocalDate migreringsdato = avtale.getArenaRyddeAvtale().getMigreringsdato() != null ? avtale.getArenaRyddeAvtale().getMigreringsdato() : standardMigreringsdato;
+            LocalDate migreringsdato = avtale.getArenaRyddeAvtale()
+                .getMigreringsdato() != null ? avtale.getArenaRyddeAvtale()
+                .getMigreringsdato() : standardMigreringsdato;
 
             BeregningStrategy.settBehandletIArena(migreringsdato, tilskuddsperioder);
         }
@@ -56,13 +61,33 @@ public abstract class GenerellLonnstilskuddAvtaleBeregningStrategy implements Be
     @Override
     public void reberegnTotal(Avtale avtale) {
         AvtaleInnhold avtaleInnhold = avtale.getGjeldendeInnhold();
-        BigDecimal feriepengerBelop = BeregningStrategy.getFeriepengerBelop(avtaleInnhold.getFeriepengesats(), avtaleInnhold.getManedslonn());
-        BigDecimal obligTjenestepensjon = BeregningStrategy.getBeregnetOtpBelop(toBigDecimal(avtaleInnhold.getOtpSats()), avtaleInnhold.getManedslonn(), feriepengerBelop);
-        BigDecimal arbeidsgiveravgiftBelop = BeregningStrategy.getArbeidsgiverAvgift(avtaleInnhold.getManedslonn(), feriepengerBelop, obligTjenestepensjon,
-                avtaleInnhold.getArbeidsgiveravgift());
-        Integer sumLonnsutgifter = BeregningStrategy.getSumLonnsutgifter(avtaleInnhold.getManedslonn(), feriepengerBelop, obligTjenestepensjon, arbeidsgiveravgiftBelop);
-        Integer sumlønnTilskudd = BeregningStrategy.getSumLonnstilskudd(sumLonnsutgifter, avtaleInnhold.getLonnstilskuddProsent());
-        Integer månedslønnFullStilling = BeregningStrategy.getLønnVedFullStilling(avtaleInnhold.getManedslonn(), avtaleInnhold.getStillingprosent());
+        BigDecimal feriepengerBelop = BeregningStrategy.getFeriepengerBelop(
+            avtaleInnhold.getFeriepengesats(),
+            avtaleInnhold.getManedslonn()
+        );
+        BigDecimal obligTjenestepensjon = BeregningStrategy.getBeregnetOtpBelop(
+            toBigDecimal(avtaleInnhold.getOtpSats()),
+            avtaleInnhold.getManedslonn(),
+            feriepengerBelop
+        );
+        BigDecimal arbeidsgiveravgiftBelop = BeregningStrategy.getArbeidsgiverAvgift(
+            avtaleInnhold.getManedslonn(), feriepengerBelop, obligTjenestepensjon,
+            avtaleInnhold.getArbeidsgiveravgift()
+        );
+        Integer sumLonnsutgifter = BeregningStrategy.getSumLonnsutgifter(
+            avtaleInnhold.getManedslonn(),
+            feriepengerBelop,
+            obligTjenestepensjon,
+            arbeidsgiveravgiftBelop
+        );
+        Integer sumlønnTilskudd = BeregningStrategy.getSumLonnstilskudd(
+            sumLonnsutgifter,
+            avtaleInnhold.getLonnstilskuddProsent()
+        );
+        Integer månedslønnFullStilling = BeregningStrategy.getLønnVedFullStilling(
+            avtaleInnhold.getManedslonn(),
+            avtaleInnhold.getStillingprosent()
+        );
         avtaleInnhold.setFeriepengerBelop(convertBigDecimalToInt(feriepengerBelop));
         avtaleInnhold.setOtpBelop(convertBigDecimalToInt(obligTjenestepensjon));
         avtaleInnhold.setArbeidsgiveravgiftBelop(convertBigDecimalToInt(arbeidsgiveravgiftBelop));
@@ -72,22 +97,18 @@ public abstract class GenerellLonnstilskuddAvtaleBeregningStrategy implements Be
     }
 
     @Override
-    public List<TilskuddPeriode> beregnTilskuddsperioderForAvtale(Avtale avtale, LocalDate datoFraOgMed, LocalDate datoTilOgMed) {
+    public List<TilskuddPeriode> beregnTilskuddsperioderForAvtale(
+        Avtale avtale,
+        LocalDate datoFraOgMed,
+        LocalDate datoTilOgMed
+    ) {
         List<Periode> reduksjonsperioder = Periode.av(datoFraOgMed, datoTilOgMed).split(getDatoerForReduksjon(avtale));
 
         return reduksjonsperioder
             .stream()
             .flatMap(p -> p.splitPerMnd()
                 .stream()
-                .map(datoPar -> {
-                    Integer prosentForPeriode = getProsentForPeriode(avtale, datoPar);
-                    return lagTilskuddsperiode(
-                        avtale,
-                        datoPar,
-                        BeregningStrategy.getSumLonnstilskudd(avtale.getGjeldendeInnhold().getSumLonnsutgifter(), prosentForPeriode),
-                        prosentForPeriode
-                    );
-                })
+                .map(datoPar -> lagTilskuddsperiode(avtale, datoPar))
             )
             .toList();
 
@@ -97,19 +118,34 @@ public abstract class GenerellLonnstilskuddAvtaleBeregningStrategy implements Be
     public boolean nødvendigeFelterErUtfyltForBeregningAvTilskuddsbeløp(Avtale avtale) {
         var gjeldendeInnhold = avtale.getGjeldendeInnhold();
         return Utils.erIkkeTomme(
-                gjeldendeInnhold.getStartDato(),
-                gjeldendeInnhold.getSluttDato(),
-                gjeldendeInnhold.getSumLonnstilskudd(),
-                gjeldendeInnhold.getLonnstilskuddProsent(),
-                gjeldendeInnhold.getArbeidsgiveravgift(),
-                gjeldendeInnhold.getManedslonn(),
-                gjeldendeInnhold.getOtpSats());
+            gjeldendeInnhold.getStartDato(),
+            gjeldendeInnhold.getSluttDato(),
+            gjeldendeInnhold.getSumLonnstilskudd(),
+            gjeldendeInnhold.getLonnstilskuddProsent(),
+            gjeldendeInnhold.getArbeidsgiveravgift(),
+            gjeldendeInnhold.getManedslonn(),
+            gjeldendeInnhold.getOtpSats()
+        );
     }
 
     @Override
     public boolean nødvendigeFelterErUtfyltForÅGenerereTilskuddsperioder(Avtale avtale) {
         AvtaleInnhold gjeldendeInnhold = avtale.getGjeldendeInnhold();
-        return Utils.erIkkeTomme(gjeldendeInnhold.getStartDato(), gjeldendeInnhold.getSluttDato(), gjeldendeInnhold.getSumLonnstilskudd());
+        return Utils.erIkkeTomme(
+            gjeldendeInnhold.getStartDato(),
+            gjeldendeInnhold.getSluttDato(),
+            gjeldendeInnhold.getSumLonnstilskudd()
+        );
+    }
+
+    @Override
+    public Integer getBeløpForPeriode(Avtale avtale, Periode periode) {
+        Integer prosentForPeriode = getProsentForPeriode(avtale, periode);
+        Integer lonnstilskudd = BeregningStrategy.getSumLonnstilskudd(
+            avtale.getGjeldendeInnhold().getSumLonnsutgifter(),
+            prosentForPeriode
+        );
+        return BeregningStrategy.beløpForPeriode(periode, lonnstilskudd);
     }
 
     public List<Tilskuddstrinn> getTilskuddstrinn(Avtale avtale) {
@@ -137,9 +173,15 @@ public abstract class GenerellLonnstilskuddAvtaleBeregningStrategy implements Be
             .toList();
     }
 
-    TilskuddPeriode lagTilskuddsperiode(Avtale avtale, Periode periode, int lonnstilskudd, int lonnstilskuddProsent) {
-        Integer beløp = BeregningStrategy.beløpForPeriode(periode.getStart(), periode.getSlutt(), lonnstilskudd);
-        TilskuddPeriode tilskuddsperiode = new TilskuddPeriode(beløp, periode.getStart(), periode.getSlutt(), lonnstilskuddProsent);
+    TilskuddPeriode lagTilskuddsperiode(Avtale avtale, Periode periode) {
+        Integer beløp = getBeløpForPeriode(avtale, periode);
+        Integer prosent = getProsentForPeriode(avtale, periode);
+        TilskuddPeriode tilskuddsperiode = new TilskuddPeriode(
+            beløp,
+            periode.getStart(),
+            periode.getSlutt(),
+            prosent
+        );
         tilskuddsperiode.setAvtale(avtale);
         tilskuddsperiode.setEnhet(avtale.getGjeldendeInnhold().getEnhetKostnadssted());
         tilskuddsperiode.setEnhetsnavn(avtale.getGjeldendeInnhold().getEnhetsnavnKostnadssted());

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/tilskuddsperiode/beregning/IkkeLonnstilskuddAvtaleBeregningStrategy.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/tilskuddsperiode/beregning/IkkeLonnstilskuddAvtaleBeregningStrategy.java
@@ -23,11 +23,6 @@ public class IkkeLonnstilskuddAvtaleBeregningStrategy implements BeregningStrate
     public void reberegnTotal(Avtale avtale) {}
 
     @Override
-    public Integer beregnTilskuddsbeløpForPeriode(Avtale avtale, LocalDate startDato, LocalDate sluttDato) {
-        return 0;
-    }
-
-    @Override
     public void forleng(Avtale avtale, LocalDate gammelSluttDato, LocalDate nySluttDato){}
 
     @Override

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/tilskuddsperiode/beregning/MentorBeregningStrategy.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/tilskuddsperiode/beregning/MentorBeregningStrategy.java
@@ -5,6 +5,7 @@ import no.nav.tag.tiltaksgjennomforing.arena.models.arena.ArenaTiltakskode;
 import no.nav.tag.tiltaksgjennomforing.avtale.Avtale;
 import no.nav.tag.tiltaksgjennomforing.avtale.AvtaleInnhold;
 import no.nav.tag.tiltaksgjennomforing.avtale.TilskuddPeriode;
+import no.nav.tag.tiltaksgjennomforing.utils.Periode;
 import no.nav.tag.tiltaksgjennomforing.utils.Utils;
 
 import java.math.BigDecimal;
@@ -85,10 +86,9 @@ public class MentorBeregningStrategy implements BeregningStrategy {
         LocalDate startDato,
         LocalDate sluttDato
     ) {
-        List<TilskuddPeriode> perioder = BeregningStrategy.lagPeriode(startDato, sluttDato).stream().map(datoPar -> {
+        List<TilskuddPeriode> perioder = Periode.av(startDato, sluttDato).splitPerMnd().stream().map(datoPar -> {
                 Integer beløp = BeregningStrategy.beløpForPeriode(
-                    datoPar.getStart(),
-                    datoPar.getSlutt(),
+                    datoPar,
                     avtale.getGjeldendeInnhold().getSumLonnsutgifter()
                 );
                 return new TilskuddPeriode(beløp, datoPar.getStart(), datoPar.getSlutt(), 100);
@@ -150,11 +150,11 @@ public class MentorBeregningStrategy implements BeregningStrategy {
     }
 
     @Override
-    public Integer beregnTilskuddsbeløpForPeriode(Avtale avtale, LocalDate startDato, LocalDate sluttDato) {
+    public Integer getBeløpForPeriode(Avtale avtale, Periode periode) {
         if (!nødvendigeFelterErUtfyltForBeregningAvTilskuddsbeløp(avtale)) {
             return null;
         }
 
-        return BeregningStrategy.beløpForPeriode(startDato, sluttDato, avtale.getGjeldendeInnhold().getSumLonnsutgifter());
+        return BeregningStrategy.beløpForPeriode(periode, avtale.getGjeldendeInnhold().getSumLonnsutgifter());
     }
 }

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/tilskuddsperiode/beregning/MidlertidigLonnstilskuddAvtaleBeregningStrategy.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/tilskuddsperiode/beregning/MidlertidigLonnstilskuddAvtaleBeregningStrategy.java
@@ -1,7 +1,6 @@
 package no.nav.tag.tiltaksgjennomforing.tilskuddsperiode.beregning;
 
 import no.nav.tag.tiltaksgjennomforing.avtale.Avtale;
-import no.nav.tag.tiltaksgjennomforing.avtale.AvtaleInnhold;
 import no.nav.tag.tiltaksgjennomforing.utils.Periode;
 
 import java.time.LocalDate;
@@ -14,22 +13,25 @@ public class MidlertidigLonnstilskuddAvtaleBeregningStrategy extends GenerellLon
     public static final int TILSKUDDSPROSENT_TILPASSET = 60;
     public static final int TILSKUDDSPROSENT_REDUKSJONSFAKTOR = 10;
 
-    @Override
-    public Integer getProsentForPeriode(Avtale avtale, Periode tilskuddsperiode) {
-        Optional<LocalDate> datoForRedusertProsent = getDatoerForReduksjon(avtale).stream().findFirst();
-
-        Integer tilskuddsprosent = switch (avtale.getKvalifiseringsgruppe()) {
+    public Integer getProsentForForstePeriode(Avtale avtale) {
+        return switch (avtale.getKvalifiseringsgruppe()) {
             case SPESIELT_TILPASSET_INNSATS, VARIG_TILPASSET_INNSATS -> TILSKUDDSPROSENT_TILPASSET;
             case SITUASJONSBESTEMT_INNSATS -> TILSKUDDSPROSENT;
             case null, default -> null;
         };
+    }
 
+    @Override
+    public Integer getProsentForPeriode(Avtale avtale, Periode periode) {
+        Optional<LocalDate> datoForRedusertProsent = getDatoerForReduksjon(avtale).stream().findFirst();
+
+        Integer tilskuddsprosent = getProsentForForstePeriode(avtale);
         if (tilskuddsprosent == null) {
             return null;
         }
 
         boolean erRedusert = datoForRedusertProsent
-            .map(dato -> !tilskuddsperiode.getSlutt().isBefore(dato))
+            .map(dato -> !periode.getSlutt().isBefore(dato))
             .orElse(false);
 
         return erRedusert ? tilskuddsprosent - TILSKUDDSPROSENT_REDUKSJONSFAKTOR : tilskuddsprosent;
@@ -56,31 +58,4 @@ public class MidlertidigLonnstilskuddAvtaleBeregningStrategy extends GenerellLon
 
         return List.of(datoForReduksjon);
     }
-
-    @Override
-    public void reberegnTotal(Avtale avtale) {
-        super.reberegnTotal(avtale);
-        regnUtDatoOgSumRedusert(avtale);
-    }
-
-    public void regnUtDatoOgSumRedusert(Avtale avtale) {
-        AvtaleInnhold avtaleInnhold = avtale.getGjeldendeInnhold();
-        LocalDate datoForRedusertProsent = getDatoerForReduksjon(avtale).stream().findFirst().orElse(null);
-        avtaleInnhold.setDatoForRedusertProsent(datoForRedusertProsent);
-        Integer sumLønnstilskuddRedusert = regnUtRedusertLønnstilskudd(avtale);
-        avtaleInnhold.setSumLønnstilskuddRedusert(sumLønnstilskuddRedusert);
-    }
-
-    public Integer regnUtRedusertLønnstilskudd(Avtale avtale) {
-        AvtaleInnhold avtaleInnhold = avtale.getGjeldendeInnhold();
-        if (avtaleInnhold.getDatoForRedusertProsent() != null && avtaleInnhold.getLonnstilskuddProsent() != null) {
-            return BeregningStrategy.getSumLonnstilskudd(
-                avtaleInnhold.getSumLonnsutgifter(),
-                avtaleInnhold.getLonnstilskuddProsent() - TILSKUDDSPROSENT_REDUKSJONSFAKTOR
-            );
-        } else {
-            return null;
-        }
-    }
-
 }

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/tilskuddsperiode/beregning/SommerjobbLonnstilskuddAvtaleBeregningStrategy.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/tilskuddsperiode/beregning/SommerjobbLonnstilskuddAvtaleBeregningStrategy.java
@@ -9,9 +9,11 @@ import java.util.Collections;
 import java.util.List;
 
 public class SommerjobbLonnstilskuddAvtaleBeregningStrategy extends GenerellLonnstilskuddAvtaleBeregningStrategy {
+    public static int TILSKUDDSPROSENT_MAKS = 75;
+    public static int TILSKUDDSPROSENT_MIN = 50;
 
     @Override
-    public Integer getProsentForPeriode(Avtale avtale, Periode tilskuddsperiode) {
+    public Integer getProsentForPeriode(Avtale avtale, Periode periode) {
         return avtale.getGjeldendeInnhold().getLonnstilskuddProsent();
     }
 

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/tilskuddsperiode/beregning/VTAOAvtaleBeregningStrategy.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/tilskuddsperiode/beregning/VTAOAvtaleBeregningStrategy.java
@@ -6,6 +6,7 @@ import no.nav.tag.tiltaksgjennomforing.avtale.Avtaleopphav;
 import no.nav.tag.tiltaksgjennomforing.avtale.TilskuddPeriode;
 import no.nav.tag.tiltaksgjennomforing.exceptions.Feilkode;
 import no.nav.tag.tiltaksgjennomforing.exceptions.FeilkodeException;
+import no.nav.tag.tiltaksgjennomforing.utils.Periode;
 import no.nav.tag.tiltaksgjennomforing.utils.Utils;
 
 import java.time.LocalDate;
@@ -15,7 +16,7 @@ import java.util.List;
 import static no.nav.tag.tiltaksgjennomforing.satser.Sats.VTAO_SATS;
 import static no.nav.tag.tiltaksgjennomforing.utils.Utils.fikseLøpenumre;
 
-public class VTAOLonnstilskuddAvtaleBeregningStrategy implements BeregningStrategy {
+public class VTAOAvtaleBeregningStrategy implements BeregningStrategy {
     private final LocalDate STANDARD_MIGRERINGSDATO = ArenaTiltakskode.VTAO.getMigreringsdatoForTilskudd();
 
     @Override
@@ -75,9 +76,9 @@ public class VTAOLonnstilskuddAvtaleBeregningStrategy implements BeregningStrate
         LocalDate startDato,
         LocalDate sluttDato
     ) {
-        return BeregningStrategy.lagPeriode(startDato, sluttDato).stream().map(datoPar -> {
+        return Periode.av(startDato, sluttDato).splitPerMnd().stream().map(datoPar -> {
             var sats = VTAO_SATS.hentGjeldendeSats(datoPar.getStart());
-            Integer beløp = sats != null ? BeregningStrategy.beløpForPeriode(datoPar.getStart(), datoPar.getSlutt(), sats) : null;
+            Integer beløp = sats != null ? BeregningStrategy.beløpForPeriode(datoPar, sats) : null;
             TilskuddPeriode tilskuddPeriode = new TilskuddPeriode(beløp, datoPar.getStart(), datoPar.getSlutt());
             tilskuddPeriode.setAvtale(avtale);
             tilskuddPeriode.setEnhet(avtale.getGjeldendeInnhold().getEnhetKostnadssted());
@@ -87,11 +88,11 @@ public class VTAOLonnstilskuddAvtaleBeregningStrategy implements BeregningStrate
     }
 
     @Override
-    public Integer beregnTilskuddsbeløpForPeriode(Avtale avtale, LocalDate startDato, LocalDate sluttDato) {
-        var vtaoSats = VTAO_SATS.hentGjeldendeSats(startDato);
+    public Integer getBeløpForPeriode(Avtale avtale, Periode periode) {
+        var vtaoSats = VTAO_SATS.hentGjeldendeSats(periode.getStart());
         if (vtaoSats == null) {
             return null;
         }
-        return BeregningStrategy.beløpForPeriode(startDato, sluttDato, vtaoSats);
+        return BeregningStrategy.beløpForPeriode(periode, vtaoSats);
     }
 }

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/tilskuddsperiode/beregning/VarigLonnstilskuddAvtaleBeregningStrategy.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/tilskuddsperiode/beregning/VarigLonnstilskuddAvtaleBeregningStrategy.java
@@ -14,11 +14,11 @@ public class VarigLonnstilskuddAvtaleBeregningStrategy extends GenerellLonnstils
     public static final int TILSKUDDSPROSENT_REDUSERT_MAKS = 67;
 
     @Override
-    public Integer getProsentForPeriode(Avtale avtale, Periode tilskuddsperiode) {
+    public Integer getProsentForPeriode(Avtale avtale, Periode periode) {
         Optional<LocalDate> datoForRedusertProsent = getDatoerForReduksjon(avtale).stream().findFirst();
 
         boolean erRedusert = datoForRedusertProsent
-            .map(dato -> !tilskuddsperiode.getSlutt().isBefore(dato))
+            .map(dato -> !periode.getSlutt().isBefore(dato))
             .orElse(false);
 
         int lonnstilskuddProsent = avtale.getGjeldendeInnhold().getLonnstilskuddProsent() != null ? avtale.getGjeldendeInnhold().getLonnstilskuddProsent() : 0;
@@ -52,38 +52,6 @@ public class VarigLonnstilskuddAvtaleBeregningStrategy extends GenerellLonnstils
         AvtaleInnhold avtaleInnhold = avtale.getGjeldendeInnhold();
         avtaleInnhold.setLonnstilskuddProsent(endreTilskuddsberegning.getLonnstilskuddProsent());
         super.endreBeregning(avtale, endreTilskuddsberegning);
-    }
-
-    @Override
-    public void reberegnTotal(Avtale avtale) {
-        super.reberegnTotal(avtale);
-        regnUtDatoOgSumRedusert(avtale);
-    }
-
-    public void regnUtDatoOgSumRedusert(Avtale avtale) {
-        AvtaleInnhold avtaleInnhold = avtale.getGjeldendeInnhold();
-        if (avtaleInnhold.getLonnstilskuddProsent() == null || avtaleInnhold.getLonnstilskuddProsent() <= TILSKUDDSPROSENT_REDUSERT_MAKS) {
-            avtaleInnhold.setDatoForRedusertProsent(null);
-            avtaleInnhold.setSumLønnstilskuddRedusert(null);
-            return;
-        }
-        LocalDate datoForRedusertProsent = getDatoerForReduksjon(avtale).stream().findFirst().orElse(null);
-        avtaleInnhold.setDatoForRedusertProsent(datoForRedusertProsent);
-        Integer sumLønnstilskuddRedusert = regnUtRedusertLønnstilskudd(avtale);
-        avtaleInnhold.setSumLønnstilskuddRedusert(sumLønnstilskuddRedusert);
-    }
-
-    public Integer regnUtRedusertLønnstilskudd(Avtale avtale) {
-        AvtaleInnhold avtaleInnhold = avtale.getGjeldendeInnhold();
-        if (avtaleInnhold.getDatoForRedusertProsent() != null && avtaleInnhold.getLonnstilskuddProsent() != null) {
-            int lonnstilskuddProsent = avtaleInnhold.getLonnstilskuddProsent();
-            if (lonnstilskuddProsent > TILSKUDDSPROSENT_REDUSERT_MAKS) {
-                lonnstilskuddProsent = TILSKUDDSPROSENT_REDUSERT_MAKS;
-            }
-            return BeregningStrategy.getSumLonnstilskudd(avtaleInnhold.getSumLonnsutgifter(), lonnstilskuddProsent);
-        } else {
-            return null;
-        }
     }
 
 }

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleTest.java
@@ -103,8 +103,6 @@ public class AvtaleTest {
         avtale.endreAvtale(endreAvtale, Avtalerolle.VEILEDER);
         final int FORVENTET_ANTALL_TILSKUDDSPERIODER_FOR_6_AAR_VARIG_AVTALE = 74;
         assertThat(avtale.getTilskuddPeriode().stream().map(TilskuddPeriode::getBeløp).toList().size()).isEqualTo(FORVENTET_ANTALL_TILSKUDDSPERIODER_FOR_6_AAR_VARIG_AVTALE);
-        assertThat(avtale.getGjeldendeInnhold().getSumLønnstilskuddRedusert()).isEqualTo(27336);
-        assertThat(avtale.getGjeldendeInnhold().getDatoForRedusertProsent()).isEqualTo(LocalDate.of(2025,07,29));
     }
 
 
@@ -1192,35 +1190,6 @@ public class AvtaleTest {
         assertThat(avtale.erGodkjentAvArbeidsgiver()).isTrue();
     }
 
-
-    @Test
-    public void ufordelt_midlertidig_lts_avtale_endrer_avtale_med_lavere_lønnstilskuddprosent_enn_mellom_kun_40_60_prosent() {
-        Avtale avtale = Avtale.opprett(
-                new OpprettAvtale(TestData.etFodselsnummer(), TestData.etBedriftNr(), Tiltakstype.MIDLERTIDIG_LONNSTILSKUDD),
-                Avtaleopphav.VEILEDER,
-                new NavIdent("Z123456"));
-        avtale.setKvalifiseringsgruppe(null);
-        EndreAvtale endreAvtale = TestData.endringPåAlleLønnstilskuddFelter();
-        endreAvtale.setLonnstilskuddProsent(20);
-        assertThatThrownBy(() -> avtale.endreAvtale(endreAvtale, Avtalerolle.VEILEDER))
-                .isInstanceOf(FeilLonnstilskuddsprosentException.class);
-    }
-
-    @Test
-    public void ufordelt_midlertidig_lts_avtale_endrer_avtale_med_høyere_enn_maks_lønnstilskuddprosent_enn_60_prosent() {
-        Avtale avtale = Avtale.opprett(
-                new OpprettAvtale(TestData.etFodselsnummer(), TestData.etBedriftNr(), Tiltakstype.MIDLERTIDIG_LONNSTILSKUDD),
-                Avtaleopphav.VEILEDER,
-                new NavIdent("Z123456")
-        );
-        EndreAvtale endreAvtale = TestData.endringPåAlleLønnstilskuddFelter();
-        avtale.setKvalifiseringsgruppe(null);
-        endreAvtale.setLonnstilskuddProsent(67);
-        assertThatThrownBy(() -> avtale.endreAvtale(endreAvtale, Avtalerolle.VEILEDER))
-                .isInstanceOf(FeilLonnstilskuddsprosentException.class);
-    }
-
-
     @Test
     public void ufordelt_varig_lts_avtale_endrer_avtale_med_lavere_lønnstilskuddprosent_enn_0_prosent() {
         Avtale avtale = Avtale.opprett(
@@ -1519,25 +1488,6 @@ public class AvtaleTest {
         // Kan heller ikke godkjenne når avtalen er tildelt en annen
         avtale.overtaAvtale(new NavIdent("P887766"));
         assertFeilkode(Feilkode.TILSKUDDSPERIODE_IKKE_GODKJENNE_EGNE, () -> avtale.godkjennTilskuddsperiode(avtale.getGjeldendeInnhold().getGodkjentAvNavIdent(), "4444"));
-    }
-
-    @Test
-    public void forleng_og_forkort_skal_redusere_prosent() {
-        Avtale avtale = Avtale.opprett(new OpprettAvtale(TestData.etFodselsnummer(), TestData.etBedriftNr(), Tiltakstype.MIDLERTIDIG_LONNSTILSKUDD), Avtaleopphav.VEILEDER, TestData.enNavIdent());
-        avtale.setKvalifiseringsgruppe(Kvalifiseringsgruppe.VARIG_TILPASSET_INNSATS);
-        EndreAvtale endreAvtale = TestData.endringPåAlleLønnstilskuddFelter(Now.localDate(), Now.localDate().plusMonths(12).minusDays(1));
-        avtale.endreAvtale(endreAvtale, Avtalerolle.VEILEDER);
-        avtale.godkjennForDeltaker(TestData.etFodselsnummer());
-        avtale.godkjennForArbeidsgiver(TestData.etFodselsnummer());
-        avtale.godkjennForVeileder(TestData.enNavIdent());
-
-        avtale.forlengAvtale(Now.localDate().plusMonths(12), TestData.enNavIdent());
-        assertThat(avtale.getGjeldendeInnhold().getDatoForRedusertProsent()).isEqualTo(Now.localDate().plusMonths(12));
-        assertThat(avtale.getGjeldendeInnhold().getSumLønnstilskuddRedusert()).isNotNull();
-
-        avtale.forkortAvtale(Now.localDate().plusMonths(12).minusDays(1), ForkortetGrunn.av("grunn", ""), TestData.enNavIdent());
-        assertThat(avtale.getGjeldendeInnhold().getDatoForRedusertProsent()).isNull();
-        assertThat(avtale.getGjeldendeInnhold().getSumLønnstilskuddRedusert()).isNull();
     }
 
     @Test

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/BeregningLonnstilskuddTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/BeregningLonnstilskuddTest.java
@@ -21,6 +21,7 @@ class BeregningLonnstilskuddTest {
         FodselsnummerValidator.ALLOW_SYNTHETIC_NUMBERS = true;
 
         Avtale avtale = TestData.enMidlertidigLonnstilskuddAvtaleMedAltUtfylt();
+        avtale.setKvalifiseringsgruppe(Kvalifiseringsgruppe.VARIG_TILPASSET_INNSATS);
         avtaleInnhold = avtale.getGjeldendeInnhold();
         strategy = AvtaleInnholdStrategyFactory.create(avtaleInnhold, MIDLERTIDIG_LONNSTILSKUDD);
     }
@@ -56,7 +57,7 @@ class BeregningLonnstilskuddTest {
         endreAvtale.setArbeidsgiveravgift(new BigDecimal(0.141));
 
         // WHEN
-        strategy.endreAvtaleInnholdMedKvalifiseringsgruppe(endreAvtale, Kvalifiseringsgruppe.VARIG_TILPASSET_INNSATS);
+        strategy.endre(endreAvtale);
 
         // THEN
         assertThat(avtaleInnhold.getSumLonnstilskudd()).isEqualTo(15642);
@@ -73,7 +74,7 @@ class BeregningLonnstilskuddTest {
         endreAvtale.setArbeidsgiveravgift(new BigDecimal(0.141));
 
         // WHEN
-        strategy.endreAvtaleInnholdMedKvalifiseringsgruppe(endreAvtale, Kvalifiseringsgruppe.VARIG_TILPASSET_INNSATS);
+        strategy.endre(endreAvtale);
 
         // THEN
         assertThat(avtaleInnhold.getSumLonnsutgifter()).isEqualTo(21375);
@@ -90,7 +91,7 @@ class BeregningLonnstilskuddTest {
         endreAvtale.setArbeidsgiveravgift(new BigDecimal(0.141));
 
         // WHEN
-        strategy.endreAvtaleInnholdMedKvalifiseringsgruppe(endreAvtale, Kvalifiseringsgruppe.VARIG_TILPASSET_INNSATS);
+        strategy.endre(endreAvtale);
 
         // THEN
         assertThat(avtaleInnhold.getSumLonnstilskudd()).isEqualTo(15642);

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/BeregningStrategyTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/BeregningStrategyTest.java
@@ -234,7 +234,6 @@ public class BeregningStrategyTest {
 
         avtale.endreAvtale(endreAvtale, Avtalerolle.VEILEDER);
 
-        assertThat(avtale.getGjeldendeInnhold().getDatoForRedusertProsent()).isEqualTo(LocalDate.of(2022, 1, 1));
         assertThat(avtale.tilskuddsperiode(0).getLonnstilskuddProsent()).isEqualTo(68);
         assertThat(avtale.tilskuddsperiode(avtale.getTilskuddPeriode().size() - 1).getLonnstilskuddProsent()).isEqualTo(67);
         harRiktigeEgenskaper(avtale);
@@ -253,7 +252,6 @@ public class BeregningStrategyTest {
 
         avtale.endreAvtale(endreAvtale, Avtalerolle.VEILEDER);
 
-        assertThat(avtale.getGjeldendeInnhold().getDatoForRedusertProsent()).isEqualTo(LocalDate.of(2023, 1, 1));
         assertThat(avtale.tilskuddsperiode(0).getLonnstilskuddProsent()).isEqualTo(70);
         assertThat(avtale.tilskuddsperiode(avtale.getTilskuddPeriode().size() - 1).getLonnstilskuddProsent()).isEqualTo(67);
         harRiktigeEgenskaper(avtale);
@@ -272,7 +270,6 @@ public class BeregningStrategyTest {
 
         avtale.endreAvtale(endreAvtale, Avtalerolle.VEILEDER);
 
-        assertThat(avtale.getGjeldendeInnhold().getDatoForRedusertProsent()).isNull();
         assertThat(avtale.getGjeldendeInnhold().getLonnstilskuddProsent()).isEqualTo(40);
         harRiktigeEgenskaper(avtale);
         Now.resetClock();
@@ -290,87 +287,8 @@ public class BeregningStrategyTest {
 
         avtale.endreAvtale(endreAvtale, Avtalerolle.VEILEDER);
 
-        assertThat(avtale.getGjeldendeInnhold().getDatoForRedusertProsent()).isNull();
         assertThat(avtale.getGjeldendeInnhold().getLonnstilskuddProsent()).isEqualTo(69);
         harRiktigeEgenskaper(avtale);
-        Now.resetClock();
-    }
-
-    @Test
-    public void sjett_at_reduksjon_ikke_skjer_før_12_mnd_under_68_prosent() {
-        Now.fixedDate(LocalDate.of(2021, 1, 1));
-        LocalDate startDato = LocalDate.of(2021, 2, 1);
-        LocalDate sluttDato = LocalDate.of(2021, 6, 1);
-        Avtale avtale = TestData.enLonnstilskuddAvtaleMedAltUtfylt(Tiltakstype.VARIG_LONNSTILSKUDD);
-
-        EndreAvtale endreAvtale = TestData.endringPåAlleLønnstilskuddFelter(startDato, sluttDato);
-        endreAvtale.setLonnstilskuddProsent(35);
-
-        avtale.endreAvtale(endreAvtale, Avtalerolle.VEILEDER);
-
-        assertThat(avtale.getGjeldendeInnhold().getDatoForRedusertProsent()).isNull();
-        assertThat(avtale.getGjeldendeInnhold().getLonnstilskuddProsent()).isEqualTo(35);
-        harRiktigeEgenskaper(avtale);
-        Now.resetClock();
-    }
-
-    @Test
-    public void sjekk_at_reduksjon_skjer_etter_6_mnd_ved_40_prosent() {
-        Now.fixedDate(LocalDate.of(2021, 1, 1));
-        LocalDate startDato = LocalDate.of(2021, 1, 1);
-        LocalDate sluttDato = LocalDate.of(2021, 7, 1);
-        Avtale avtale = TestData.enMidlertidigLonnstilskuddAvtaleMedAltUtfylt();
-        EndreAvtale endreAvtale = TestData.endringPåAlleLønnstilskuddFelter(startDato, sluttDato);
-        endreAvtale.setLonnstilskuddProsent(40);
-        avtale.endreAvtale(endreAvtale, Avtalerolle.VEILEDER);
-
-        assertThat(avtale.getGjeldendeInnhold().getDatoForRedusertProsent()).isEqualTo(LocalDate.of(2021, 7, 1));
-        harRiktigeEgenskaper(avtale);
-        Now.resetClock();
-    }
-
-    @Test
-    public void sjekk_at_reduksjon_skjer_etter_12_mnd_ved_60_prosent() {
-        Now.fixedDate(LocalDate.of(2021, 1, 1));
-        LocalDate startDato = LocalDate.of(2021, 1, 1);
-        LocalDate sluttDato = LocalDate.of(2022, 12, 31);
-        Avtale avtale = TestData.enMidlertidigLonnstilskuddAvtaleMedAltUtfylt();
-        avtale.setKvalifiseringsgruppe(Kvalifiseringsgruppe.SPESIELT_TILPASSET_INNSATS);
-        EndreAvtale endreAvtale = TestData.endringPåAlleLønnstilskuddFelter(startDato, sluttDato);
-        endreAvtale.setLonnstilskuddProsent(60);
-        avtale.endreAvtale(endreAvtale, Avtalerolle.VEILEDER);
-
-        assertThat(avtale.getGjeldendeInnhold().getDatoForRedusertProsent()).isEqualTo(LocalDate.of(2022, 1, 1));
-        harRiktigeEgenskaper(avtale);
-        Now.resetClock();
-    }
-
-    @Test
-    public void sjekk_at_ingen_redusering_under_1_år_60_prosent() {
-        Now.fixedDate(LocalDate.of(2021, 1, 1));
-        LocalDate startDato = LocalDate.of(2021, 1, 1);
-        LocalDate sluttDato = LocalDate.of(2021, 12, 31);
-        Avtale avtale = TestData.enMidlertidigLonnstilskuddAvtaleMedAltUtfylt();
-        avtale.setKvalifiseringsgruppe(Kvalifiseringsgruppe.VARIG_TILPASSET_INNSATS);
-        EndreAvtale endreAvtale = TestData.endringPåAlleLønnstilskuddFelter(startDato, sluttDato);
-        endreAvtale.setLonnstilskuddProsent(60);
-        avtale.endreAvtale(endreAvtale, Avtalerolle.VEILEDER);
-
-        assertThat(avtale.getGjeldendeInnhold().getDatoForRedusertProsent()).isNull();
-        harRiktigeEgenskaper(avtale);
-        Now.resetClock();
-    }
-
-    @Test
-    public void sjekk_at_varig_lonnstilskudd_ikke_reduserses() {
-        Now.fixedDate(LocalDate.of(2021, 1, 1));
-        Avtale avtale = TestData.enLonnstilskuddAvtaleMedAltUtfylt(Tiltakstype.VARIG_LONNSTILSKUDD);
-        EndreAvtale endreAvtale = TestData.endringPåAlleLønnstilskuddFelter(LocalDate.of(2021, 1, 1), LocalDate.of(2031, 1, 1));
-        endreAvtale.setLonnstilskuddProsent(60);
-        avtale.endreAvtale(endreAvtale, Avtalerolle.VEILEDER);
-
-        assertThat(avtale.tilskuddsperiode(avtale.getTilskuddPeriode().size() - 1).getLonnstilskuddProsent()).isEqualTo(60);
-        assertThat(avtale.getGjeldendeInnhold().getDatoForRedusertProsent()).isNull();
         Now.resetClock();
     }
 

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/tilskuddsperiode/beregning/GenerellLonnstilskuddAvtaleBeregningStrategyTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/tilskuddsperiode/beregning/GenerellLonnstilskuddAvtaleBeregningStrategyTest.java
@@ -42,13 +42,11 @@ class GenerellLonnstilskuddAvtaleBeregningStrategyTest {
             }
         };
 
-    private Avtale lagAvtale(Tiltakstype tiltakstype, LocalDate datoForRedusertProsent) {
+    private Avtale lagAvtale(Tiltakstype tiltakstype) {
         Avtale avtale = TestData.enLonnstilskuddAvtaleMedAltUtfylt(tiltakstype);
         avtale.getGjeldendeInnhold().setSumLonnstilskudd(SUM_LONNSTILSKUDD_PER_MANED);
-        avtale.getGjeldendeInnhold().setSumLønnstilskuddRedusert(SUM_LONNSTILSKUDD_REDUSERT_PER_MANED);
         avtale.getGjeldendeInnhold().setLonnstilskuddProsent(PROSENT);
         avtale.getGjeldendeInnhold().setSumLonnsutgifter(SUM_LONNSUTGIFTER);
-        avtale.getGjeldendeInnhold().setDatoForRedusertProsent(datoForRedusertProsent);
         return avtale;
     }
 
@@ -71,7 +69,7 @@ class GenerellLonnstilskuddAvtaleBeregningStrategyTest {
     void ingen_reduksjon__en_maned_gir_en_periode_med_riktig_prosent() {
         LocalDate fra = LocalDate.of(2024, 1, 1);
         LocalDate til = LocalDate.of(2024, 1, 31);
-        Avtale avtale = lagAvtale(Tiltakstype.MIDLERTIDIG_LONNSTILSKUDD, null);
+        Avtale avtale = lagAvtale(Tiltakstype.MIDLERTIDIG_LONNSTILSKUDD);
 
         List<TilskuddPeriode> perioder = strategy.beregnTilskuddsperioderForAvtale(avtale, fra, til);
 
@@ -85,7 +83,7 @@ class GenerellLonnstilskuddAvtaleBeregningStrategyTest {
     void ingen_reduksjon__hele_maneder_gir_riktig_belop_per_maned() {
         LocalDate fra = LocalDate.of(2024, 1, 1);
         LocalDate til = LocalDate.of(2024, 3, 31);
-        Avtale avtale = lagAvtale(Tiltakstype.MIDLERTIDIG_LONNSTILSKUDD, null);
+        Avtale avtale = lagAvtale(Tiltakstype.MIDLERTIDIG_LONNSTILSKUDD);
 
         List<TilskuddPeriode> perioder = strategy.beregnTilskuddsperioderForAvtale(avtale, fra, til);
 
@@ -98,7 +96,7 @@ class GenerellLonnstilskuddAvtaleBeregningStrategyTest {
     void ingen_reduksjon__perioden_starter_midt_i_maneden_gir_proratert_belop() {
         LocalDate fra = LocalDate.of(2024, 1, 15);
         LocalDate til = LocalDate.of(2024, 1, 31);
-        Avtale avtale = lagAvtale(Tiltakstype.MIDLERTIDIG_LONNSTILSKUDD, null);
+        Avtale avtale = lagAvtale(Tiltakstype.MIDLERTIDIG_LONNSTILSKUDD);
 
         List<TilskuddPeriode> perioder = strategy.beregnTilskuddsperioderForAvtale(avtale, fra, til);
 
@@ -115,12 +113,12 @@ class GenerellLonnstilskuddAvtaleBeregningStrategyTest {
         LocalDate fra = LocalDate.of(2024, 3, 1);
         LocalDate til = LocalDate.of(2024, 4, 30);
         datoForRedusertProsent = LocalDate.of(2024, 1, 1); // allerede passert
-        Avtale avtale = lagAvtale(Tiltakstype.MIDLERTIDIG_LONNSTILSKUDD, datoForRedusertProsent);
+        Avtale avtale = lagAvtale(Tiltakstype.MIDLERTIDIG_LONNSTILSKUDD);
 
         List<TilskuddPeriode> perioder = strategy.beregnTilskuddsperioderForAvtale(avtale, fra, til);
 
         assertThat(perioder).hasSize(2);
-        int redusertProsent = BeregningStrategy.getRedusertLonnstilskuddprosent(Tiltakstype.MIDLERTIDIG_LONNSTILSKUDD, PROSENT);
+        int redusertProsent = strategy.getProsentForPeriode(avtale, Periode.av(datoForRedusertProsent, til));
         assertThat(perioder).allMatch(p -> p.getLonnstilskuddProsent() == redusertProsent);
         assertThat(perioder).allMatch(p -> p.getBeløp() == SUM_LONNSTILSKUDD_REDUSERT_PER_MANED);
     }
@@ -134,7 +132,7 @@ class GenerellLonnstilskuddAvtaleBeregningStrategyTest {
         LocalDate fra = LocalDate.of(2024, 1, 1);
         LocalDate til = LocalDate.of(2024, 4, 30);
         datoForRedusertProsent = LocalDate.of(2024, 3, 1);
-        Avtale avtale = lagAvtale(Tiltakstype.MIDLERTIDIG_LONNSTILSKUDD, datoForRedusertProsent);
+        Avtale avtale = lagAvtale(Tiltakstype.MIDLERTIDIG_LONNSTILSKUDD);
 
         List<TilskuddPeriode> perioder = strategy.beregnTilskuddsperioderForAvtale(avtale, fra, til);
 
@@ -152,7 +150,7 @@ class GenerellLonnstilskuddAvtaleBeregningStrategyTest {
         assertThat(forReduksjon).allMatch(p -> p.getLonnstilskuddProsent() == PROSENT);
         assertThat(forReduksjon).allMatch(p -> p.getBeløp() == SUM_LONNSTILSKUDD_PER_MANED);
 
-        int redusertProsent = BeregningStrategy.getRedusertLonnstilskuddprosent(Tiltakstype.MIDLERTIDIG_LONNSTILSKUDD, PROSENT);
+        int redusertProsent = strategy.getProsentForPeriode(avtale, Periode.av(datoForRedusertProsent, til));
         assertThat(etterReduksjon).hasSize(2);
         assertThat(etterReduksjon).allMatch(p -> p.getLonnstilskuddProsent() == redusertProsent);
         assertThat(etterReduksjon).allMatch(p -> p.getBeløp() == SUM_LONNSTILSKUDD_REDUSERT_PER_MANED);
@@ -163,11 +161,11 @@ class GenerellLonnstilskuddAvtaleBeregningStrategyTest {
         LocalDate fra = LocalDate.of(2024, 1, 1);
         LocalDate til = LocalDate.of(2024, 3, 31);
         datoForRedusertProsent = LocalDate.of(2024, 1, 1); // lik startdato
-        Avtale avtale = lagAvtale(Tiltakstype.MIDLERTIDIG_LONNSTILSKUDD, datoForRedusertProsent);
+        Avtale avtale = lagAvtale(Tiltakstype.MIDLERTIDIG_LONNSTILSKUDD);
 
         List<TilskuddPeriode> perioder = strategy.beregnTilskuddsperioderForAvtale(avtale, fra, til);
 
-        int redusertProsent = BeregningStrategy.getRedusertLonnstilskuddprosent(Tiltakstype.MIDLERTIDIG_LONNSTILSKUDD, PROSENT);
+        int redusertProsent = strategy.getProsentForPeriode(avtale, Periode.av(datoForRedusertProsent, til));
         assertThat(perioder).allMatch(p -> p.getLonnstilskuddProsent() == redusertProsent);
     }
 
@@ -176,14 +174,14 @@ class GenerellLonnstilskuddAvtaleBeregningStrategyTest {
         LocalDate fra = LocalDate.of(2024, 1, 1);
         LocalDate til = LocalDate.of(2024, 2, 29);
         datoForRedusertProsent = LocalDate.of(2024, 2, 29); // siste dag
-        Avtale avtale = lagAvtale(Tiltakstype.MIDLERTIDIG_LONNSTILSKUDD, datoForRedusertProsent);
+        Avtale avtale = lagAvtale(Tiltakstype.MIDLERTIDIG_LONNSTILSKUDD);
 
         List<TilskuddPeriode> perioder = strategy.beregnTilskuddsperioderForAvtale(avtale, fra, til);
 
         // Jan 1–31 og Feb 1–28 → full prosent (2 perioder), Feb 29–29 → redusert (1 periode)
         assertThat(perioder).hasSize(3);
 
-        int redusertProsent = BeregningStrategy.getRedusertLonnstilskuddprosent(Tiltakstype.MIDLERTIDIG_LONNSTILSKUDD, PROSENT);
+        int redusertProsent = strategy.getProsentForPeriode(avtale, Periode.av(datoForRedusertProsent, til));
 
         List<TilskuddPeriode> fullePerioder = perioder.stream()
                 .filter(p -> p.getSluttDato().isBefore(datoForRedusertProsent))
@@ -207,7 +205,7 @@ class GenerellLonnstilskuddAvtaleBeregningStrategyTest {
         LocalDate fra = LocalDate.of(2024, 1, 1);
         LocalDate til = LocalDate.of(2024, 3, 31);
         datoForRedusertProsent = LocalDate.of(2024, 2, 1);
-        Avtale avtale = lagAvtale(Tiltakstype.VARIG_LONNSTILSKUDD, datoForRedusertProsent);
+        Avtale avtale = lagAvtale(Tiltakstype.VARIG_LONNSTILSKUDD);
         avtale.getGjeldendeInnhold().setLonnstilskuddProsent(prosent);
 
         List<TilskuddPeriode> perioder = strategy.beregnTilskuddsperioderForAvtale(avtale, fra, til);
@@ -229,7 +227,7 @@ class GenerellLonnstilskuddAvtaleBeregningStrategyTest {
         LocalDate fra = LocalDate.of(2024, 1, 1);
         LocalDate til = LocalDate.of(2024, 1, 31);
         datoForRedusertProsent = LocalDate.of(2024, 6, 1); // etter perioden
-        Avtale avtale = lagAvtale(Tiltakstype.MIDLERTIDIG_LONNSTILSKUDD, datoForRedusertProsent);
+        Avtale avtale = lagAvtale(Tiltakstype.MIDLERTIDIG_LONNSTILSKUDD);
 
         List<TilskuddPeriode> tilskuddPerioder = strategy.beregnTilskuddsperioderForAvtale(avtale, fra, til);
         assertThat(tilskuddPerioder.getFirst().getStartDato()).isEqualTo(fra);


### PR DESCRIPTION
* Ny strategi for beregning har ikke lengre behov for egne felt
* Fireårig lts har flere reduskjonsdatoer - så modellen med et eget felt passer dårlig her.
* Redusjoner finnes allerede i tilskuddsperiodene - som er mer dynamiske enn feltene i avtalen.