### PR TITLE
fix. vise ubehandlet tilskudd på avsluttet avtaler

### DIFF
--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleRepository.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleRepository.java
@@ -193,6 +193,7 @@ public interface AvtaleRepository extends JpaRepository<Avtale, UUID>, JpaSpecif
           AND (:bedriftNr IS NULL OR a.bedriftNr = :bedriftNr)
           AND (:harReturnertSomKanBehandles IS FALSE OR ashrskb.avtaleHarReturnertSomKanBehandles = :harReturnertSomKanBehandles)
           AND (:avtaleStatus IS NULL OR a.status IN :avtaleStatus)
+          AND (:avtaleStatus IS NULL OR a.status <> 'AVSLUTTET' OR a.gjeldendeTilskuddsperiode.status IN ('UBEHANDLET', 'AVSLÅTT'))
     """)
     Page<BeslutterOversiktEntity> finnGodkjenteAvtalerMedTilskuddsperiodestatusOgNavEnheter(
         TilskuddPeriodeStatus tilskuddsperiodestatus,

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/Beslutter.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/Beslutter.java
@@ -132,7 +132,7 @@ public class Beslutter extends Avtalepart<NavIdent> implements InternBruker {
             ));
 
         Set<Status> avtaleStatus = queryParametre.getAvtaleNr() == null
-            ? Set.of(Status.PÅBEGYNT, Status.GJENNOMFØRES, Status.MANGLER_GODKJENNING, Status.KLAR_FOR_OPPSTART)
+            ? Set.of(Status.PÅBEGYNT, Status.GJENNOMFØRES, Status.MANGLER_GODKJENNING, Status.KLAR_FOR_OPPSTART, Status.AVSLUTTET)
             : null;
 
         Set<String> enheter = Optional.ofNullable(queryParametre.getNavEnhet())


### PR DESCRIPTION
* Vi har en bug hvor vi ikke viser avsluttet avtaler selv om de har tilskuddsperioder som kan behandles dersom beslutter ikke spesefikt søker på avtalen.
* Denne endringen legger til AVSLUTTET som en avtale status i filtere for db-spørringen. Dersom status på avtalen er AVSLUTTET så vil vi bare vise den i beslutteroversikten dersom gjeldende periode enten er ubehandlet eller avslått.