### PR TITLE
Admin-endepunkt for å regenerere tilskuddsperioder på mentor-avtale

### DIFF
--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/Avtale.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/Avtale.java
@@ -1108,6 +1108,7 @@ public class Avtale extends AbstractAggregateRoot<Avtale> implements AuditerbarE
     }
 
     public void regenererMentorTilskuddsperioder() {
+        sjekkAtIkkeAvtaleErAnnullert();
         if (tiltakstype != Tiltakstype.MENTOR) {
             throw new FeilkodeException(Feilkode.KAN_IKKE_ENDRE_FEIL_TILTAKSTYPE);
         }
@@ -1121,7 +1122,10 @@ public class Avtale extends AbstractAggregateRoot<Avtale> implements AuditerbarE
         if (tilskuddPeriode.isEmpty()) {
             throw new IllegalStateException("Kunne ikke generere tilskuddsperioder. Sjekk at nødvendige felter er utfylt.");
         }
-        log.info("Regenererte {} tilskuddsperioder for avtale {}", tilskuddPeriode.size(), id);
+        utforEndring();
+        log.atInfo()
+            .addKeyValue("avtaleId", id.toString())
+            .log("Regenererte {} tilskuddsperioder", tilskuddPeriode.size());
     }
 
     private boolean sjekkRyddingAvTilskuddsperioder() {

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/Avtale.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/Avtale.java
@@ -1107,6 +1107,23 @@ public class Avtale extends AbstractAggregateRoot<Avtale> implements AuditerbarE
         }
     }
 
+    public void regenererMentorTilskuddsperioder() {
+        if (tiltakstype != Tiltakstype.MENTOR) {
+            throw new FeilkodeException(Feilkode.KAN_IKKE_ENDRE_FEIL_TILTAKSTYPE);
+        }
+        if (erAvtaleInngått()) {
+            throw new IllegalStateException("Kan ikke regenerere tilskuddsperioder for en inngått avtale");
+        }
+        if (!tilskuddPeriode.isEmpty()) {
+            throw new IllegalStateException("Avtalen har allerede tilskuddsperioder");
+        }
+        nyeTilskuddsperioder();
+        if (tilskuddPeriode.isEmpty()) {
+            throw new IllegalStateException("Kunne ikke generere tilskuddsperioder. Sjekk at nødvendige felter er utfylt.");
+        }
+        log.info("Regenererte {} tilskuddsperioder for avtale {}", tilskuddPeriode.size(), id);
+    }
+
     private boolean sjekkRyddingAvTilskuddsperioder() {
         if (!this.hentBeregningStrategi().nødvendigeFelterErUtfyltForBeregningAvTilskuddsbeløp(this)) {
             // TODO: Her blir det trøbbel i migrering pga start og sluttdato. her må vi refaktorere litt!!

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/admin/AdminController.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/admin/AdminController.java
@@ -486,4 +486,16 @@ public class AdminController {
         }
         return resultat;
     }
+
+    @Transactional
+    @PostMapping("/avtale/{avtaleId}/regenerer-tilskuddsperioder-mentor")
+    public ResponseEntity<String> regenererTilskuddsperioderForMentor(@PathVariable UUID avtaleId) {
+        log.info("Admin: Regenererer tilskuddsperioder for mentor-avtale {}", avtaleId);
+        Avtale avtale = avtaleRepository.findById(avtaleId).orElseThrow(RessursFinnesIkkeException::new);
+        avtale.regenererMentorTilskuddsperioder();
+        avtaleRepository.save(avtale);
+        return ResponseEntity.ok("Regenererte " + avtale.getTilskuddPeriode().size() + " tilskuddsperioder for avtale " + avtaleId);
+    }
+
+
 }

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/admin/AdminController.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/admin/AdminController.java
@@ -494,7 +494,7 @@ public class AdminController {
         Avtale avtale = avtaleRepository.findById(avtaleId).orElseThrow(RessursFinnesIkkeException::new);
         avtale.regenererMentorTilskuddsperioder();
         avtaleRepository.save(avtale);
-        return ResponseEntity.ok("Regenererte " + avtale.getTilskuddPeriode().size() + " tilskuddsperioder for avtale " + avtaleId);
+        return ResponseEntity.ok("Regenererte " + avtale.getTilskuddPeriode().size() + " tilskuddsperioder");
     }
 
 

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/MentorAvtaleBeregningStrategyTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/MentorAvtaleBeregningStrategyTest.java
@@ -1,8 +1,10 @@
 package no.nav.tag.tiltaksgjennomforing.avtale;
 
 import no.bekk.bekkopen.person.FodselsnummerValidator;
+import no.nav.tag.tiltaksgjennomforing.AssertFeilkode;
 import no.nav.tag.tiltaksgjennomforing.Miljø;
 import no.nav.tag.tiltaksgjennomforing.enhet.Kvalifiseringsgruppe;
+import no.nav.tag.tiltaksgjennomforing.exceptions.Feilkode;
 import no.nav.tag.tiltaksgjennomforing.tilskuddsperiode.beregning.EndreTilskuddsberegning;
 import no.nav.tag.tiltaksgjennomforing.tilskuddsperiode.beregning.MentorBeregningStrategy;
 import no.nav.tag.tiltaksgjennomforing.utils.Now;
@@ -18,6 +20,7 @@ import java.util.Set;
 import java.util.stream.IntStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @SpringBootTest(properties = {
     "tiltaksgjennomforing.mentor-tilskuddsperioder.enabled=true"
@@ -243,5 +246,67 @@ public class MentorAvtaleBeregningStrategyTest {
         assertThat(avtale.getGjeldendeInnhold().getMentorAntallTimer()).isEqualTo(endring.getMentorAntallTimer());
         assertThat(avtale.getGjeldendeInnhold().getSumLonnsutgifter()).isNotEqualTo(sumFør);
         assertThat(avtale.getGjeldendeInnhold().getSumLonnsutgifter()).isNotNull().isPositive();
+    }
+
+    @Test
+    public void regenererMentorTilskuddsperioder__genererer_perioder_når_de_mangler() {
+        Now.fixedDate(LocalDate.of(2026, 2, 4));
+        Avtale avtale = TestData.enMentorAvtaleSignertAvAlle();
+
+        avtale.getTilskuddPeriode().clear();
+        assertThat(avtale.getTilskuddPeriode()).isEmpty();
+
+        avtale.regenererMentorTilskuddsperioder();
+
+        assertThat(avtale.getTilskuddPeriode()).isNotEmpty();
+        assertThat(avtale.getGjeldendeTilskuddsperiode()).isNotNull();
+        assertThat(avtale.getSistEndret()).isNotNull();
+    }
+
+    @Test
+    public void regenererMentorTilskuddsperioder__feiler_for_ikke_mentor_avtale() {
+        Now.fixedDate(LocalDate.of(2026, 2, 4));
+        Avtale avtale = TestData.enArbeidstreningAvtale();
+
+        AssertFeilkode.assertFeilkode(Feilkode.KAN_IKKE_ENDRE_FEIL_TILTAKSTYPE,
+            avtale::regenererMentorTilskuddsperioder);
+    }
+
+    @Test
+    public void regenererMentorTilskuddsperioder__feiler_for_inngått_avtale() {
+        Now.fixedDate(LocalDate.of(2026, 2, 4));
+        Avtale avtale = TestData.enMentorAvtaleSignertAvAlle();
+
+        Beslutter beslutter = TestData.enBeslutter(avtale);
+        beslutter.godkjennTilskuddsperiode(avtale, TestData.ENHET_OPPFØLGING.getVerdi());
+        assertThat(avtale.erAvtaleInngått()).isTrue();
+
+        avtale.getTilskuddPeriode().clear();
+
+        assertThatThrownBy(avtale::regenererMentorTilskuddsperioder)
+            .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    public void regenererMentorTilskuddsperioder__feiler_for_annullert_avtale() {
+        Now.fixedDate(LocalDate.of(2026, 2, 4));
+        Avtale avtale = TestData.enMentorAvtaleSignertAvAlle();
+        avtale.getTilskuddPeriode().clear();
+
+        avtale.annuller(AnnullertGrunn.FEILREGISTRERING, Identifikator.SYSTEM);
+
+        AssertFeilkode.assertFeilkode(Feilkode.KAN_IKKE_ENDRE_ANNULLERT_AVTALE,
+            avtale::regenererMentorTilskuddsperioder);
+    }
+
+    @Test
+    public void regenererMentorTilskuddsperioder__feiler_når_perioder_allerede_eksisterer() {
+        Now.fixedDate(LocalDate.of(2026, 2, 4));
+        Avtale avtale = TestData.enMentorAvtaleSignertAvAlle();
+
+        assertThat(avtale.getTilskuddPeriode()).isNotEmpty();
+
+        assertThatThrownBy(avtale::regenererMentorTilskuddsperioder)
+            .isInstanceOf(IllegalStateException.class);
     }
 }


### PR DESCRIPTION
Fix: Admin-endepunkt for å regenerere tilskuddsperioder på mentor-avtale

En mentor-avtale mistet tilskuddsperiodene ved
forlengelse pga. bug i hentTilskuddsperioderForPeriode() som
returnerte tom liste for mentor (fikset i fad91f948).