### PR TITLE
bruker tilganger() fra nye altinn apiet

### DIFF
--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/Arbeidsgiver.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/Arbeidsgiver.java
@@ -112,7 +112,7 @@ public class Arbeidsgiver extends Avtalepart<Fnr> {
 
     @Override
     public Collection<BedriftNr> identifikatorer() {
-        return tilganger.keySet();
+        return altinnTilganger.tilganger().keySet();
     }
 
     @Override
@@ -196,10 +196,10 @@ public class Arbeidsgiver extends Avtalepart<Fnr> {
     }
 
     private boolean harTilgangPåTiltakIBedrift(BedriftNr bedriftNr, Tiltakstype tiltakstype) {
-        if (!tilganger.containsKey(bedriftNr)) {
+        if (!altinnTilganger.tilganger().containsKey(bedriftNr)) {
             return false;
         }
-        Collection<Tiltakstype> gyldigeTilgangerPåBedriftNr = tilganger.get(bedriftNr);
+        Collection<Tiltakstype> gyldigeTilgangerPåBedriftNr = altinnTilganger.tilganger().get(bedriftNr);
         return gyldigeTilgangerPåBedriftNr.contains(tiltakstype);
     }
 
@@ -219,7 +219,7 @@ public class Arbeidsgiver extends Avtalepart<Fnr> {
         AvtaleQueryParameter queryParametre,
         Pageable pageable
     ) {
-        if (tilganger.isEmpty()) {
+        if (altinnTilganger.tilganger().isEmpty()) {
             return Page.empty();
         }
         Page<Avtale> avtaler;
@@ -232,7 +232,7 @@ public class Arbeidsgiver extends Avtalepart<Fnr> {
                 );
             } else if (queryParametre.getBedriftNr() == null) {
                 avtaler = avtaleRepository.findAllByBedriftNrAndTiltakstype(
-                    tilganger.keySet(),
+                    altinnTilganger.tilganger().keySet(),
                     queryParametre.getTiltakstype(),
                     pageable
                 );
@@ -240,13 +240,13 @@ public class Arbeidsgiver extends Avtalepart<Fnr> {
                 avtaler = Page.empty();
             }
         } else {
-            if (queryParametre.getBedriftNr() != null && tilganger.containsKey(queryParametre.getBedriftNr())) {
+            if (queryParametre.getBedriftNr() != null && altinnTilganger.tilganger().containsKey(queryParametre.getBedriftNr())) {
                 avtaler = avtaleRepository.findAllByBedriftNr(
                     Set.of(queryParametre.getBedriftNr()),
                     pageable
                 );
             } else if (queryParametre.getBedriftNr() == null) {
-                avtaler = avtaleRepository.findAllByBedriftNr(tilganger.keySet(), pageable);
+                avtaler = avtaleRepository.findAllByBedriftNr(altinnTilganger.tilganger().keySet(), pageable);
             } else { // Bruker ba om informasjon på en bedrift hen ikke har tilgang til, og får dermed tom liste
                 avtaler = Page.empty();
             }

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/InnloggetBrukerTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/InnloggetBrukerTest.java
@@ -56,7 +56,7 @@ public class InnloggetBrukerTest {
     private VeilarboppfolgingService veilarboppfolgingService;
     private AvtaleRepository avtaleRepository;
     private FeatureToggleService featureToggleService;
-    private final AltinnTilgangerDto altinn3Organisasjoner = null;
+    private final AltinnTilgangerDto altinn3Organisasjoner = TestData.enAltinnTilgangerDto(Map.of());
     @Value("${tiltaksgjennomforing.mentor-tilskuddsperioder.enabled}")
     private boolean mentorTilskuddsperioderEnabled;
 
@@ -252,7 +252,7 @@ public class InnloggetBrukerTest {
                 Fnr.generer(1956, 7, 8),
                 Set.of(),
                 tilganger,
-            altinn3Organisasjoner, List.of(),
+            TestData.enAltinnTilgangerDto(tilganger), List.of(),
                 persondataService,
                 null,
                 null,
@@ -270,7 +270,7 @@ public class InnloggetBrukerTest {
             Fnr.generer(1956, 7, 8),
                 Set.of(),
                 tilganger,
-            altinn3Organisasjoner, List.of(),
+            TestData.enAltinnTilgangerDto(tilganger), List.of(),
                 persondataService,
                 null,
                 null,
@@ -307,7 +307,7 @@ public class InnloggetBrukerTest {
                 Fnr.generer(1956, 7, 8),
                 Set.of(),
                 tilganger,
-            altinn3Organisasjoner, List.of(),
+            TestData.enAltinnTilgangerDto(tilganger), List.of(),
                 persondataService,
                 null,
                 null,
@@ -325,7 +325,7 @@ public class InnloggetBrukerTest {
                 Fnr.generer(1956, 7, 8),
                 Set.of(),
                 tilganger,
-            altinn3Organisasjoner, List.of(),
+            TestData.enAltinnTilgangerDto(tilganger), List.of(),
                 persondataService,
                 null,
                 null,

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/ArbeidsgiverTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/ArbeidsgiverTest.java
@@ -30,6 +30,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -53,7 +54,6 @@ public class ArbeidsgiverTest {
     @MockitoBean
     private AvtaleRepository avtaleRepository;
 
-    private final AltinnTilgangerDto altinn3Organisasjoner = null;
     private final Pageable pageable = PageRequest.of(0, 100);
 
     @BeforeEach
@@ -108,6 +108,7 @@ public class ArbeidsgiverTest {
             "0411"
         ));
 
+        Map<BedriftNr, Collection<Tiltakstype>> tilgangerMap = Map.of(TestData.etBedriftNr(), Set.of(Tiltakstype.ARBEIDSTRENING));
         Arbeidsgiver arbeidsgiver = new Arbeidsgiver(
             TestData.etFodselsnummer(),
             Set.of(
@@ -121,8 +122,8 @@ public class ArbeidsgiverTest {
                     null
                 )
             ),
-            Map.of(TestData.etBedriftNr(), Set.of(Tiltakstype.ARBEIDSTRENING)),
-            altinn3Organisasjoner,
+            tilgangerMap,
+            TestData.enAltinnTilgangerDto(tilgangerMap),
             List.of(),
             persondataService,
             norg2Client,
@@ -144,7 +145,7 @@ public class ArbeidsgiverTest {
             null,
             null,
             null,
-            altinn3Organisasjoner,
+            TestData.enAltinnTilgangerDto(Map.of()),
             null,
             null,
             null,
@@ -163,7 +164,7 @@ public class ArbeidsgiverTest {
             null,
             null,
             null,
-            altinn3Organisasjoner,
+            TestData.enAltinnTilgangerDto(Map.of()),
             null,
             null,
             null,
@@ -180,11 +181,12 @@ public class ArbeidsgiverTest {
         PersondataService persondataService = mock(PersondataService.class);
         when(persondataService.hentDiskresjonskode(any(Fnr.class))).thenReturn(Diskresjonskode.STRENGT_FORTROLIG);
 
+        Map<BedriftNr, Collection<Tiltakstype>> tilgangerMap = Map.of(TestData.etBedriftNr(), Set.of(Tiltakstype.ARBEIDSTRENING));
         Arbeidsgiver arbeidsgiver = new Arbeidsgiver(
             null,
             null,
-            Map.of(TestData.etBedriftNr(), Set.of(Tiltakstype.ARBEIDSTRENING)),
-            altinn3Organisasjoner,
+            tilgangerMap,
+            TestData.enAltinnTilgangerDto(tilgangerMap),
             List.of(),
             persondataService,
             null,
@@ -222,11 +224,12 @@ public class ArbeidsgiverTest {
         ));
 
         List<BedriftNr> adressesperreTilganger = List.of(TestData.etBedriftNr());
+        Map<BedriftNr, Collection<Tiltakstype>> tilgangerMap = Map.of(TestData.etBedriftNr(), Set.of(Tiltakstype.ARBEIDSTRENING));
         Arbeidsgiver arbeidsgiver = new Arbeidsgiver(
             null,
             null,
-            Map.of(TestData.etBedriftNr(), Set.of(Tiltakstype.ARBEIDSTRENING)),
-            altinn3Organisasjoner, 
+            tilgangerMap,
+            TestData.enAltinnTilgangerDto(tilgangerMap),
             adressesperreTilganger,
             persondataService,
             norg2Client,
@@ -257,11 +260,12 @@ public class ArbeidsgiverTest {
             Diskresjonskode.STRENGT_FORTROLIG
         ));
 
+        Map<BedriftNr, Collection<Tiltakstype>> tilgangerMap = Map.of(TestData.etBedriftNr(), Set.of(Tiltakstype.ARBEIDSTRENING));
         Arbeidsgiver arbeidsgiver = new Arbeidsgiver(
             null,
             null,
-            Map.of(TestData.etBedriftNr(), Set.of(Tiltakstype.ARBEIDSTRENING)),
-            altinn3Organisasjoner, 
+            tilgangerMap,
+            TestData.enAltinnTilgangerDto(tilgangerMap),
             emptyList(),
             persondataService,
             null,
@@ -287,11 +291,12 @@ public class ArbeidsgiverTest {
 
 
         List<BedriftNr> adressesperreTilganger = List.of(TestData.etBedriftNr());
+        Map<BedriftNr, Collection<Tiltakstype>> tilgangerMap = Map.of(TestData.etBedriftNr(), Set.of(Tiltakstype.ARBEIDSTRENING));
         Arbeidsgiver arbeidsgiver = new Arbeidsgiver(
             null,
             null,
-            Map.of(TestData.etBedriftNr(), Set.of(Tiltakstype.ARBEIDSTRENING)),
-            altinn3Organisasjoner, 
+            tilgangerMap,
+            TestData.enAltinnTilgangerDto(tilgangerMap),
             adressesperreTilganger,
             persondataService,
             null,
@@ -319,11 +324,12 @@ public class ArbeidsgiverTest {
 
 
         List<BedriftNr> adressesperreTilganger = List.of(TestData.etBedriftNr());
+        Map<BedriftNr, Collection<Tiltakstype>> tilgangerMap = Map.of(TestData.etBedriftNr(), Set.of(Tiltakstype.ARBEIDSTRENING));
         Arbeidsgiver arbeidsgiverUtenAdressesperreTilgang = new Arbeidsgiver(
             null,
             null,
-            Map.of(TestData.etBedriftNr(), Set.of(Tiltakstype.ARBEIDSTRENING)),
-            altinn3Organisasjoner, 
+            tilgangerMap,
+            TestData.enAltinnTilgangerDto(tilgangerMap),
             emptyList(),
             persondataService,
             null,
@@ -333,8 +339,8 @@ public class ArbeidsgiverTest {
         Arbeidsgiver arbeidsgiverMedAdressesperreTilgang = new Arbeidsgiver(
             null,
             null,
-            Map.of(TestData.etBedriftNr(), Set.of(Tiltakstype.ARBEIDSTRENING)),
-            altinn3Organisasjoner, 
+            tilgangerMap,
+            TestData.enAltinnTilgangerDto(tilgangerMap),
             adressesperreTilganger,
             persondataService,
             null,
@@ -381,16 +387,17 @@ public class ArbeidsgiverTest {
         PersondataService persondataService = mock(PersondataService.class);
         when(persondataService.hentDiskresjonskode(any(Fnr.class))).thenReturn(Diskresjonskode.UGRADERT);
 
+        Map<BedriftNr, Collection<Tiltakstype>> tilgangerMap = Map.of(
+            TestData.etBedriftNr(),
+            Set.of(Tiltakstype.MENTOR),
+            new BedriftNr("999999999"),
+            Set.of(Tiltakstype.MENTOR)
+        );
         Arbeidsgiver arbeidsgiver = new Arbeidsgiver(
             null,
             null,
-            Map.of(
-                TestData.etBedriftNr(),
-                Set.of(Tiltakstype.MENTOR),
-                new BedriftNr("999999999"),
-                Set.of(Tiltakstype.MENTOR)
-            ),
-            altinn3Organisasjoner,
+            tilgangerMap,
+            TestData.enAltinnTilgangerDto(tilgangerMap),
             List.of(),
             persondataService,
             null,

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleControllerTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/AvtaleControllerTest.java
@@ -96,7 +96,7 @@ public class AvtaleControllerTest {
     private FeatureToggleService featureToggleServiceMock;
 
     private Pageable pageable = PageRequest.of(0, 100);
-    private final AltinnTilgangerDto altinn3Organisasjoner = null;
+    private final AltinnTilgangerDto altinn3Organisasjoner = TestData.enAltinnTilgangerDto(Map.of());
 
     @BeforeEach
     public void setup() {

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/TestData.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/TestData.java
@@ -3,6 +3,7 @@ package no.nav.tag.tiltaksgjennomforing.avtale;
 import no.nav.arbeidsgiver.altinnrettigheter.proxy.klient.model.AltinnReportee;
 import no.nav.tag.tiltaksgjennomforing.autorisasjon.AdGruppeTilganger;
 import no.nav.tag.tiltaksgjennomforing.autorisasjon.InnloggetArbeidsgiver;
+import no.nav.tag.tiltaksgjennomforing.autorisasjon.altinntilgangsstyring.AltinnTilgangerDto;
 import no.nav.tag.tiltaksgjennomforing.autorisasjon.InnloggetBeslutter;
 import no.nav.tag.tiltaksgjennomforing.autorisasjon.InnloggetDeltaker;
 import no.nav.tag.tiltaksgjennomforing.autorisasjon.InnloggetMentor;
@@ -29,6 +30,7 @@ import no.nav.team_tiltak.felles.persondata.pdl.domene.Navn;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
@@ -906,10 +908,17 @@ public class TestData {
         return new InnloggetBeslutter(new NavIdent("F888888"), Set.of(ENHET_OPPFØLGING));
     }
 
+    public static AltinnTilgangerDto enAltinnTilgangerDto(Map<BedriftNr, ? extends Collection<Tiltakstype>> tilganger) {
+        Map<BedriftNr, Set<Tiltakstype>> converted = tilganger.entrySet().stream()
+            .collect(java.util.stream.Collectors.toMap(Map.Entry::getKey, e -> Set.copyOf(e.getValue())));
+        return new AltinnTilgangerDto(List.of(), converted);
+    }
+
     public static Arbeidsgiver enArbeidsgiver() {
         PersondataService persondataService = mock(PersondataService.class);
         when(persondataService.hentDiskresjonskode(any(Fnr.class))).thenReturn(Diskresjonskode.UGRADERT);
-        return new Arbeidsgiver(Fnr.generer(1978, 9, 10), Set.of(), Map.of(), null, List.of(), persondataService, null, null, null);
+        Map<BedriftNr, Collection<Tiltakstype>> tilganger = Map.of();
+        return new Arbeidsgiver(Fnr.generer(1978, 9, 10), Set.of(), tilganger, enAltinnTilgangerDto(tilganger), List.of(), persondataService, null, null, null);
     }
 
     public static Mentor enMentor(Avtale avtale) {
@@ -917,12 +926,12 @@ public class TestData {
     }
 
     public static Arbeidsgiver enArbeidsgiver(Avtale avtale) {
+        Map<BedriftNr, Collection<Tiltakstype>> tilganger = Map.of(avtale.getBedriftNr(), List.of(Tiltakstype.values()));
         return new Arbeidsgiver(
                 TestData.etFodselsnummer(),
-                Set.of(new AltinnReportee("Bedriftnavn", "", null, avtale.getBedriftNr().asString(), "", "", null))
-                , Map.of(avtale.getBedriftNr(),
-                List.of(Tiltakstype.values())),
-                null,
+                Set.of(new AltinnReportee("Bedriftnavn", "", null, avtale.getBedriftNr().asString(), "", "", null)),
+                tilganger,
+                enAltinnTilgangerDto(tilganger),
                 List.of(),
                 mock(PersondataService.class),
                 null,


### PR DESCRIPTION
`altinnTilganger.tilganger()` erstatter `tilganger` og  inneholder i praksis det samme — en map fra BedriftNr til hvilke Tiltakstype bedriften har tilgang til — men altinnTilganger er den nye Altinn 3-baserte kilden.

Per nå er det kun fireårig lønnstilskudd som ikke finnes i den gamle, men snart skrurs den gamle av.

TL;DR: 
Denne PR-en endrer slik at tilgangsstyring går gjennom nytt api/altinn 3. Tidligere endiringer gjorde kun slik at respons fra nytt api/altinn 3 ble eksponert til frontend og der brukt i virksomhetsvelgeren.