### PR TITLE
Adressesperre altinn 3

### DIFF
--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/InnloggingService.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/InnloggingService.java
@@ -74,7 +74,7 @@ public class InnloggingService {
             Map<BedriftNr, Collection<Tiltakstype>> tilganger = altinnTilgangsstyringService.hentTilganger(
                 new Fnr(brukerOgIssuer.getBrukerIdent()), hentArbeidsgiverToken);
             AltinnTilgangerDto altinnTilganger = altinnTilgangsstyringService.hentAltinnTilganger();
-            List<BedriftNr> adressesperreTilganger = altinnTilgangsstyringService.hentAdressesperreTilganger(new Fnr(brukerOgIssuer.getBrukerIdent()), hentArbeidsgiverToken);
+            List<BedriftNr> adressesperreTilganger = altinnTilganger.adressesperreTilganger();
             log.info(
                 "InnloggetArbeidsgiver - bedrifter: altinn2TilgangerBedrifter={}, altinn3TilgangerBedrifter={}, tilganger: altinn2TotaltTilganger={}, altinn3TotaltTilganger={}",
                 tilganger.size(),

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/altinntilgangsstyring/AltinnTilgangerDto.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/altinntilgangsstyring/AltinnTilgangerDto.java
@@ -9,5 +9,6 @@ import java.util.Set;
 
 public record AltinnTilgangerDto(
     List<AltinnTilgang> hierarki,
-    Map<BedriftNr, Set<Tiltakstype>> tilganger
+    Map<BedriftNr, Set<Tiltakstype>> tilganger,
+    List<BedriftNr> adressesperreTilganger
 ) {}

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/altinntilgangsstyring/AltinnTilgangsstyringProperties.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/altinntilgangsstyring/AltinnTilgangsstyringProperties.java
@@ -46,7 +46,7 @@ public class AltinnTilgangsstyringProperties {
     private static final String MENTOR = "nav_tiltak_mentor";
     private static final String INKLUDERINGSTILSKUDD = "nav_tiltak_inkluderingstilskudd";
     private static final String VTAO = "nav_tiltak_varig-tilrettelagt-arbeid-ordinaer";
-    private static final String ADRESSESPERRE = "nav_tiltak_adressesperre";
+    static final String ADRESSESPERRE = "nav_tiltak_adressesperre";
     private static final String FIREARIG_LONNSTILSKUDD = "nav_tiltak_firearig-lonnstilskudd";
 
     public Map<String, Tiltakstype> tilgangerTilTiltakstype() {

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/altinntilgangsstyring/AltinnTilgangsstyringProperties.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/altinntilgangsstyring/AltinnTilgangsstyringProperties.java
@@ -46,8 +46,8 @@ public class AltinnTilgangsstyringProperties {
     private static final String MENTOR = "nav_tiltak_mentor";
     private static final String INKLUDERINGSTILSKUDD = "nav_tiltak_inkluderingstilskudd";
     private static final String VTAO = "nav_tiltak_varig-tilrettelagt-arbeid-ordinaer";
-    static final String ADRESSESPERRE = "nav_tiltak_adressesperre";
     private static final String FIREARIG_LONNSTILSKUDD = "nav_tiltak_firearig-lonnstilskudd";
+    static final String ADRESSESPERRE = "nav_tiltak_adressesperre";
 
     public Map<String, Tiltakstype> tilgangerTilTiltakstype() {
         Map<String, Tiltakstype> map = new HashMap<>();

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/altinntilgangsstyring/AltinnTilgangsstyringService.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/altinntilgangsstyring/AltinnTilgangsstyringService.java
@@ -44,7 +44,7 @@ public class AltinnTilgangsstyringService {
             TokenUtils tokenUtils,
             RestTemplate azureRestTemplate,
             @Value("${spring.application.name}") String applicationName) {
-Œ
+
         if (Utils.erNoenTomme(altinnTilgangsstyringProperties.getArbtreningServiceCode(),
                 altinnTilgangsstyringProperties.getArbtreningServiceEdition(),
                 altinnTilgangsstyringProperties.getLtsMidlertidigServiceCode(),

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/altinntilgangsstyring/AltinnTilgangsstyringService.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/altinntilgangsstyring/AltinnTilgangsstyringService.java
@@ -25,7 +25,6 @@ import org.springframework.web.client.ResourceAccessException;
 import org.springframework.web.client.RestClientResponseException;
 import org.springframework.web.client.RestTemplate;
 
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -45,7 +44,7 @@ public class AltinnTilgangsstyringService {
             TokenUtils tokenUtils,
             RestTemplate azureRestTemplate,
             @Value("${spring.application.name}") String applicationName) {
-
+Œ
         if (Utils.erNoenTomme(altinnTilgangsstyringProperties.getArbtreningServiceCode(),
                 altinnTilgangsstyringProperties.getArbtreningServiceEdition(),
                 altinnTilgangsstyringProperties.getLtsMidlertidigServiceCode(),

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/altinntilgangsstyring/AltinnTilgangsstyringService.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/altinntilgangsstyring/AltinnTilgangsstyringService.java
@@ -76,15 +76,6 @@ public class AltinnTilgangsstyringService {
         this.klient = new AltinnrettigheterProxyKlient(proxyKlientConfig);
     }
 
-    public List<BedriftNr> hentAdressesperreTilganger(Fnr fnr, HentArbeidsgiverToken hentArbeidsgiverToken) {
-        String arbeidsgiverToken = hentArbeidsgiverToken.hentArbeidsgiverToken();
-        AltinnReportee[] adressesperreTilganger = kallAltinn(altinnTilgangsstyringProperties.getAdressesperreServiceCode(), altinnTilgangsstyringProperties.getAdressesperreServiceEdition(), fnr, arbeidsgiverToken);
-        List<BedriftNr> bedrifter = Arrays.stream(adressesperreTilganger)
-                .filter(altinnReportee -> !altinnReportee.getType().equals("Enterprise"))
-                .map(altinnReportee -> new BedriftNr(altinnReportee.getOrganizationNumber()))
-                .toList();
-        return bedrifter;
-    }
 
     public Map<BedriftNr, Collection<Tiltakstype>> hentTilganger(Fnr fnr, HentArbeidsgiverToken hentArbeidsgiverToken) {
         MultiValueMap<BedriftNr, Tiltakstype> tilganger = MultiValueMap.empty();
@@ -154,10 +145,35 @@ public class AltinnTilgangsstyringService {
 
         return new AltinnTilgangerDto(
             response.hierarki(),
-            mapTilgangerFraAltinn3(response)
+            mapTilgangerFraAltinn3(response),
+            mapAdressesperreFraAltinn3(response)
         );
     }
-    
+
+    private List<BedriftNr> mapAdressesperreFraAltinn3(AltinnTilgangerResponse response) {
+        if (response.tilgangTilOrgNr() == null) {
+            return List.of();
+        }
+        Set<String> orgNrs = new HashSet<>();
+
+        // Altinn 3 ressurs
+        Set<String> altinn3 = response.tilgangTilOrgNr().get(AltinnTilgangsstyringProperties.ADRESSESPERRE);
+        if (altinn3 != null) {
+            orgNrs.addAll(altinn3);
+        }
+
+        // Altinn 2 serviceCode:serviceEdition
+        // Kan fjernes på sikt (juni 26) - letter overgangen til Altinn 3
+        String altinn2Key = altinnTilgangsstyringProperties.getAdressesperreServiceCode()
+            + ":" + altinnTilgangsstyringProperties.getAdressesperreServiceEdition();
+        Set<String> altinn2 = response.tilgangTilOrgNr().get(altinn2Key);
+        if (altinn2 != null) {
+            orgNrs.addAll(altinn2);
+        }
+
+        return orgNrs.stream().map(BedriftNr::new).toList();
+    }
+
     private Map<BedriftNr, Set<Tiltakstype>> mapTilgangerFraAltinn3(AltinnTilgangerResponse response) {
         Map<String, Tiltakstype> tilgangerTilTiltakstype = altinnTilgangsstyringProperties.tilgangerTilTiltakstype();
         Map<BedriftNr, Set<Tiltakstype>> tilganger = new HashMap<>();

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/altinntilgangsstyring/AltinnTilgangsstyringService.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/altinntilgangsstyring/AltinnTilgangsstyringService.java
@@ -164,9 +164,9 @@ public class AltinnTilgangsstyringService {
 
         // Altinn 2 serviceCode:serviceEdition
         // Kan fjernes på sikt (juni 26) - letter overgangen til Altinn 3
-        String altinn2Key = altinnTilgangsstyringProperties.getAdressesperreServiceCode()
+        String altinn2Tilgang = altinnTilgangsstyringProperties.getAdressesperreServiceCode()
             + ":" + altinnTilgangsstyringProperties.getAdressesperreServiceEdition();
-        Set<String> altinn2 = response.tilgangTilOrgNr().get(altinn2Key);
+        Set<String> altinn2 = response.tilgangTilOrgNr().get(altinn2Tilgang);
         if (altinn2 != null) {
             orgNrs.addAll(altinn2);
         }

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/InnloggingServiceTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/InnloggingServiceTest.java
@@ -83,10 +83,10 @@ public class InnloggingServiceTest {
 
     @Test
     public void hentInnloggetBruker__selvbetjeningbruker_type_arbeidsgiver_skal_hente_organisasjoner() {
-        InnloggetArbeidsgiver selvbetjeningBruker = new InnloggetArbeidsgiver(new Fnr("11111111111"), Set.of(), Map.of(), new AltinnTilgangerDto(List.of(), Map.of()));
+        InnloggetArbeidsgiver selvbetjeningBruker = new InnloggetArbeidsgiver(new Fnr("11111111111"), Set.of(), Map.of(), new AltinnTilgangerDto(List.of(), Map.of(), List.of()));
         when(altinnTilgangsstyringService.hentTilganger(eq(selvbetjeningBruker.getIdentifikator()), any())).thenReturn(Map.of());
         when(altinnTilgangsstyringService.hentAltinnOrganisasjoner(eq(selvbetjeningBruker.getIdentifikator()), any())).thenReturn(Set.of());
-        when(altinnTilgangsstyringService.hentAltinnTilganger()).thenReturn(new AltinnTilgangerDto(List.of(), Map.of()));
+        when(altinnTilgangsstyringService.hentAltinnTilganger()).thenReturn(new AltinnTilgangerDto(List.of(), Map.of(), List.of()));
         værInnloggetArbeidsgiver(selvbetjeningBruker);
 
        when(arbeidsgiverTokenStrategyFactory.create(Issuer.ISSUER_TOKENX)).thenReturn(() -> "");

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/TestData.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/TestData.java
@@ -911,7 +911,7 @@ public class TestData {
     public static AltinnTilgangerDto enAltinnTilgangerDto(Map<BedriftNr, ? extends Collection<Tiltakstype>> tilganger) {
         Map<BedriftNr, Set<Tiltakstype>> converted = tilganger.entrySet().stream()
             .collect(java.util.stream.Collectors.toMap(Map.Entry::getKey, e -> Set.copyOf(e.getValue())));
-        return new AltinnTilgangerDto(List.of(), converted);
+        return new AltinnTilgangerDto(List.of(), converted, List.of());
     }
 
     public static Arbeidsgiver enArbeidsgiver() {


### PR DESCRIPTION
Bytter til å hente adressesperretilgang via nytt api. Sjekker på link linje med de andre altinn tilgangene både altinn 2 og altinn 3 varianten av adressesperre.
Utledes nå fra opprinnelig kall til nytt api, slik at vi kaller altinn 1 gang mindre.