### PR TITLE
fix. Gjør beregningsstrategier uavhengige av gjeldendeInnhold

### DIFF
--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/Avtale.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/Avtale.java
@@ -1091,11 +1091,11 @@ public class Avtale extends AbstractAggregateRoot<Avtale> implements AuditerbarE
     }
 
     Integer beregnTilskuddsprosentForPeriode(LocalDate startdato, LocalDate sluttdato) {
-        return this.hentBeregningStrategi().getProsentForPeriode(this, Periode.av(startdato, sluttdato));
+        return this.hentBeregningStrategi().getProsentForPeriode(this, gjeldendeInnhold, Periode.av(startdato, sluttdato));
     }
 
     Integer beregnTilskuddsbeløpForPeriode(LocalDate startdato, LocalDate sluttdato) {
-        return this.hentBeregningStrategi().getBeløpForPeriode(this, Periode.av(startdato, sluttdato));
+        return this.hentBeregningStrategi().getBeløpForPeriode(this, gjeldendeInnhold, Periode.av(startdato, sluttdato));
     }
 
     private void nyeTilskuddsperioder() {

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/transportlag/TilskuddstrinnDTO.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/transportlag/TilskuddstrinnDTO.java
@@ -29,7 +29,7 @@ public record TilskuddstrinnDTO(
         Avtale avtale = db.getAvtale();
         BeregningStrategy strategy = avtale.hentBeregningStrategi();
         if (strategy instanceof GenerellLonnstilskuddAvtaleBeregningStrategy ltsStrategy) {
-            return ltsStrategy.getTilskuddstrinn(avtale).stream().map(TilskuddstrinnDTO::new).toList();
+            return ltsStrategy.getTilskuddstrinn(avtale, db).stream().map(TilskuddstrinnDTO::new).toList();
         }
         return Collections.emptyList();
     }

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/tilskuddsperiode/beregning/BeregningStrategy.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/tilskuddsperiode/beregning/BeregningStrategy.java
@@ -1,6 +1,7 @@
 package no.nav.tag.tiltaksgjennomforing.tilskuddsperiode.beregning;
 
 import no.nav.tag.tiltaksgjennomforing.avtale.Avtale;
+import no.nav.tag.tiltaksgjennomforing.avtale.AvtaleInnhold;
 import no.nav.tag.tiltaksgjennomforing.avtale.TilskuddPeriode;
 import no.nav.tag.tiltaksgjennomforing.avtale.TilskuddPeriodeStatus;
 import no.nav.tag.tiltaksgjennomforing.avtale.Tiltakstype;
@@ -70,11 +71,11 @@ public interface BeregningStrategy {
         }
     }
 
-    default Integer getBeløpForPeriode(Avtale avtale, Periode periode) {
+    default Integer getBeløpForPeriode(Avtale avtale, AvtaleInnhold avtaleInnhold, Periode periode) {
         return 0;
     }
 
-    default Integer getProsentForPeriode(Avtale avtale, Periode periode) {
+    default Integer getProsentForPeriode(Avtale avtale, AvtaleInnhold avtaleInnhold, Periode periode) {
         return null;
     }
 

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/tilskuddsperiode/beregning/FirearigLonnstilskuddBeregningStrategy.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/tilskuddsperiode/beregning/FirearigLonnstilskuddBeregningStrategy.java
@@ -1,6 +1,7 @@
 package no.nav.tag.tiltaksgjennomforing.tilskuddsperiode.beregning;
 
 import no.nav.tag.tiltaksgjennomforing.avtale.Avtale;
+import no.nav.tag.tiltaksgjennomforing.avtale.AvtaleInnhold;
 import no.nav.tag.tiltaksgjennomforing.utils.Periode;
 
 import java.time.LocalDate;
@@ -18,8 +19,8 @@ public class FirearigLonnstilskuddBeregningStrategy extends GenerellLonnstilskud
     }
 
     @Override
-    public Integer getProsentForPeriode(Avtale avtale, Periode periode) {
-        LocalDate avtaleStart = avtale.getGjeldendeInnhold().getStartDato();
+    public Integer getProsentForPeriode(Avtale avtale, AvtaleInnhold avtaleInnhold, Periode periode) {
+        LocalDate avtaleStart = avtaleInnhold.getStartDato();
         LocalDate tilskuddSlutt = periode.getSlutt();
 
         if (tilskuddSlutt.isBefore(avtaleStart.plusYears(1))) {
@@ -39,9 +40,9 @@ public class FirearigLonnstilskuddBeregningStrategy extends GenerellLonnstilskud
     }
 
     @Override
-    public List<LocalDate> getDatoerForReduksjon(Avtale avtale) {
-        LocalDate startDato = avtale.getGjeldendeInnhold().getStartDato();
-        LocalDate sluttDato = avtale.getGjeldendeInnhold().getSluttDato();
+    public List<LocalDate> getDatoerForReduksjon(Avtale avtale, AvtaleInnhold avtaleInnhold) {
+        LocalDate startDato = avtaleInnhold.getStartDato();
+        LocalDate sluttDato = avtaleInnhold.getSluttDato();
 
         if (startDato == null || sluttDato == null) {
             return Collections.emptyList();

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/tilskuddsperiode/beregning/GenerellLonnstilskuddAvtaleBeregningStrategy.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/tilskuddsperiode/beregning/GenerellLonnstilskuddAvtaleBeregningStrategy.java
@@ -18,7 +18,7 @@ import static no.nav.tag.tiltaksgjennomforing.utils.Utils.fikseLøpenumre;
 import static no.nav.tag.tiltaksgjennomforing.utils.Utils.toBigDecimal;
 
 public abstract class GenerellLonnstilskuddAvtaleBeregningStrategy implements BeregningStrategy {
-    public abstract List<LocalDate> getDatoerForReduksjon(Avtale avtale);
+    public abstract List<LocalDate> getDatoerForReduksjon(Avtale avtale, AvtaleInnhold avtaleInnhold);
 
     @Override
     public List<TilskuddPeriode> genererNyeTilskuddsperioder(Avtale avtale) {
@@ -102,7 +102,8 @@ public abstract class GenerellLonnstilskuddAvtaleBeregningStrategy implements Be
         LocalDate datoFraOgMed,
         LocalDate datoTilOgMed
     ) {
-        List<Periode> reduksjonsperioder = Periode.av(datoFraOgMed, datoTilOgMed).split(getDatoerForReduksjon(avtale));
+        List<Periode> reduksjonsperioder = Periode.av(datoFraOgMed, datoTilOgMed)
+            .split(getDatoerForReduksjon(avtale, avtale.getGjeldendeInnhold()));
 
         return reduksjonsperioder
             .stream()
@@ -139,33 +140,33 @@ public abstract class GenerellLonnstilskuddAvtaleBeregningStrategy implements Be
     }
 
     @Override
-    public Integer getBeløpForPeriode(Avtale avtale, Periode periode) {
-        Integer prosentForPeriode = getProsentForPeriode(avtale, periode);
-        return getBeløpForPeriode(avtale, prosentForPeriode, periode);
+    public Integer getBeløpForPeriode(Avtale avtale, AvtaleInnhold avtaleInnhold, Periode periode) {
+        Integer prosentForPeriode = getProsentForPeriode(avtale, avtaleInnhold, periode);
+        return getBeløpForPeriode(avtaleInnhold, prosentForPeriode, periode);
     }
 
-    private Integer getBeløpForPeriode(Avtale avtale, Integer prosent, Periode periode) {
+    private Integer getBeløpForPeriode(AvtaleInnhold avtaleInnhold, Integer prosent, Periode periode) {
         Integer lonnstilskudd = BeregningStrategy.getSumLonnstilskudd(
-            avtale.getGjeldendeInnhold().getSumLonnsutgifter(),
+            avtaleInnhold.getSumLonnsutgifter(),
             prosent
         );
         return BeregningStrategy.beløpForPeriode(periode, lonnstilskudd);
     }
 
-    public List<Tilskuddstrinn> getTilskuddstrinn(Avtale avtale) {
-        LocalDate startdato = avtale.getGjeldendeInnhold().getStartDato();
-        LocalDate sluttdato = avtale.getGjeldendeInnhold().getSluttDato();
-        Integer sumLonnsutgifter = avtale.getGjeldendeInnhold().getSumLonnsutgifter();
+    public List<Tilskuddstrinn> getTilskuddstrinn(Avtale avtale, AvtaleInnhold avtaleInnhold) {
+        LocalDate startdato = avtaleInnhold.getStartDato();
+        LocalDate sluttdato = avtaleInnhold.getSluttDato();
+        Integer sumLonnsutgifter = avtaleInnhold.getSumLonnsutgifter();
 
         if (startdato == null || sluttdato == null) {
             return Collections.emptyList();
         }
 
         return Periode.av(startdato, sluttdato)
-            .split(getDatoerForReduksjon(avtale))
+            .split(getDatoerForReduksjon(avtale, avtaleInnhold))
             .stream()
             .map(periode -> {
-                Integer prosent = getProsentForPeriode(avtale, periode);
+                Integer prosent = getProsentForPeriode(avtale, avtaleInnhold, periode);
                 Integer belopPerMnd = BeregningStrategy.getSumLonnstilskudd(sumLonnsutgifter, prosent);
                 return new Tilskuddstrinn(
                     periode.getStart(),
@@ -178,8 +179,8 @@ public abstract class GenerellLonnstilskuddAvtaleBeregningStrategy implements Be
     }
 
     TilskuddPeriode lagTilskuddsperiode(Avtale avtale, Periode periode) {
-        Integer prosent = getProsentForPeriode(avtale, periode);
-        Integer beløp = getBeløpForPeriode(avtale, prosent, periode);
+        Integer prosent = getProsentForPeriode(avtale, avtale.getGjeldendeInnhold(), periode);
+        Integer beløp = getBeløpForPeriode(avtale.getGjeldendeInnhold(), prosent, periode);
         TilskuddPeriode tilskuddsperiode = new TilskuddPeriode(
             beløp,
             periode.getStart(),

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/tilskuddsperiode/beregning/MentorBeregningStrategy.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/tilskuddsperiode/beregning/MentorBeregningStrategy.java
@@ -150,11 +150,11 @@ public class MentorBeregningStrategy implements BeregningStrategy {
     }
 
     @Override
-    public Integer getBeløpForPeriode(Avtale avtale, Periode periode) {
+    public Integer getBeløpForPeriode(Avtale avtale, AvtaleInnhold avtaleInnhold, Periode periode) {
         if (!nødvendigeFelterErUtfyltForBeregningAvTilskuddsbeløp(avtale)) {
             return null;
         }
 
-        return BeregningStrategy.beløpForPeriode(periode, avtale.getGjeldendeInnhold().getSumLonnsutgifter());
+        return BeregningStrategy.beløpForPeriode(periode, avtaleInnhold.getSumLonnsutgifter());
     }
 }

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/tilskuddsperiode/beregning/MidlertidigLonnstilskuddAvtaleBeregningStrategy.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/tilskuddsperiode/beregning/MidlertidigLonnstilskuddAvtaleBeregningStrategy.java
@@ -1,6 +1,7 @@
 package no.nav.tag.tiltaksgjennomforing.tilskuddsperiode.beregning;
 
 import no.nav.tag.tiltaksgjennomforing.avtale.Avtale;
+import no.nav.tag.tiltaksgjennomforing.avtale.AvtaleInnhold;
 import no.nav.tag.tiltaksgjennomforing.utils.Periode;
 
 import java.time.LocalDate;
@@ -22,8 +23,8 @@ public class MidlertidigLonnstilskuddAvtaleBeregningStrategy extends GenerellLon
     }
 
     @Override
-    public Integer getProsentForPeriode(Avtale avtale, Periode periode) {
-        Optional<LocalDate> datoForRedusertProsent = getDatoerForReduksjon(avtale).stream().findFirst();
+    public Integer getProsentForPeriode(Avtale avtale, AvtaleInnhold avtaleInnhold, Periode periode) {
+        Optional<LocalDate> datoForRedusertProsent = getDatoerForReduksjon(avtale, avtaleInnhold).stream().findFirst();
 
         Integer tilskuddsprosent = getProsentForForstePeriode(avtale);
         if (tilskuddsprosent == null) {
@@ -38,9 +39,9 @@ public class MidlertidigLonnstilskuddAvtaleBeregningStrategy extends GenerellLon
     }
 
     @Override
-    public List<LocalDate> getDatoerForReduksjon(Avtale avtale) {
-        LocalDate startDato = avtale.getGjeldendeInnhold().getStartDato();
-        LocalDate sluttDato = avtale.getGjeldendeInnhold().getSluttDato();
+    public List<LocalDate> getDatoerForReduksjon(Avtale avtale, AvtaleInnhold avtaleInnhold) {
+        LocalDate startDato = avtaleInnhold.getStartDato();
+        LocalDate sluttDato = avtaleInnhold.getSluttDato();
 
         if (startDato == null || sluttDato == null) {
             return Collections.emptyList();

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/tilskuddsperiode/beregning/SommerjobbLonnstilskuddAvtaleBeregningStrategy.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/tilskuddsperiode/beregning/SommerjobbLonnstilskuddAvtaleBeregningStrategy.java
@@ -2,6 +2,7 @@ package no.nav.tag.tiltaksgjennomforing.tilskuddsperiode.beregning;
 
 
 import no.nav.tag.tiltaksgjennomforing.avtale.Avtale;
+import no.nav.tag.tiltaksgjennomforing.avtale.AvtaleInnhold;
 import no.nav.tag.tiltaksgjennomforing.utils.Periode;
 
 import java.time.LocalDate;
@@ -13,12 +14,12 @@ public class SommerjobbLonnstilskuddAvtaleBeregningStrategy extends GenerellLonn
     public static int TILSKUDDSPROSENT_MIN = 50;
 
     @Override
-    public Integer getProsentForPeriode(Avtale avtale, Periode periode) {
-        return avtale.getGjeldendeInnhold().getLonnstilskuddProsent();
+    public Integer getProsentForPeriode(Avtale avtale, AvtaleInnhold avtaleInnhold, Periode periode) {
+        return avtaleInnhold.getLonnstilskuddProsent();
     }
 
     @Override
-    public List<LocalDate> getDatoerForReduksjon(Avtale avtale) {
+    public List<LocalDate> getDatoerForReduksjon(Avtale avtale, AvtaleInnhold avtaleInnhold) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/tilskuddsperiode/beregning/VTAOAvtaleBeregningStrategy.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/tilskuddsperiode/beregning/VTAOAvtaleBeregningStrategy.java
@@ -2,6 +2,7 @@ package no.nav.tag.tiltaksgjennomforing.tilskuddsperiode.beregning;
 
 import no.nav.tag.tiltaksgjennomforing.arena.models.arena.ArenaTiltakskode;
 import no.nav.tag.tiltaksgjennomforing.avtale.Avtale;
+import no.nav.tag.tiltaksgjennomforing.avtale.AvtaleInnhold;
 import no.nav.tag.tiltaksgjennomforing.avtale.Avtaleopphav;
 import no.nav.tag.tiltaksgjennomforing.avtale.TilskuddPeriode;
 import no.nav.tag.tiltaksgjennomforing.exceptions.Feilkode;
@@ -88,7 +89,7 @@ public class VTAOAvtaleBeregningStrategy implements BeregningStrategy {
     }
 
     @Override
-    public Integer getBeløpForPeriode(Avtale avtale, Periode periode) {
+    public Integer getBeløpForPeriode(Avtale avtale, AvtaleInnhold avtaleInnhold, Periode periode) {
         var vtaoSats = VTAO_SATS.hentGjeldendeSats(periode.getStart());
         if (vtaoSats == null) {
             return null;

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/tilskuddsperiode/beregning/VarigLonnstilskuddAvtaleBeregningStrategy.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/tilskuddsperiode/beregning/VarigLonnstilskuddAvtaleBeregningStrategy.java
@@ -14,27 +14,27 @@ public class VarigLonnstilskuddAvtaleBeregningStrategy extends GenerellLonnstils
     public static final int TILSKUDDSPROSENT_REDUSERT_MAKS = 67;
 
     @Override
-    public Integer getProsentForPeriode(Avtale avtale, Periode periode) {
-        Optional<LocalDate> datoForRedusertProsent = getDatoerForReduksjon(avtale).stream().findFirst();
+    public Integer getProsentForPeriode(Avtale avtale, AvtaleInnhold avtaleInnhold, Periode periode) {
+        Optional<LocalDate> datoForRedusertProsent = getDatoerForReduksjon(avtale, avtaleInnhold).stream().findFirst();
 
         boolean erRedusert = datoForRedusertProsent
             .map(dato -> !periode.getSlutt().isBefore(dato))
             .orElse(false);
 
-        int lonnstilskuddProsent = avtale.getGjeldendeInnhold().getLonnstilskuddProsent() != null ? avtale.getGjeldendeInnhold().getLonnstilskuddProsent() : 0;
+        int lonnstilskuddProsent = avtaleInnhold.getLonnstilskuddProsent() != null ? avtaleInnhold.getLonnstilskuddProsent() : 0;
 
         return Math.min(lonnstilskuddProsent, erRedusert ? TILSKUDDSPROSENT_REDUSERT_MAKS : TILSKUDDSPROSENT_MAKS);
     }
 
     @Override
-    public List<LocalDate> getDatoerForReduksjon(Avtale avtale) {
-        LocalDate startDato = avtale.getGjeldendeInnhold().getStartDato();
-        LocalDate sluttDato = avtale.getGjeldendeInnhold().getSluttDato();
+    public List<LocalDate> getDatoerForReduksjon(Avtale avtale, AvtaleInnhold avtaleInnhold) {
+        LocalDate startDato = avtaleInnhold.getStartDato();
+        LocalDate sluttDato = avtaleInnhold.getSluttDato();
         if (startDato == null || sluttDato == null) {
             return Collections.emptyList();
         }
 
-        Integer lonnstilskuddProsent = avtale.getGjeldendeInnhold().getLonnstilskuddProsent();
+        Integer lonnstilskuddProsent = avtaleInnhold.getLonnstilskuddProsent();
         if (lonnstilskuddProsent != null && lonnstilskuddProsent <= TILSKUDDSPROSENT_REDUSERT_MAKS) {
             return Collections.emptyList();
         }

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/tilskuddsperiode/beregning/FirearigLonnstilskuddBeregningStrategyTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/tilskuddsperiode/beregning/FirearigLonnstilskuddBeregningStrategyTest.java
@@ -2,10 +2,14 @@ package no.nav.tag.tiltaksgjennomforing.tilskuddsperiode.beregning;
 
 import no.bekk.bekkopen.person.FodselsnummerValidator;
 import no.nav.tag.tiltaksgjennomforing.avtale.Avtale;
+import no.nav.tag.tiltaksgjennomforing.avtale.AvtaleInnhold;
 import no.nav.tag.tiltaksgjennomforing.avtale.TestData;
 import no.nav.tag.tiltaksgjennomforing.avtale.Tiltakstype;
+import no.nav.tag.tiltaksgjennomforing.avtale.startOgSluttDatoStrategy.FirearigLonnstilskuddProperties;
 import no.nav.tag.tiltaksgjennomforing.utils.Periode;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -25,6 +29,22 @@ class FirearigLonnstilskuddBeregningStrategyTest {
     private final FirearigLonnstilskuddBeregningStrategy strategy =
             new FirearigLonnstilskuddBeregningStrategy();
 
+    @BeforeAll
+    static void setupFirearigProperties() throws Exception {
+        FirearigLonnstilskuddProperties props = new FirearigLonnstilskuddProperties();
+        props.setDato(LocalDate.of(2024, 1, 1));
+        var field = FirearigLonnstilskuddProperties.class.getDeclaredField("instance");
+        field.setAccessible(true);
+        field.set(null, props);
+    }
+
+    @AfterAll
+    static void teardownFirearigProperties() throws Exception {
+        var field = FirearigLonnstilskuddProperties.class.getDeclaredField("instance");
+        field.setAccessible(true);
+        field.set(null, null);
+    }
+
     @BeforeEach
     void setup() {
         FodselsnummerValidator.ALLOW_SYNTHETIC_NUMBERS = true;
@@ -42,20 +62,27 @@ class FirearigLonnstilskuddBeregningStrategyTest {
         return avtale;
     }
 
+    private static AvtaleInnhold innholdMedDatoer(LocalDate startDato, LocalDate sluttDato) {
+        AvtaleInnhold innhold = new AvtaleInnhold();
+        innhold.setStartDato(startDato);
+        innhold.setSluttDato(sluttDato);
+        return innhold;
+    }
+
     @Test
     void getDatoerForReduksjon__returnerer_tom_liste_naar_startdato_er_null() {
-        Avtale avtale = lagAvtaleMedDatoer(null, LocalDate.of(2028, 1, 1));
+        Avtale avtale = TestData.enLonnstilskuddAvtaleMedAltUtfylt(Tiltakstype.FIREARIG_LONNSTILSKUDD);
 
-        List<LocalDate> result = strategy.getDatoerForReduksjon(avtale);
+        List<LocalDate> result = strategy.getDatoerForReduksjon(avtale, innholdMedDatoer(null, LocalDate.of(2028, 1, 1)));
 
         assertThat(result).isEmpty();
     }
 
     @Test
     void getDatoerForReduksjon__returnerer_tom_liste_naar_sluttdato_er_null() {
-        Avtale avtale = lagAvtaleMedDatoer(LocalDate.of(2027, 1, 1), null);
+        Avtale avtale = TestData.enLonnstilskuddAvtaleMedAltUtfylt(Tiltakstype.FIREARIG_LONNSTILSKUDD);
 
-        List<LocalDate> result = strategy.getDatoerForReduksjon(avtale);
+        List<LocalDate> result = strategy.getDatoerForReduksjon(avtale, innholdMedDatoer(LocalDate.of(2027, 1, 1), null));
 
         assertThat(result).isEmpty();
     }
@@ -64,9 +91,9 @@ class FirearigLonnstilskuddBeregningStrategyTest {
     void getDatoerForReduksjon__returnerer_alle_tre_reduksjonsdatoer_for_fireaarig_avtale() {
         LocalDate startDato = LocalDate.of(2028, 1, 1);
         LocalDate sluttDato = LocalDate.of(2031, 12, 31);
-        Avtale avtale = lagAvtaleMedDatoer(startDato, sluttDato);
+        Avtale avtale = TestData.enLonnstilskuddAvtaleMedAltUtfylt(Tiltakstype.FIREARIG_LONNSTILSKUDD);
 
-        List<LocalDate> result = strategy.getDatoerForReduksjon(avtale);
+        List<LocalDate> result = strategy.getDatoerForReduksjon(avtale, innholdMedDatoer(startDato, sluttDato));
 
         assertThat(result).containsExactly(
                 startDato.plusYears(1),
@@ -80,9 +107,9 @@ class FirearigLonnstilskuddBeregningStrategyTest {
         LocalDate startDato = LocalDate.of(2027, 1, 1);
         // Sluttdato er innenfor år 2 – bare første reduksjonsdato skal inkluderes
         LocalDate sluttDato = LocalDate.of(2028, 6, 30);
-        Avtale avtale = lagAvtaleMedDatoer(startDato, sluttDato);
+        Avtale avtale = TestData.enLonnstilskuddAvtaleMedAltUtfylt(Tiltakstype.FIREARIG_LONNSTILSKUDD);
 
-        List<LocalDate> result = strategy.getDatoerForReduksjon(avtale);
+        List<LocalDate> result = strategy.getDatoerForReduksjon(avtale, innholdMedDatoer(startDato, sluttDato));
 
         assertThat(result).containsExactly(startDato.plusYears(1));
     }
@@ -92,9 +119,9 @@ class FirearigLonnstilskuddBeregningStrategyTest {
         LocalDate startDato = LocalDate.of(2027, 1, 1);
         // Sluttdato er før første reduksjonsdato
         LocalDate sluttDato = LocalDate.of(2027, 12, 31);
-        Avtale avtale = lagAvtaleMedDatoer(startDato, sluttDato);
+        Avtale avtale = TestData.enLonnstilskuddAvtaleMedAltUtfylt(Tiltakstype.FIREARIG_LONNSTILSKUDD);
 
-        List<LocalDate> result = strategy.getDatoerForReduksjon(avtale);
+        List<LocalDate> result = strategy.getDatoerForReduksjon(avtale, innholdMedDatoer(startDato, sluttDato));
 
         assertThat(result).isEmpty();
     }
@@ -104,9 +131,9 @@ class FirearigLonnstilskuddBeregningStrategyTest {
         LocalDate startDato = LocalDate.of(2027, 1, 1);
         // Sluttdato er eksakt lik første reduksjonsdato
         LocalDate sluttDato = startDato.plusYears(1);
-        Avtale avtale = lagAvtaleMedDatoer(startDato, sluttDato);
+        Avtale avtale = TestData.enLonnstilskuddAvtaleMedAltUtfylt(Tiltakstype.FIREARIG_LONNSTILSKUDD);
 
-        List<LocalDate> result = strategy.getDatoerForReduksjon(avtale);
+        List<LocalDate> result = strategy.getDatoerForReduksjon(avtale, innholdMedDatoer(startDato, sluttDato));
 
         // !dato.isAfter(sluttDato) → includes the date when it equals sluttDato
         assertThat(result).containsExactly(startDato.plusYears(1));
@@ -116,9 +143,9 @@ class FirearigLonnstilskuddBeregningStrategyTest {
     void getDatoerForReduksjon__returnerer_to_datoer_naar_sluttdato_er_i_tredje_aar() {
         LocalDate startDato = LocalDate.of(2028, 1, 1);
         LocalDate sluttDato = LocalDate.of(2030, 6, 30);
-        Avtale avtale = lagAvtaleMedDatoer(startDato, sluttDato);
+        Avtale avtale = TestData.enLonnstilskuddAvtaleMedAltUtfylt(Tiltakstype.FIREARIG_LONNSTILSKUDD);
 
-        List<LocalDate> result = strategy.getDatoerForReduksjon(avtale);
+        List<LocalDate> result = strategy.getDatoerForReduksjon(avtale, innholdMedDatoer(startDato, sluttDato));
 
         assertThat(result).containsExactly(
                 startDato.plusYears(1),
@@ -129,8 +156,8 @@ class FirearigLonnstilskuddBeregningStrategyTest {
     @Test
     void getDatoerForReduksjon_handterer_skuddaar() {
         LocalDate startDato = LocalDate.of(2028, 2, 29);
-        Avtale avtale = lagAvtaleMedDatoer(startDato, LocalDate.of(2032, 2, 27));
-        List<LocalDate> reduksjon = strategy.getDatoerForReduksjon(avtale);
+        Avtale avtale = TestData.enLonnstilskuddAvtaleMedAltUtfylt(Tiltakstype.FIREARIG_LONNSTILSKUDD);
+        List<LocalDate> reduksjon = strategy.getDatoerForReduksjon(avtale, innholdMedDatoer(startDato, LocalDate.of(2032, 2, 27)));
 
         assertThat(reduksjon).containsExactly(
             LocalDate.of(2029, 2, 28),
@@ -143,8 +170,8 @@ class FirearigLonnstilskuddBeregningStrategyTest {
     void getDatoerForReduksjon_handterer_skuddaar_i_midten_av_trinn() {
         // Start 28.02 året før skuddår
         LocalDate startDato = LocalDate.of(2027, 2, 28);
-        Avtale avtale = lagAvtaleMedDatoer(startDato, LocalDate.of(2031, 2, 27));
-        List<LocalDate> reduksjon = strategy.getDatoerForReduksjon(avtale);
+        Avtale avtale = TestData.enLonnstilskuddAvtaleMedAltUtfylt(Tiltakstype.FIREARIG_LONNSTILSKUDD);
+        List<LocalDate> reduksjon = strategy.getDatoerForReduksjon(avtale, innholdMedDatoer(startDato, LocalDate.of(2031, 2, 27)));
 
         assertThat(reduksjon).containsExactly(
             LocalDate.of(2028, 2, 28), // 2028 = skuddaar
@@ -154,8 +181,8 @@ class FirearigLonnstilskuddBeregningStrategyTest {
 
         // Start 01.03 året før skuddår
         startDato = LocalDate.of(2027, 3, 1);
-        avtale = lagAvtaleMedDatoer(startDato, LocalDate.of(2031, 2, 27));
-        reduksjon = strategy.getDatoerForReduksjon(avtale);
+        avtale = TestData.enLonnstilskuddAvtaleMedAltUtfylt(Tiltakstype.FIREARIG_LONNSTILSKUDD);
+        reduksjon = strategy.getDatoerForReduksjon(avtale, innholdMedDatoer(startDato, LocalDate.of(2031, 2, 27)));
 
         assertThat(reduksjon).containsExactly(
             LocalDate.of(2028, 3, 1), // 2028 = skuddaar
@@ -171,7 +198,7 @@ class FirearigLonnstilskuddBeregningStrategyTest {
         // Perioden slutter innenfor første år
         Periode periode = new Periode(LocalDate.of(2028, 6, 1), LocalDate.of(2028, 6, 30));
 
-        Integer prosent = strategy.getProsentForPeriode(avtale, periode);
+        Integer prosent = strategy.getProsentForPeriode(avtale, avtale.getGjeldendeInnhold(), periode);
 
         assertThat(prosent).isEqualTo(PROSENT_AAR_1);
     }
@@ -183,7 +210,7 @@ class FirearigLonnstilskuddBeregningStrategyTest {
         // Perioden slutter i andre år (1 år etter start)
         Periode periode = new Periode(LocalDate.of(2028, 1, 1), LocalDate.of(2028, 1, 31));
 
-        Integer prosent = strategy.getProsentForPeriode(avtale, periode);
+        Integer prosent = strategy.getProsentForPeriode(avtale, avtale.getGjeldendeInnhold(), periode);
 
         assertThat(prosent).isEqualTo(PROSENT_AAR_2);
     }
@@ -195,7 +222,7 @@ class FirearigLonnstilskuddBeregningStrategyTest {
         // Perioden slutter i tredje år (2 år etter start)
         Periode periode = new Periode(LocalDate.of(2030, 1, 1), LocalDate.of(2030, 1, 31));
 
-        Integer prosent = strategy.getProsentForPeriode(avtale, periode);
+        Integer prosent = strategy.getProsentForPeriode(avtale, avtale.getGjeldendeInnhold(), periode);
 
         assertThat(prosent).isEqualTo(PROSENT_AAR_3);
     }
@@ -207,7 +234,7 @@ class FirearigLonnstilskuddBeregningStrategyTest {
         // Perioden slutter i fjerde år (3 år etter start)
         Periode periode = new Periode(LocalDate.of(2031, 1, 1), LocalDate.of(2031, 1, 31));
 
-        Integer prosent = strategy.getProsentForPeriode(avtale, periode);
+        Integer prosent = strategy.getProsentForPeriode(avtale, avtale.getGjeldendeInnhold(), periode);
 
         assertThat(prosent).isEqualTo(PROSENT_AAR_4);
     }
@@ -219,7 +246,7 @@ class FirearigLonnstilskuddBeregningStrategyTest {
         // Perioden slutter eksakt på 1-årsmerket → Period.between gir getYears() == 1 → år 2
         Periode periode = new Periode(LocalDate.of(2028, 12, 1), LocalDate.of(2029, 1, 1));
 
-        Integer prosent = strategy.getProsentForPeriode(avtale, periode);
+        Integer prosent = strategy.getProsentForPeriode(avtale, avtale.getGjeldendeInnhold(), periode);
 
         assertThat(prosent).isEqualTo(PROSENT_AAR_2);
     }
@@ -231,7 +258,7 @@ class FirearigLonnstilskuddBeregningStrategyTest {
         // Perioden slutter mer enn 4 år etter startdato
         Periode periode = new Periode(LocalDate.of(2031, 6, 1), LocalDate.of(2032, 6, 30));
 
-        assertThatThrownBy(() -> strategy.getProsentForPeriode(avtale, periode))
+        assertThatThrownBy(() -> strategy.getProsentForPeriode(avtale, avtale.getGjeldendeInnhold(), periode))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("Tilskuddsperiode avsluttes mer enn 4 år etter startdato");
     }
@@ -243,24 +270,28 @@ class FirearigLonnstilskuddBeregningStrategyTest {
 
         Integer forstePeriode = strategy.getProsentForPeriode(
             avtale,
+            avtale.getGjeldendeInnhold(),
             Periode.av(LocalDate.of(2028, 2, 29), LocalDate.of(2029, 2, 27))
         );
         assertThat(forstePeriode).isEqualTo(PROSENT_AAR_1);
 
         Integer andrePeriode = strategy.getProsentForPeriode(
             avtale,
+            avtale.getGjeldendeInnhold(),
             Periode.av(LocalDate.of(2029, 2, 28), LocalDate.of(2030, 2, 27))
         );
         assertThat(andrePeriode).isEqualTo(PROSENT_AAR_2);
 
         Integer tredjePeriode = strategy.getProsentForPeriode(
             avtale,
+            avtale.getGjeldendeInnhold(),
             Periode.av(LocalDate.of(2030, 2, 28), LocalDate.of(2031, 2, 27))
         );
         assertThat(tredjePeriode).isEqualTo(PROSENT_AAR_3);
 
         Integer fjerdePeriode = strategy.getProsentForPeriode(
             avtale,
+            avtale.getGjeldendeInnhold(),
             Periode.av(LocalDate.of(2031, 2, 28), LocalDate.of(2032, 2, 28))
         );
         assertThat(fjerdePeriode).isEqualTo(PROSENT_AAR_4);
@@ -274,24 +305,28 @@ class FirearigLonnstilskuddBeregningStrategyTest {
 
         Integer forstePeriode = strategy.getProsentForPeriode(
             avtale,
+            avtale.getGjeldendeInnhold(),
             Periode.av(LocalDate.of(2027, 2, 28), LocalDate.of(2028, 2, 27))
         );
         assertThat(forstePeriode).isEqualTo(PROSENT_AAR_1);
 
         Integer andrePeriode = strategy.getProsentForPeriode(
             avtale,
+            avtale.getGjeldendeInnhold(),
             Periode.av(LocalDate.of(2028, 2, 28), LocalDate.of(2029, 2, 27)) // 2028 = skuddaar
         );
         assertThat(andrePeriode).isEqualTo(PROSENT_AAR_2);
 
         Integer tredjePeriode = strategy.getProsentForPeriode(
             avtale,
+            avtale.getGjeldendeInnhold(),
             Periode.av(LocalDate.of(2029, 2, 28), LocalDate.of(2030, 2, 27))
         );
         assertThat(tredjePeriode).isEqualTo(PROSENT_AAR_3);
 
         Integer fjerdePeriode = strategy.getProsentForPeriode(
             avtale,
+            avtale.getGjeldendeInnhold(),
             Periode.av(LocalDate.of(2030, 2, 28), LocalDate.of(2031, 2, 27))
         );
         assertThat(fjerdePeriode).isEqualTo(PROSENT_AAR_4);
@@ -302,24 +337,28 @@ class FirearigLonnstilskuddBeregningStrategyTest {
 
         forstePeriode = strategy.getProsentForPeriode(
             avtale,
+            avtale.getGjeldendeInnhold(),
             Periode.av(LocalDate.of(2027, 3, 1), LocalDate.of(2028, 2, 29))
         );
         assertThat(forstePeriode).isEqualTo(PROSENT_AAR_1);
 
         andrePeriode = strategy.getProsentForPeriode(
             avtale,
+            avtale.getGjeldendeInnhold(),
             Periode.av(LocalDate.of(2028, 3, 1), LocalDate.of(2029, 2, 28)) // 2028 = skuddaar
         );
         assertThat(andrePeriode).isEqualTo(PROSENT_AAR_2);
 
         tredjePeriode = strategy.getProsentForPeriode(
             avtale,
+            avtale.getGjeldendeInnhold(),
             Periode.av(LocalDate.of(2029, 3, 1), LocalDate.of(2030, 2, 28))
         );
         assertThat(tredjePeriode).isEqualTo(PROSENT_AAR_3);
 
         fjerdePeriode = strategy.getProsentForPeriode(
             avtale,
+            avtale.getGjeldendeInnhold(),
             Periode.av(LocalDate.of(2030, 3, 1), LocalDate.of(2031, 2, 28))
         );
         assertThat(fjerdePeriode).isEqualTo(PROSENT_AAR_4);

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/tilskuddsperiode/beregning/GenerellLonnstilskuddAvtaleBeregningStrategyTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/tilskuddsperiode/beregning/GenerellLonnstilskuddAvtaleBeregningStrategyTest.java
@@ -2,6 +2,7 @@ package no.nav.tag.tiltaksgjennomforing.tilskuddsperiode.beregning;
 
 import no.bekk.bekkopen.person.FodselsnummerValidator;
 import no.nav.tag.tiltaksgjennomforing.avtale.Avtale;
+import no.nav.tag.tiltaksgjennomforing.avtale.AvtaleInnhold;
 import no.nav.tag.tiltaksgjennomforing.avtale.TestData;
 import no.nav.tag.tiltaksgjennomforing.avtale.TilskuddPeriode;
 import no.nav.tag.tiltaksgjennomforing.avtale.Tiltakstype;
@@ -26,7 +27,7 @@ class GenerellLonnstilskuddAvtaleBeregningStrategyTest {
     private final GenerellLonnstilskuddAvtaleBeregningStrategy strategy =
         new GenerellLonnstilskuddAvtaleBeregningStrategy() {
             @Override
-            public Integer getProsentForPeriode(Avtale avtale, Periode periode) {
+            public Integer getProsentForPeriode(Avtale avtale, AvtaleInnhold avtaleInnhold, Periode periode) {
                 if (datoForRedusertProsent != null && !periode.getStart().isBefore(datoForRedusertProsent)) {
                     return PROSENT - 10;
                 }
@@ -34,7 +35,7 @@ class GenerellLonnstilskuddAvtaleBeregningStrategyTest {
             }
 
             @Override
-            public List<LocalDate> getDatoerForReduksjon(Avtale avtale) {
+            public List<LocalDate> getDatoerForReduksjon(Avtale avtale, AvtaleInnhold avtaleInnhold) {
                 if (datoForRedusertProsent != null) {
                     return List.of(datoForRedusertProsent);
                 }
@@ -118,7 +119,7 @@ class GenerellLonnstilskuddAvtaleBeregningStrategyTest {
         List<TilskuddPeriode> perioder = strategy.beregnTilskuddsperioderForAvtale(avtale, fra, til);
 
         assertThat(perioder).hasSize(2);
-        int redusertProsent = strategy.getProsentForPeriode(avtale, Periode.av(datoForRedusertProsent, til));
+        int redusertProsent = strategy.getProsentForPeriode(avtale, avtale.getGjeldendeInnhold(), Periode.av(datoForRedusertProsent, til));
         assertThat(perioder).allMatch(p -> p.getLonnstilskuddProsent() == redusertProsent);
         assertThat(perioder).allMatch(p -> p.getBeløp() == SUM_LONNSTILSKUDD_REDUSERT_PER_MANED);
     }
@@ -150,7 +151,7 @@ class GenerellLonnstilskuddAvtaleBeregningStrategyTest {
         assertThat(forReduksjon).allMatch(p -> p.getLonnstilskuddProsent() == PROSENT);
         assertThat(forReduksjon).allMatch(p -> p.getBeløp() == SUM_LONNSTILSKUDD_PER_MANED);
 
-        int redusertProsent = strategy.getProsentForPeriode(avtale, Periode.av(datoForRedusertProsent, til));
+        int redusertProsent = strategy.getProsentForPeriode(avtale, avtale.getGjeldendeInnhold(), Periode.av(datoForRedusertProsent, til));
         assertThat(etterReduksjon).hasSize(2);
         assertThat(etterReduksjon).allMatch(p -> p.getLonnstilskuddProsent() == redusertProsent);
         assertThat(etterReduksjon).allMatch(p -> p.getBeløp() == SUM_LONNSTILSKUDD_REDUSERT_PER_MANED);
@@ -165,7 +166,7 @@ class GenerellLonnstilskuddAvtaleBeregningStrategyTest {
 
         List<TilskuddPeriode> perioder = strategy.beregnTilskuddsperioderForAvtale(avtale, fra, til);
 
-        int redusertProsent = strategy.getProsentForPeriode(avtale, Periode.av(datoForRedusertProsent, til));
+        int redusertProsent = strategy.getProsentForPeriode(avtale, avtale.getGjeldendeInnhold(), Periode.av(datoForRedusertProsent, til));
         assertThat(perioder).allMatch(p -> p.getLonnstilskuddProsent() == redusertProsent);
     }
 
@@ -181,7 +182,7 @@ class GenerellLonnstilskuddAvtaleBeregningStrategyTest {
         // Jan 1–31 og Feb 1–28 → full prosent (2 perioder), Feb 29–29 → redusert (1 periode)
         assertThat(perioder).hasSize(3);
 
-        int redusertProsent = strategy.getProsentForPeriode(avtale, Periode.av(datoForRedusertProsent, til));
+        int redusertProsent = strategy.getProsentForPeriode(avtale, avtale.getGjeldendeInnhold(), Periode.av(datoForRedusertProsent, til));
 
         List<TilskuddPeriode> fullePerioder = perioder.stream()
                 .filter(p -> p.getSluttDato().isBefore(datoForRedusertProsent))

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/tilskuddsperiode/beregning/MidlertidigLonnstilskuddAvtaleBeregningStrategyTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/tilskuddsperiode/beregning/MidlertidigLonnstilskuddAvtaleBeregningStrategyTest.java
@@ -2,6 +2,7 @@ package no.nav.tag.tiltaksgjennomforing.tilskuddsperiode.beregning;
 
 import no.bekk.bekkopen.person.FodselsnummerValidator;
 import no.nav.tag.tiltaksgjennomforing.avtale.Avtale;
+import no.nav.tag.tiltaksgjennomforing.avtale.AvtaleInnhold;
 import no.nav.tag.tiltaksgjennomforing.avtale.TestData;
 import no.nav.tag.tiltaksgjennomforing.avtale.Tiltakstype;
 import no.nav.tag.tiltaksgjennomforing.enhet.Kvalifiseringsgruppe;
@@ -33,28 +34,33 @@ class MidlertidigLonnstilskuddAvtaleBeregningStrategyTest {
         FodselsnummerValidator.ALLOW_SYNTHETIC_NUMBERS = false;
     }
 
-    private Avtale lagAvtaleMedDatoer(Kvalifiseringsgruppe kvalifiseringsgruppe, LocalDate startDato, LocalDate sluttDato) {
+    private Avtale lagAvtale(Kvalifiseringsgruppe kvalifiseringsgruppe) {
         Avtale avtale = TestData.enLonnstilskuddAvtaleMedAltUtfylt(Tiltakstype.MIDLERTIDIG_LONNSTILSKUDD);
         avtale.setKvalifiseringsgruppe(kvalifiseringsgruppe);
-        avtale.getGjeldendeInnhold().setStartDato(startDato);
-        avtale.getGjeldendeInnhold().setSluttDato(sluttDato);
         return avtale;
+    }
+
+    private static AvtaleInnhold innholdMedDatoer(LocalDate startDato, LocalDate sluttDato) {
+        AvtaleInnhold innhold = new AvtaleInnhold();
+        innhold.setStartDato(startDato);
+        innhold.setSluttDato(sluttDato);
+        return innhold;
     }
 
     @Test
     void getDatoerForReduksjon__returnerer_tom_liste_naar_startdato_er_null() {
-        Avtale avtale = lagAvtaleMedDatoer(Kvalifiseringsgruppe.SITUASJONSBESTEMT_INNSATS, null, LocalDate.of(2025, 1, 1));
+        Avtale avtale = lagAvtale(Kvalifiseringsgruppe.SITUASJONSBESTEMT_INNSATS);
 
-        List<LocalDate> result = strategy.getDatoerForReduksjon(avtale);
+        List<LocalDate> result = strategy.getDatoerForReduksjon(avtale, innholdMedDatoer(null, LocalDate.of(2025, 1, 1)));
 
         assertThat(result).isEmpty();
     }
 
     @Test
     void getDatoerForReduksjon__returnerer_tom_liste_naar_sluttdato_er_null() {
-        Avtale avtale = lagAvtaleMedDatoer(Kvalifiseringsgruppe.SITUASJONSBESTEMT_INNSATS, LocalDate.of(2024, 1, 1), null);
+        Avtale avtale = lagAvtale(Kvalifiseringsgruppe.SITUASJONSBESTEMT_INNSATS);
 
-        List<LocalDate> result = strategy.getDatoerForReduksjon(avtale);
+        List<LocalDate> result = strategy.getDatoerForReduksjon(avtale, innholdMedDatoer(LocalDate.of(2024, 1, 1), null));
 
         assertThat(result).isEmpty();
     }
@@ -63,9 +69,9 @@ class MidlertidigLonnstilskuddAvtaleBeregningStrategyTest {
     void getDatoerForReduksjon__situasjonsbestemt_innsats_gir_reduksjon_etter_6_maaneder() {
         LocalDate startDato = LocalDate.of(2024, 1, 1);
         LocalDate sluttDato = LocalDate.of(2024, 12, 31);
-        Avtale avtale = lagAvtaleMedDatoer(Kvalifiseringsgruppe.SITUASJONSBESTEMT_INNSATS, startDato, sluttDato);
+        Avtale avtale = lagAvtale(Kvalifiseringsgruppe.SITUASJONSBESTEMT_INNSATS);
 
-        List<LocalDate> result = strategy.getDatoerForReduksjon(avtale);
+        List<LocalDate> result = strategy.getDatoerForReduksjon(avtale, innholdMedDatoer(startDato, sluttDato));
 
         assertThat(result).containsExactly(startDato.plusMonths(6));
     }
@@ -74,9 +80,9 @@ class MidlertidigLonnstilskuddAvtaleBeregningStrategyTest {
     void getDatoerForReduksjon__spesielt_tilpasset_innsats_gir_reduksjon_etter_1_aar() {
         LocalDate startDato = LocalDate.of(2024, 1, 1);
         LocalDate sluttDato = LocalDate.of(2026, 1, 1);
-        Avtale avtale = lagAvtaleMedDatoer(Kvalifiseringsgruppe.SPESIELT_TILPASSET_INNSATS, startDato, sluttDato);
+        Avtale avtale = lagAvtale(Kvalifiseringsgruppe.SPESIELT_TILPASSET_INNSATS);
 
-        List<LocalDate> result = strategy.getDatoerForReduksjon(avtale);
+        List<LocalDate> result = strategy.getDatoerForReduksjon(avtale, innholdMedDatoer(startDato, sluttDato));
 
         assertThat(result).containsExactly(startDato.plusYears(1));
     }
@@ -85,9 +91,9 @@ class MidlertidigLonnstilskuddAvtaleBeregningStrategyTest {
     void getDatoerForReduksjon__varig_tilpasset_innsats_gir_reduksjon_etter_1_aar() {
         LocalDate startDato = LocalDate.of(2024, 1, 1);
         LocalDate sluttDato = LocalDate.of(2026, 1, 1);
-        Avtale avtale = lagAvtaleMedDatoer(Kvalifiseringsgruppe.VARIG_TILPASSET_INNSATS, startDato, sluttDato);
+        Avtale avtale = lagAvtale(Kvalifiseringsgruppe.VARIG_TILPASSET_INNSATS);
 
-        List<LocalDate> result = strategy.getDatoerForReduksjon(avtale);
+        List<LocalDate> result = strategy.getDatoerForReduksjon(avtale, innholdMedDatoer(startDato, sluttDato));
 
         assertThat(result).containsExactly(startDato.plusYears(1));
     }
@@ -97,9 +103,9 @@ class MidlertidigLonnstilskuddAvtaleBeregningStrategyTest {
         LocalDate startDato = LocalDate.of(2024, 1, 1);
         // Sluttdato er bare 3 måneder frem, men reduksjon for SITUASJONSBESTEMT er etter 6 måneder
         LocalDate sluttDato = LocalDate.of(2024, 3, 31);
-        Avtale avtale = lagAvtaleMedDatoer(Kvalifiseringsgruppe.SITUASJONSBESTEMT_INNSATS, startDato, sluttDato);
+        Avtale avtale = lagAvtale(Kvalifiseringsgruppe.SITUASJONSBESTEMT_INNSATS);
 
-        List<LocalDate> result = strategy.getDatoerForReduksjon(avtale);
+        List<LocalDate> result = strategy.getDatoerForReduksjon(avtale, innholdMedDatoer(startDato, sluttDato));
 
         assertThat(result).isEmpty();
     }
@@ -110,9 +116,9 @@ class MidlertidigLonnstilskuddAvtaleBeregningStrategyTest {
         // so the date IS returned (the reduksjon starts on the very last day of the avtale).
         LocalDate startDato = LocalDate.of(2024, 1, 1);
         LocalDate sluttDato = startDato.plusMonths(6); // Reduksjonsdato for SITUASJONSBESTEMT = 2024-07-01
-        Avtale avtale = lagAvtaleMedDatoer(Kvalifiseringsgruppe.SITUASJONSBESTEMT_INNSATS, startDato, sluttDato);
+        Avtale avtale = lagAvtale(Kvalifiseringsgruppe.SITUASJONSBESTEMT_INNSATS);
 
-        List<LocalDate> result = strategy.getDatoerForReduksjon(avtale);
+        List<LocalDate> result = strategy.getDatoerForReduksjon(avtale, innholdMedDatoer(startDato, sluttDato));
 
         assertThat(result).containsExactly(startDato.plusMonths(6));
     }
@@ -120,14 +126,14 @@ class MidlertidigLonnstilskuddAvtaleBeregningStrategyTest {
     @Test
     void getDatoerForReduksjon_handterer_skuddaar() {
         LocalDate varigTilpassetStart = LocalDate.of(2024, 2, 29);
-        Avtale varigTilpassetAvtale = lagAvtaleMedDatoer(Kvalifiseringsgruppe.VARIG_TILPASSET_INNSATS, varigTilpassetStart, LocalDate.of(2026, 2, 28));
-        List<LocalDate> reduksjon = strategy.getDatoerForReduksjon(varigTilpassetAvtale);
+        Avtale varigTilpassetAvtale = lagAvtale(Kvalifiseringsgruppe.VARIG_TILPASSET_INNSATS);
+        List<LocalDate> reduksjon = strategy.getDatoerForReduksjon(varigTilpassetAvtale, innholdMedDatoer(varigTilpassetStart, LocalDate.of(2026, 2, 28)));
 
         assertThat(reduksjon).containsExactly(LocalDate.of(2025, 2, 28));
 
         LocalDate situasjonsbestemtStart = LocalDate.of(2024, 2, 29);
-        Avtale situasjonsbestemtAvtale = lagAvtaleMedDatoer(Kvalifiseringsgruppe.SITUASJONSBESTEMT_INNSATS, situasjonsbestemtStart, LocalDate.of(2026, 2, 28));
-        reduksjon = strategy.getDatoerForReduksjon(situasjonsbestemtAvtale);
+        Avtale situasjonsbestemtAvtale = lagAvtale(Kvalifiseringsgruppe.SITUASJONSBESTEMT_INNSATS);
+        reduksjon = strategy.getDatoerForReduksjon(situasjonsbestemtAvtale, innholdMedDatoer(situasjonsbestemtStart, LocalDate.of(2026, 2, 28)));
 
         assertThat(reduksjon).containsExactly(LocalDate.of(2024, 8, 29));
     }
@@ -135,20 +141,20 @@ class MidlertidigLonnstilskuddAvtaleBeregningStrategyTest {
     @Test
     void getDatoerForReduksjon_handterer_skuddaar_i_midten_av_trinn() {
         LocalDate varigTilpassetStart = LocalDate.of(2023, 3, 1);
-        Avtale varigTilpassetAvtale = lagAvtaleMedDatoer(Kvalifiseringsgruppe.VARIG_TILPASSET_INNSATS, varigTilpassetStart, LocalDate.of(2025, 2, 28));
-        List<LocalDate> reduksjon = strategy.getDatoerForReduksjon(varigTilpassetAvtale);
+        Avtale varigTilpassetAvtale = lagAvtale(Kvalifiseringsgruppe.VARIG_TILPASSET_INNSATS);
+        List<LocalDate> reduksjon = strategy.getDatoerForReduksjon(varigTilpassetAvtale, innholdMedDatoer(varigTilpassetStart, LocalDate.of(2025, 2, 28)));
 
         assertThat(reduksjon).containsExactly(LocalDate.of(2024, 3, 1)); // 2024 = skuddaar
 
         LocalDate situasjonsbestemtStart = LocalDate.of(2023, 8, 29);
-        Avtale situasjonsbestemtAvtale = lagAvtaleMedDatoer(Kvalifiseringsgruppe.SITUASJONSBESTEMT_INNSATS, situasjonsbestemtStart, LocalDate.of(2025, 2, 28));
-        reduksjon = strategy.getDatoerForReduksjon(situasjonsbestemtAvtale);
+        Avtale situasjonsbestemtAvtale = lagAvtale(Kvalifiseringsgruppe.SITUASJONSBESTEMT_INNSATS);
+        reduksjon = strategy.getDatoerForReduksjon(situasjonsbestemtAvtale, innholdMedDatoer(situasjonsbestemtStart, LocalDate.of(2025, 2, 28)));
 
         assertThat(reduksjon).containsExactly(LocalDate.of(2024, 2, 29)); // 2024 = skuddaar
 
         LocalDate situasjonsbestemtStart2 = LocalDate.of(2023, 8, 31);
-        Avtale situasjonsbestemtAvtale2 = lagAvtaleMedDatoer(Kvalifiseringsgruppe.SITUASJONSBESTEMT_INNSATS, situasjonsbestemtStart2, LocalDate.of(2025, 2, 28));
-        reduksjon = strategy.getDatoerForReduksjon(situasjonsbestemtAvtale2);
+        Avtale situasjonsbestemtAvtale2 = lagAvtale(Kvalifiseringsgruppe.SITUASJONSBESTEMT_INNSATS);
+        reduksjon = strategy.getDatoerForReduksjon(situasjonsbestemtAvtale2, innholdMedDatoer(situasjonsbestemtStart2, LocalDate.of(2025, 2, 28)));
 
         assertThat(reduksjon).containsExactly(LocalDate.of(2024, 2, 29)); // 2024 = skuddaar
     }
@@ -157,10 +163,10 @@ class MidlertidigLonnstilskuddAvtaleBeregningStrategyTest {
     void getProsentForPeriode__situasjonsbestemt_innsats_gir_40_prosent_foer_reduksjon() {
         LocalDate startDato = LocalDate.of(2024, 1, 1);
         LocalDate sluttDato = LocalDate.of(2024, 12, 31);
-        Avtale avtale = lagAvtaleMedDatoer(Kvalifiseringsgruppe.SITUASJONSBESTEMT_INNSATS, startDato, sluttDato);
+        Avtale avtale = lagAvtale(Kvalifiseringsgruppe.SITUASJONSBESTEMT_INNSATS);
         Periode periode = new Periode(LocalDate.of(2024, 1, 1), LocalDate.of(2024, 1, 31));
 
-        Integer prosent = strategy.getProsentForPeriode(avtale, periode);
+        Integer prosent = strategy.getProsentForPeriode(avtale, innholdMedDatoer(startDato, sluttDato), periode);
 
         assertThat(prosent).isEqualTo(TILSKUDDSPROSENT);
     }
@@ -169,11 +175,11 @@ class MidlertidigLonnstilskuddAvtaleBeregningStrategyTest {
     void getProsentForPeriode__situasjonsbestemt_innsats_gir_redusert_prosent_etter_6_maaneder() {
         LocalDate startDato = LocalDate.of(2024, 1, 1);
         LocalDate sluttDato = LocalDate.of(2024, 12, 31);
-        Avtale avtale = lagAvtaleMedDatoer(Kvalifiseringsgruppe.SITUASJONSBESTEMT_INNSATS, startDato, sluttDato);
+        Avtale avtale = lagAvtale(Kvalifiseringsgruppe.SITUASJONSBESTEMT_INNSATS);
         // Perioden starter etter reduksjonsdato (2024-07-01)
         Periode periode = new Periode(LocalDate.of(2024, 8, 1), LocalDate.of(2024, 8, 31));
 
-        Integer prosent = strategy.getProsentForPeriode(avtale, periode);
+        Integer prosent = strategy.getProsentForPeriode(avtale, innholdMedDatoer(startDato, sluttDato), periode);
 
         assertThat(prosent).isEqualTo(
                 TILSKUDDSPROSENT
@@ -185,10 +191,10 @@ class MidlertidigLonnstilskuddAvtaleBeregningStrategyTest {
     void getProsentForPeriode__spesielt_tilpasset_innsats_gir_60_prosent_foer_reduksjon() {
         LocalDate startDato = LocalDate.of(2024, 1, 1);
         LocalDate sluttDato = LocalDate.of(2026, 1, 1);
-        Avtale avtale = lagAvtaleMedDatoer(Kvalifiseringsgruppe.SPESIELT_TILPASSET_INNSATS, startDato, sluttDato);
+        Avtale avtale = lagAvtale(Kvalifiseringsgruppe.SPESIELT_TILPASSET_INNSATS);
         Periode periode = new Periode(LocalDate.of(2024, 6, 1), LocalDate.of(2024, 6, 30));
 
-        Integer prosent = strategy.getProsentForPeriode(avtale, periode);
+        Integer prosent = strategy.getProsentForPeriode(avtale, innholdMedDatoer(startDato, sluttDato), periode);
 
         assertThat(prosent).isEqualTo(TILSKUDDSPROSENT_TILPASSET);
     }
@@ -197,11 +203,11 @@ class MidlertidigLonnstilskuddAvtaleBeregningStrategyTest {
     void getProsentForPeriode__spesielt_tilpasset_innsats_gir_redusert_prosent_etter_1_aar() {
         LocalDate startDato = LocalDate.of(2024, 1, 1);
         LocalDate sluttDato = LocalDate.of(2026, 1, 1);
-        Avtale avtale = lagAvtaleMedDatoer(Kvalifiseringsgruppe.SPESIELT_TILPASSET_INNSATS, startDato, sluttDato);
+        Avtale avtale = lagAvtale(Kvalifiseringsgruppe.SPESIELT_TILPASSET_INNSATS);
         // Perioden starter etter reduksjonsdato (2025-01-01)
         Periode periode = new Periode(LocalDate.of(2025, 3, 1), LocalDate.of(2025, 3, 31));
 
-        Integer prosent = strategy.getProsentForPeriode(avtale, periode);
+        Integer prosent = strategy.getProsentForPeriode(avtale, innholdMedDatoer(startDato, sluttDato), periode);
 
         assertThat(prosent).isEqualTo(
                 TILSKUDDSPROSENT_TILPASSET
@@ -213,10 +219,10 @@ class MidlertidigLonnstilskuddAvtaleBeregningStrategyTest {
     void getProsentForPeriode__ukjent_kvalifiseringsgruppe_gir_null() {
         LocalDate startDato = LocalDate.of(2024, 1, 1);
         LocalDate sluttDato = LocalDate.of(2024, 12, 31);
-        Avtale avtale = lagAvtaleMedDatoer(Kvalifiseringsgruppe.STANDARD_INNSATS, startDato, sluttDato);
+        Avtale avtale = lagAvtale(Kvalifiseringsgruppe.STANDARD_INNSATS);
         Periode periode = new Periode(LocalDate.of(2024, 1, 1), LocalDate.of(2024, 1, 31));
 
-        Integer prosent = strategy.getProsentForPeriode(avtale, periode);
+        Integer prosent = strategy.getProsentForPeriode(avtale, innholdMedDatoer(startDato, sluttDato), periode);
 
         assertThat(prosent).isNull();
     }
@@ -225,11 +231,11 @@ class MidlertidigLonnstilskuddAvtaleBeregningStrategyTest {
     void getProsentForPeriode__periode_slutter_paa_reduksjonsdato_er_redusert() {
         LocalDate startDato = LocalDate.of(2024, 1, 1);
         LocalDate sluttDato = LocalDate.of(2025, 1, 1);
-        Avtale avtale = lagAvtaleMedDatoer(Kvalifiseringsgruppe.SITUASJONSBESTEMT_INNSATS, startDato, sluttDato);
+        Avtale avtale = lagAvtale(Kvalifiseringsgruppe.SITUASJONSBESTEMT_INNSATS);
         // Perioden slutter akkurat på reduksjonsdatoen
         Periode periode = new Periode(LocalDate.of(2025, 1, 1), LocalDate.of(2025, 7, 1));
 
-        Integer prosent = strategy.getProsentForPeriode(avtale, periode);
+        Integer prosent = strategy.getProsentForPeriode(avtale, innholdMedDatoer(startDato, sluttDato), periode);
 
         assertThat(prosent).isEqualTo(TILSKUDDSPROSENT - TILSKUDDSPROSENT_REDUKSJONSFAKTOR);
     }
@@ -237,30 +243,34 @@ class MidlertidigLonnstilskuddAvtaleBeregningStrategyTest {
     @Test
     void getProsentForPeriode_handterer_skuddaar() {
         LocalDate varigTilpassetStart = LocalDate.of(2024, 2, 29);
-        Avtale varigTilpassetAvtale = lagAvtaleMedDatoer(Kvalifiseringsgruppe.VARIG_TILPASSET_INNSATS, varigTilpassetStart, LocalDate.of(2026, 2, 28));
+        Avtale varigTilpassetAvtale = lagAvtale(Kvalifiseringsgruppe.VARIG_TILPASSET_INNSATS);
 
         Integer forstePeriode = strategy.getProsentForPeriode(
             varigTilpassetAvtale,
+            innholdMedDatoer(varigTilpassetStart, LocalDate.of(2026, 2, 28)),
             Periode.av(LocalDate.of(2024, 2, 29), LocalDate.of(2025, 2, 27))
         );
         assertThat(forstePeriode).isEqualTo(TILSKUDDSPROSENT_TILPASSET);
 
         Integer andrePeriode = strategy.getProsentForPeriode(
             varigTilpassetAvtale,
+            innholdMedDatoer(varigTilpassetStart, LocalDate.of(2026, 2, 28)),
             Periode.av(LocalDate.of(2025, 2, 28), LocalDate.of(2026, 2, 28))
         );
         assertThat(andrePeriode).isEqualTo(TILSKUDDSPROSENT_TILPASSET - TILSKUDDSPROSENT_REDUKSJONSFAKTOR);
 
         LocalDate situasjonsbestemtStart = LocalDate.of(2024, 2, 29);
-        Avtale situasjonsbestemtAvtale = lagAvtaleMedDatoer(Kvalifiseringsgruppe.SITUASJONSBESTEMT_INNSATS, situasjonsbestemtStart, LocalDate.of(2026, 2, 28));
+        Avtale situasjonsbestemtAvtale = lagAvtale(Kvalifiseringsgruppe.SITUASJONSBESTEMT_INNSATS);
         forstePeriode = strategy.getProsentForPeriode(
             situasjonsbestemtAvtale,
+            innholdMedDatoer(situasjonsbestemtStart, LocalDate.of(2026, 2, 28)),
             Periode.av(LocalDate.of(2024, 2, 29), LocalDate.of(2024, 8, 28))
         );
         assertThat(forstePeriode).isEqualTo(TILSKUDDSPROSENT);
 
         andrePeriode = strategy.getProsentForPeriode(
             situasjonsbestemtAvtale,
+            innholdMedDatoer(situasjonsbestemtStart, LocalDate.of(2026, 2, 28)),
             Periode.av(LocalDate.of(2024, 8, 29), LocalDate.of(2026, 2, 28))
         );
         assertThat(andrePeriode).isEqualTo(TILSKUDDSPROSENT - TILSKUDDSPROSENT_REDUKSJONSFAKTOR);
@@ -269,44 +279,50 @@ class MidlertidigLonnstilskuddAvtaleBeregningStrategyTest {
     @Test
     void getProsentForPeriode_handterer_skuddaar_i_midten_av_trinn() {
         LocalDate varigTilpassetStart = LocalDate.of(2023, 3, 1);
-        Avtale varigTilpassetAvtale = lagAvtaleMedDatoer(Kvalifiseringsgruppe.VARIG_TILPASSET_INNSATS, varigTilpassetStart, LocalDate.of(2025, 2, 28));
+        Avtale varigTilpassetAvtale = lagAvtale(Kvalifiseringsgruppe.VARIG_TILPASSET_INNSATS);
 
         Integer forstePeriode = strategy.getProsentForPeriode(
             varigTilpassetAvtale,
+            innholdMedDatoer(varigTilpassetStart, LocalDate.of(2025, 2, 28)),
             Periode.av(LocalDate.of(2023, 3, 1), LocalDate.of(2024, 2, 29))
         );
         assertThat(forstePeriode).isEqualTo(TILSKUDDSPROSENT_TILPASSET);
 
         Integer andrePeriode = strategy.getProsentForPeriode(
             varigTilpassetAvtale,
+            innholdMedDatoer(varigTilpassetStart, LocalDate.of(2025, 2, 28)),
             Periode.av(LocalDate.of(2024, 3, 1), LocalDate.of(2025, 2, 28))
         );
         assertThat(andrePeriode).isEqualTo(TILSKUDDSPROSENT_TILPASSET - TILSKUDDSPROSENT_REDUKSJONSFAKTOR);
 
         LocalDate situasjonsbestemtStart = LocalDate.of(2023, 8, 29);
-        Avtale situasjonsbestemtAvtale = lagAvtaleMedDatoer(Kvalifiseringsgruppe.SITUASJONSBESTEMT_INNSATS, situasjonsbestemtStart, LocalDate.of(2025, 2, 28));
+        Avtale situasjonsbestemtAvtale = lagAvtale(Kvalifiseringsgruppe.SITUASJONSBESTEMT_INNSATS);
         forstePeriode = strategy.getProsentForPeriode(
             situasjonsbestemtAvtale,
+            innholdMedDatoer(situasjonsbestemtStart, LocalDate.of(2025, 2, 28)),
             Periode.av(LocalDate.of(2023, 8, 29), LocalDate.of(2024, 2, 28))
         );
         assertThat(forstePeriode).isEqualTo(TILSKUDDSPROSENT);
 
         andrePeriode = strategy.getProsentForPeriode(
             situasjonsbestemtAvtale,
+            innholdMedDatoer(situasjonsbestemtStart, LocalDate.of(2025, 2, 28)),
             Periode.av(LocalDate.of(2024, 2, 29), LocalDate.of(2025, 2, 28))
         );
         assertThat(andrePeriode).isEqualTo(TILSKUDDSPROSENT - TILSKUDDSPROSENT_REDUKSJONSFAKTOR);
 
         LocalDate situasjonsbestemtStart2 = LocalDate.of(2023, 8, 31);
-        Avtale situasjonsbestemtAvtale2 = lagAvtaleMedDatoer(Kvalifiseringsgruppe.SITUASJONSBESTEMT_INNSATS, situasjonsbestemtStart2, LocalDate.of(2025, 2, 28));
+        Avtale situasjonsbestemtAvtale2 = lagAvtale(Kvalifiseringsgruppe.SITUASJONSBESTEMT_INNSATS);
         forstePeriode = strategy.getProsentForPeriode(
             situasjonsbestemtAvtale2,
+            innholdMedDatoer(situasjonsbestemtStart2, LocalDate.of(2025, 2, 28)),
             Periode.av(LocalDate.of(2023, 8, 31), LocalDate.of(2024, 2, 28))
         );
         assertThat(forstePeriode).isEqualTo(TILSKUDDSPROSENT);
 
         andrePeriode = strategy.getProsentForPeriode(
             situasjonsbestemtAvtale2,
+            innholdMedDatoer(situasjonsbestemtStart2, LocalDate.of(2025, 2, 28)),
             Periode.av(LocalDate.of(2024, 2, 29), LocalDate.of(2025, 2, 28))
         );
         assertThat(andrePeriode).isEqualTo(TILSKUDDSPROSENT - TILSKUDDSPROSENT_REDUKSJONSFAKTOR);

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/tilskuddsperiode/beregning/VarigLonnstilskuddAvtaleBeregningStrategyTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/tilskuddsperiode/beregning/VarigLonnstilskuddAvtaleBeregningStrategyTest.java
@@ -2,6 +2,7 @@ package no.nav.tag.tiltaksgjennomforing.tilskuddsperiode.beregning;
 
 import no.bekk.bekkopen.person.FodselsnummerValidator;
 import no.nav.tag.tiltaksgjennomforing.avtale.Avtale;
+import no.nav.tag.tiltaksgjennomforing.avtale.AvtaleInnhold;
 import no.nav.tag.tiltaksgjennomforing.avtale.TestData;
 import no.nav.tag.tiltaksgjennomforing.avtale.Tiltakstype;
 import no.nav.tag.tiltaksgjennomforing.utils.Periode;
@@ -31,28 +32,32 @@ class VarigLonnstilskuddAvtaleBeregningStrategyTest {
         FodselsnummerValidator.ALLOW_SYNTHETIC_NUMBERS = false;
     }
 
-    private Avtale lagAvtaleMedDatoerOgProsent(LocalDate startDato, LocalDate sluttDato, Integer lonnstilskuddProsent) {
-        Avtale avtale = TestData.enLonnstilskuddAvtaleMedAltUtfylt(Tiltakstype.VARIG_LONNSTILSKUDD);
-        avtale.getGjeldendeInnhold().setLonnstilskuddProsent(lonnstilskuddProsent);
-        avtale.getGjeldendeInnhold().setStartDato(startDato);
-        avtale.getGjeldendeInnhold().setSluttDato(sluttDato);
-        return avtale;
+    private Avtale lagAvtale() {
+        return TestData.enLonnstilskuddAvtaleMedAltUtfylt(Tiltakstype.VARIG_LONNSTILSKUDD);
+    }
+
+    private static AvtaleInnhold innholdMedDatoerOgProsent(LocalDate startDato, LocalDate sluttDato, Integer lonnstilskuddProsent) {
+        AvtaleInnhold innhold = new AvtaleInnhold();
+        innhold.setStartDato(startDato);
+        innhold.setSluttDato(sluttDato);
+        innhold.setLonnstilskuddProsent(lonnstilskuddProsent);
+        return innhold;
     }
 
     @Test
     void getDatoerForReduksjon__returnerer_tom_liste_naar_startdato_er_null() {
-        Avtale avtale = lagAvtaleMedDatoerOgProsent(null, LocalDate.of(2025, 1, 1), 75);
+        Avtale avtale = lagAvtale();
 
-        List<LocalDate> result = strategy.getDatoerForReduksjon(avtale);
+        List<LocalDate> result = strategy.getDatoerForReduksjon(avtale, innholdMedDatoerOgProsent(null, LocalDate.of(2025, 1, 1), 75));
 
         assertThat(result).isEmpty();
     }
 
     @Test
     void getDatoerForReduksjon__returnerer_tom_liste_naar_sluttdato_er_null() {
-        Avtale avtale = lagAvtaleMedDatoerOgProsent(LocalDate.of(2024, 1, 1), null, 75);
+        Avtale avtale = lagAvtale();
 
-        List<LocalDate> result = strategy.getDatoerForReduksjon(avtale);
+        List<LocalDate> result = strategy.getDatoerForReduksjon(avtale, innholdMedDatoerOgProsent(LocalDate.of(2024, 1, 1), null, 75));
 
         assertThat(result).isEmpty();
     }
@@ -62,9 +67,9 @@ class VarigLonnstilskuddAvtaleBeregningStrategyTest {
         // When prosent is null the "lonnstilskuddProsent <= REDUSERT_MAKS" guard is skipped,
         // so the code falls through and returns the date 1 year after start.
         LocalDate startDato = LocalDate.of(2024, 1, 1);
-        Avtale avtale = lagAvtaleMedDatoerOgProsent(startDato, LocalDate.of(2026, 1, 1), null);
+        Avtale avtale = lagAvtale();
 
-        List<LocalDate> result = strategy.getDatoerForReduksjon(avtale);
+        List<LocalDate> result = strategy.getDatoerForReduksjon(avtale, innholdMedDatoerOgProsent(startDato, LocalDate.of(2026, 1, 1), null));
 
         assertThat(result).containsExactly(startDato.plusYears(1));
     }
@@ -72,13 +77,13 @@ class VarigLonnstilskuddAvtaleBeregningStrategyTest {
     @Test
     void getDatoerForReduksjon__returnerer_tom_liste_naar_prosent_er_under_eller_lik_redusert_maks() {
         // TILSKUDDSPROSENT_REDUSERT_MAKS = 67
-        Avtale avtale = lagAvtaleMedDatoerOgProsent(
+        Avtale avtale = lagAvtale();
+
+        List<LocalDate> result = strategy.getDatoerForReduksjon(avtale, innholdMedDatoerOgProsent(
                 LocalDate.of(2024, 1, 1),
                 LocalDate.of(2026, 1, 1),
                 TILSKUDDSPROSENT_REDUSERT_MAKS
-        );
-
-        List<LocalDate> result = strategy.getDatoerForReduksjon(avtale);
+        ));
 
         assertThat(result).isEmpty();
     }
@@ -86,13 +91,13 @@ class VarigLonnstilskuddAvtaleBeregningStrategyTest {
     @Test
     void getDatoerForReduksjon__gir_reduksjonsdato_etter_1_aar_naar_prosent_er_over_redusert_maks() {
         LocalDate startDato = LocalDate.of(2024, 1, 1);
-        Avtale avtale = lagAvtaleMedDatoerOgProsent(
+        Avtale avtale = lagAvtale();
+
+        List<LocalDate> result = strategy.getDatoerForReduksjon(avtale, innholdMedDatoerOgProsent(
                 startDato,
                 LocalDate.of(2026, 1, 1),
                 TILSKUDDSPROSENT_MAKS
-        );
-
-        List<LocalDate> result = strategy.getDatoerForReduksjon(avtale);
+        ));
 
         assertThat(result).containsExactly(startDato.plusYears(1));
     }
@@ -102,13 +107,13 @@ class VarigLonnstilskuddAvtaleBeregningStrategyTest {
         LocalDate startDato = LocalDate.of(2024, 1, 1);
         // Sluttdato er bare 6 måneder frem, men reduksjon skjer etter 1 år
         LocalDate sluttDato = LocalDate.of(2024, 6, 30);
-        Avtale avtale = lagAvtaleMedDatoerOgProsent(
+        Avtale avtale = lagAvtale();
+
+        List<LocalDate> result = strategy.getDatoerForReduksjon(avtale, innholdMedDatoerOgProsent(
                 startDato,
                 sluttDato,
                 TILSKUDDSPROSENT_MAKS
-        );
-
-        List<LocalDate> result = strategy.getDatoerForReduksjon(avtale);
+        ));
 
         assertThat(result).isEmpty();
     }
@@ -119,13 +124,13 @@ class VarigLonnstilskuddAvtaleBeregningStrategyTest {
         // so the date IS returned (the reduksjon starts on the very last day of the avtale).
         LocalDate startDato = LocalDate.of(2024, 1, 1);
         LocalDate sluttDato = LocalDate.of(2025, 1, 1);
-        Avtale avtale = lagAvtaleMedDatoerOgProsent(
+        Avtale avtale = lagAvtale();
+
+        List<LocalDate> result = strategy.getDatoerForReduksjon(avtale, innholdMedDatoerOgProsent(
                 startDato,
                 sluttDato,
                 TILSKUDDSPROSENT_MAKS
-        );
-
-        List<LocalDate> result = strategy.getDatoerForReduksjon(avtale);
+        ));
 
         assertThat(result).containsExactly(LocalDate.of(2025, 1, 1));
     }
@@ -133,8 +138,8 @@ class VarigLonnstilskuddAvtaleBeregningStrategyTest {
     @Test
     void getDatoerForReduksjon_handterer_skuddaar() {
         LocalDate varigTilpassetStart = LocalDate.of(2024, 2, 29);
-        Avtale varigTilpassetAvtale = lagAvtaleMedDatoerOgProsent(varigTilpassetStart, LocalDate.of(2030, 2, 28), TILSKUDDSPROSENT_MAKS);
-        List<LocalDate> reduksjon = strategy.getDatoerForReduksjon(varigTilpassetAvtale);
+        Avtale varigTilpassetAvtale = lagAvtale();
+        List<LocalDate> reduksjon = strategy.getDatoerForReduksjon(varigTilpassetAvtale, innholdMedDatoerOgProsent(varigTilpassetStart, LocalDate.of(2030, 2, 28), TILSKUDDSPROSENT_MAKS));
 
         assertThat(reduksjon).containsExactly(LocalDate.of(2025, 2, 28));
     }
@@ -142,14 +147,14 @@ class VarigLonnstilskuddAvtaleBeregningStrategyTest {
     @Test
     void getDatoerForReduksjon_handterer_skuddaar_i_midten_av_trinn() {
         LocalDate varigTilpassetStart = LocalDate.of(2023, 2, 28);
-        Avtale varigTilpassetAvtale = lagAvtaleMedDatoerOgProsent(varigTilpassetStart, LocalDate.of(2025, 2, 28), TILSKUDDSPROSENT_MAKS);
-        List<LocalDate> reduksjon = strategy.getDatoerForReduksjon(varigTilpassetAvtale);
+        Avtale varigTilpassetAvtale = lagAvtale();
+        List<LocalDate> reduksjon = strategy.getDatoerForReduksjon(varigTilpassetAvtale, innholdMedDatoerOgProsent(varigTilpassetStart, LocalDate.of(2025, 2, 28), TILSKUDDSPROSENT_MAKS));
 
         assertThat(reduksjon).containsExactly(LocalDate.of(2024, 2, 28)); // 2024 = skuddaar
 
         varigTilpassetStart = LocalDate.of(2023, 3, 1);
-        varigTilpassetAvtale = lagAvtaleMedDatoerOgProsent(varigTilpassetStart, LocalDate.of(2025, 2, 28), TILSKUDDSPROSENT_MAKS);
-        reduksjon = strategy.getDatoerForReduksjon(varigTilpassetAvtale);
+        varigTilpassetAvtale = lagAvtale();
+        reduksjon = strategy.getDatoerForReduksjon(varigTilpassetAvtale, innholdMedDatoerOgProsent(varigTilpassetStart, LocalDate.of(2025, 2, 28), TILSKUDDSPROSENT_MAKS));
 
         assertThat(reduksjon).containsExactly(LocalDate.of(2024, 3, 1)); // 2024 = skuddaar
     }
@@ -160,10 +165,10 @@ class VarigLonnstilskuddAvtaleBeregningStrategyTest {
         // Sluttdato kort slik at ingen reduksjon
         LocalDate sluttDato = LocalDate.of(2024, 6, 30);
         int lonnstilskuddProsent = TILSKUDDSPROSENT_MAKS;
-        Avtale avtale = lagAvtaleMedDatoerOgProsent(startDato, sluttDato, lonnstilskuddProsent);
+        Avtale avtale = lagAvtale();
         Periode periode = new Periode(LocalDate.of(2024, 2, 1), LocalDate.of(2024, 2, 29));
 
-        Integer prosent = strategy.getProsentForPeriode(avtale, periode);
+        Integer prosent = strategy.getProsentForPeriode(avtale, innholdMedDatoerOgProsent(startDato, sluttDato, lonnstilskuddProsent), periode);
 
         assertThat(prosent).isEqualTo(lonnstilskuddProsent);
     }
@@ -173,10 +178,10 @@ class VarigLonnstilskuddAvtaleBeregningStrategyTest {
         LocalDate startDato = LocalDate.of(2024, 1, 1);
         LocalDate sluttDato = LocalDate.of(2024, 6, 30);
         // Sett en for høy prosent – skal begrenses til TILSKUDDSPROSENT_MAKS (75)
-        Avtale avtale = lagAvtaleMedDatoerOgProsent(startDato, sluttDato, 80);
+        Avtale avtale = lagAvtale();
         Periode periode = new Periode(LocalDate.of(2024, 2, 1), LocalDate.of(2024, 2, 29));
 
-        Integer prosent = strategy.getProsentForPeriode(avtale, periode);
+        Integer prosent = strategy.getProsentForPeriode(avtale, innholdMedDatoerOgProsent(startDato, sluttDato, 80), periode);
 
         assertThat(prosent).isEqualTo(TILSKUDDSPROSENT_MAKS);
     }
@@ -186,15 +191,15 @@ class VarigLonnstilskuddAvtaleBeregningStrategyTest {
         LocalDate startDato = LocalDate.of(2024, 1, 1);
         LocalDate sluttDato = LocalDate.of(2026, 1, 1);
         // Prosenten er over TILSKUDDSPROSENT_REDUSERT_MAKS, så reduksjon skal skje etter 1 år
-        Avtale avtale = lagAvtaleMedDatoerOgProsent(
-                startDato,
-                sluttDato,
-                TILSKUDDSPROSENT_MAKS
-        );
+        Avtale avtale = lagAvtale();
         // Periode er etter reduksjonsdato (2025-01-01)
         Periode periode = new Periode(LocalDate.of(2025, 3, 1), LocalDate.of(2025, 3, 31));
 
-        Integer prosent = strategy.getProsentForPeriode(avtale, periode);
+        Integer prosent = strategy.getProsentForPeriode(avtale, innholdMedDatoerOgProsent(
+                startDato,
+                sluttDato,
+                TILSKUDDSPROSENT_MAKS
+        ), periode);
 
         assertThat(prosent).isEqualTo(TILSKUDDSPROSENT_REDUSERT_MAKS);
     }
@@ -204,11 +209,11 @@ class VarigLonnstilskuddAvtaleBeregningStrategyTest {
         LocalDate startDato = LocalDate.of(2024, 1, 1);
         LocalDate sluttDato = LocalDate.of(2026, 1, 1);
         int lonnstilskuddProsent = 50; // under TILSKUDDSPROSENT_REDUSERT_MAKS (67)
-        Avtale avtale = lagAvtaleMedDatoerOgProsent(startDato, sluttDato, lonnstilskuddProsent);
+        Avtale avtale = lagAvtale();
         // Periode langt etter startdato – men getDatoerForReduksjon returnerer tom liste
         Periode periode = new Periode(LocalDate.of(2025, 6, 1), LocalDate.of(2025, 6, 30));
 
-        Integer prosent = strategy.getProsentForPeriode(avtale, periode);
+        Integer prosent = strategy.getProsentForPeriode(avtale, innholdMedDatoerOgProsent(startDato, sluttDato, lonnstilskuddProsent), periode);
 
         assertThat(prosent).isEqualTo(lonnstilskuddProsent);
     }
@@ -217,10 +222,10 @@ class VarigLonnstilskuddAvtaleBeregningStrategyTest {
     void getProsentForPeriode__returnerer_0_naar_lonnstilskuddprosent_er_null() {
         LocalDate startDato = LocalDate.of(2024, 1, 1);
         LocalDate sluttDato = LocalDate.of(2024, 6, 30);
-        Avtale avtale = lagAvtaleMedDatoerOgProsent(startDato, sluttDato, null);
+        Avtale avtale = lagAvtale();
         Periode periode = new Periode(LocalDate.of(2024, 2, 1), LocalDate.of(2024, 2, 29));
 
-        Integer prosent = strategy.getProsentForPeriode(avtale, periode);
+        Integer prosent = strategy.getProsentForPeriode(avtale, innholdMedDatoerOgProsent(startDato, sluttDato, null), periode);
 
         assertThat(prosent).isZero();
     }
@@ -229,35 +234,33 @@ class VarigLonnstilskuddAvtaleBeregningStrategyTest {
     void getProsentForPeriode__periode_slutter_paa_reduksjonsdato_er_redusert() {
         LocalDate startDato = LocalDate.of(2024, 1, 1);
         LocalDate sluttDato = LocalDate.of(2026, 1, 1);
-        Avtale avtale = lagAvtaleMedDatoerOgProsent(
-                startDato,
-                sluttDato,
-                TILSKUDDSPROSENT_MAKS
-        );
+        Avtale avtale = lagAvtale();
 
         Periode periode = new Periode(LocalDate.of(2025, 1, 1), LocalDate.of(2025, 1, 1));
 
-        Integer prosent = strategy.getProsentForPeriode(avtale, periode);
+        Integer prosent = strategy.getProsentForPeriode(avtale, innholdMedDatoerOgProsent(
+                startDato,
+                sluttDato,
+                TILSKUDDSPROSENT_MAKS
+        ), periode);
         assertThat(prosent).isEqualTo(TILSKUDDSPROSENT_REDUSERT_MAKS);
     }
 
     @Test
     void getProsentForPeriode_handterer_skuddaar() {
         LocalDate startDato = LocalDate.of(2024, 2, 29);
-        Avtale avtale = lagAvtaleMedDatoerOgProsent(
-            startDato,
-            LocalDate.of(2026, 2, 28),
-            TILSKUDDSPROSENT_MAKS
-        );
+        Avtale avtale = lagAvtale();
 
         Integer forstePeriode = strategy.getProsentForPeriode(
             avtale,
+            innholdMedDatoerOgProsent(startDato, LocalDate.of(2026, 2, 28), TILSKUDDSPROSENT_MAKS),
             Periode.av(LocalDate.of(2024, 2, 29), LocalDate.of(2025, 2, 27))
         );
         assertThat(forstePeriode).isEqualTo(TILSKUDDSPROSENT_MAKS);
 
         Integer andrePeriode = strategy.getProsentForPeriode(
             avtale,
+            innholdMedDatoerOgProsent(startDato, LocalDate.of(2026, 2, 28), TILSKUDDSPROSENT_MAKS),
             Periode.av(LocalDate.of(2025, 2, 28), LocalDate.of(2026, 2, 28))
         );
         assertThat(andrePeriode).isEqualTo(TILSKUDDSPROSENT_REDUSERT_MAKS);
@@ -266,20 +269,18 @@ class VarigLonnstilskuddAvtaleBeregningStrategyTest {
     @Test
     void getProsentForPeriode_handterer_skuddaar_i_midten_av_trinn() {
         LocalDate startDato = LocalDate.of(2023, 3, 1);
-        Avtale avtale = lagAvtaleMedDatoerOgProsent(
-            startDato,
-            LocalDate.of(2025, 2, 28),
-            TILSKUDDSPROSENT_MAKS
-        );
+        Avtale avtale = lagAvtale();
 
         Integer forstePeriode = strategy.getProsentForPeriode(
             avtale,
+            innholdMedDatoerOgProsent(startDato, LocalDate.of(2025, 2, 28), TILSKUDDSPROSENT_MAKS),
             Periode.av(LocalDate.of(2023, 3, 1), LocalDate.of(2024, 2, 29))
         );
         assertThat(forstePeriode).isEqualTo(TILSKUDDSPROSENT_MAKS);
 
         Integer andrePeriode = strategy.getProsentForPeriode(
             avtale,
+            innholdMedDatoerOgProsent(startDato, LocalDate.of(2025, 2, 28), TILSKUDDSPROSENT_MAKS),
             Periode.av(LocalDate.of(2024, 3, 1), LocalDate.of(2025, 2, 28))
         );
         assertThat(andrePeriode).isEqualTo(TILSKUDDSPROSENT_REDUSERT_MAKS);


### PR DESCRIPTION
Beregningsmetodene i BeregningStrategy og underklassene leste tidligere alltid fra avtale.getGjeldendeInnhold() internt. Dette gjør det umulig å beregne tilskudd basert på en historisk eller godkjent versjon av AvtaleInnhold. Som vi gjør når vi henter alle avtaleversjonene.

Refaktorer getBeløpForPeriode, getProsentForPeriode og getDatoerForReduksjon til å ta inn AvtaleInnhold eksplisitt som parameter, slik at kallstedet bestemmer hvilken versjon som brukes.

Oppdaterer tilhørende tester til å sende inn en dedikert AvtaleInnhold-instans (uavhengig av gjeldendeInnhold) for å verifisere at den innsendte versjonen faktisk brukes i beregningene.