### PR TITLE
Wip rewrite path

### DIFF
--- a/nais/dev-fss.yaml
+++ b/nais/dev-fss.yaml
@@ -51,6 +51,7 @@ spec:
       memory: 600Mi
   ingresses:
     - https://arbeidsgiver.nais.preprod.local/tiltaksgjennomforing-api/
+    - https://tiltaksgjennomforing-api.intern.dev.nav.no/
   vault:
     enabled: true
   webproxy: true

--- a/nais/dev-fss.yaml
+++ b/nais/dev-fss.yaml
@@ -31,13 +31,13 @@ spec:
   image: {{image}}
   port: 8080
   liveness:
-    path: /tiltaksgjennomforing-api/internal/healthcheck
+    path: /internal/healthcheck
     initialDelay: 30
     timeout: 1
     periodSeconds: 30
     failureThreshold: 10
   readiness:
-    path: /tiltaksgjennomforing-api/internal/healthcheck
+    path: /internal/healthcheck
     initialDelay: 30
     timeout: 1
     periodSeconds: 30
@@ -60,7 +60,7 @@ spec:
     enabled: true
   prometheus:
     enabled: true
-    path: /tiltaksgjennomforing-api/internal/actuator/prometheus
+    path: /internal/actuator/prometheus
   observability:
     autoInstrumentation:
       enabled: true

--- a/nais/dev-fss.yaml
+++ b/nais/dev-fss.yaml
@@ -50,7 +50,6 @@ spec:
       cpu: 500m
       memory: 600Mi
   ingresses:
-    - https://arbeidsgiver.nais.preprod.local/tiltaksgjennomforing-api/
     - https://tiltaksgjennomforing-api.intern.dev.nav.no/
   vault:
     enabled: true

--- a/nais/dev-gcp-labs.yaml
+++ b/nais/dev-gcp-labs.yaml
@@ -27,13 +27,13 @@ spec:
     min: 1
     max: 1
   liveness:
-    path: /tiltaksgjennomforing-api/internal/healthcheck
+    path: /internal/healthcheck
     initialDelay: 30
     timeout: 1
     periodSeconds: 30
     failureThreshold: 10
   readiness:
-    path: /tiltaksgjennomforing-api/internal/healthcheck
+    path: /internal/healthcheck
     initialDelay: 30
     timeout: 1
     periodSeconds: 30
@@ -56,7 +56,7 @@ spec:
       memory: 600Mi
   prometheus:
     enabled: true
-    path: /tiltaksgjennomforing-api/internal/actuator/prometheus
+    path: /internal/actuator/prometheus
   accessPolicy:
     inbound:
       rules:

--- a/nais/prod-fss.yaml
+++ b/nais/prod-fss.yaml
@@ -53,6 +53,7 @@ spec:
       memory: 6000Mi
   ingresses:
     - https://arbeidsgiver.nais.adeo.no/tiltaksgjennomforing-api/
+    - https://tiltaksgjennomforing-api.intern.nav.no/
   vault:
     enabled: true
   webproxy: true

--- a/nais/prod-fss.yaml
+++ b/nais/prod-fss.yaml
@@ -31,13 +31,13 @@ spec:
   image: {{image}}
   port: 8080
   liveness:
-    path: /tiltaksgjennomforing-api/internal/healthcheck
+    path: /internal/healthcheck
     initialDelay: 30
     timeout: 1
     periodSeconds: 30
     failureThreshold: 10
   readiness:
-    path: /tiltaksgjennomforing-api/internal/healthcheck
+    path: /internal/healthcheck
     initialDelay: 30
     timeout: 1
     periodSeconds: 30
@@ -62,7 +62,7 @@ spec:
     enabled: true
   prometheus:
     enabled: true
-    path: /tiltaksgjennomforing-api/internal/actuator/prometheus
+    path: /internal/actuator/prometheus
   observability:
     autoInstrumentation:
       enabled: true

--- a/nais/prod-fss.yaml
+++ b/nais/prod-fss.yaml
@@ -52,7 +52,6 @@ spec:
       cpu: 500m
       memory: 6000Mi
   ingresses:
-    - https://arbeidsgiver.nais.adeo.no/tiltaksgjennomforing-api/
     - https://tiltaksgjennomforing-api.intern.nav.no/
   vault:
     enabled: true

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/infrastruktur/LegacyContextPathRedirectFilter.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/infrastruktur/LegacyContextPathRedirectFilter.java
@@ -37,9 +37,6 @@ public class LegacyContextPathRedirectFilter extends OncePerRequestFilter {
     private static final String LEGACY_COUNTER = "legacy_url_path_counter";
     private static final String LEGACY_CONTEXT_PATH = "/tiltaksgjennomforing-api";
 
-    @Value("${tiltaksgjennomforing.legacy-context-path.rewrite-enabled:true}")
-    private boolean rewriteEnabled;
-
     @Override
     protected void doFilterInternal(
         HttpServletRequest request,
@@ -50,7 +47,7 @@ public class LegacyContextPathRedirectFilter extends OncePerRequestFilter {
         String requestURI = request.getRequestURI();
 
         // Vi skal skrive om url'en dersom den starter med gammel base path
-        if (rewriteEnabled && requestURI.startsWith(LEGACY_CONTEXT_PATH)) {
+        if (requestURI.startsWith(LEGACY_CONTEXT_PATH)) {
             meterRegistry.counter(LEGACY_COUNTER).increment();
             final String newPath = requestURI.substring(LEGACY_CONTEXT_PATH.length()).isEmpty()
                     ? "/"

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/infrastruktur/LegacyContextPathRedirectFilter.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/infrastruktur/LegacyContextPathRedirectFilter.java
@@ -1,0 +1,87 @@
+package no.nav.tag.tiltaksgjennomforing.infrastruktur;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequestWrapper;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NonNull;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+/**
+ * Midlertidig filter for å håndtere bakoverkompatibilitet når context-path fjernes.
+ * Skriver transparent over forespørsler med den gamle /tiltaksgjennomforing-api-prefiksen for å fungere med den nye rotstien.
+ * Både gamle og nye stier fungerer samtidig uten omdirigering.
+ * <p>
+ * TODO: Fjern dette filteret etter migreringperioden (f.eks. 6 måneder etter utrulling)
+ */
+@Slf4j
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public class LegacyContextPathRedirectFilter extends OncePerRequestFilter {
+
+    private final MeterRegistry meterRegistry;
+
+    public LegacyContextPathRedirectFilter(MeterRegistry meterRegistry) {
+        this.meterRegistry = meterRegistry;
+    }
+
+    private static final String LEGACY_COUNTER = "legacy_url_path_counter";
+    private static final String LEGACY_CONTEXT_PATH = "/tiltaksgjennomforing-api";
+
+    @Value("${tiltaksgjennomforing.legacy-context-path.rewrite-enabled:true}")
+    private boolean rewriteEnabled;
+
+    @Override
+    protected void doFilterInternal(
+        HttpServletRequest request,
+        @NonNull HttpServletResponse response,
+        @NonNull FilterChain filterChain
+    ) throws ServletException, IOException {
+
+        String requestURI = request.getRequestURI();
+
+        // Vi skal skrive om url'en dersom den starter med gammel base path
+        if (rewriteEnabled && requestURI.startsWith(LEGACY_CONTEXT_PATH)) {
+            meterRegistry.counter(LEGACY_COUNTER).increment();
+            final String newPath = requestURI.substring(LEGACY_CONTEXT_PATH.length()).isEmpty()
+                    ? "/"
+                    : requestURI.substring(LEGACY_CONTEXT_PATH.length());
+
+            log.info("Gammel path brukt: {} -> omskriver til: {} (klient: {})",
+                    requestURI,
+                    newPath,
+                    request.getRemoteAddr()
+            );
+
+            // Overstyr request med en wrapper der getterne for paths er den omskrevne versjonen.
+            HttpServletRequest wrappedRequest = new HttpServletRequestWrapper(request) {
+                @Override
+                public String getRequestURI() {
+                    return newPath;
+                }
+
+                @Override
+                public String getServletPath() {
+                    return newPath;
+                }
+            };
+
+            filterChain.doFilter(wrappedRequest, response);
+            return;
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}
+
+
+

--- a/src/main/resources/config/application.yaml
+++ b/src/main/resources/config/application.yaml
@@ -66,11 +66,6 @@ tiltaksgjennomforing:
   notifikasjoner:
     uri: https://ag-notifikasjon-produsent-api.dev.intern.nav.no/api/graphql
     lenke: https://arbeidsgiver.nav.no/tiltaksgjennomforing/avtale/
-  legacy-context-path:
-    # Transparent URL rewrite from old /tiltaksgjennomforing-api prefix to new root path
-    # Both paths work simultaneously without redirects
-    # TODO: Disable after migration period (e.g., 6 months after deployment)
-    rewrite-enabled: true
 
 no.nav.security.jwt:
   client:

--- a/src/main/resources/config/application.yaml
+++ b/src/main/resources/config/application.yaml
@@ -1,4 +1,3 @@
-server.servlet.context-path: /tiltaksgjennomforing-api
 
 management.endpoints.web:
   exposure.include: info, health, metrics, prometheus
@@ -67,6 +66,11 @@ tiltaksgjennomforing:
   notifikasjoner:
     uri: https://ag-notifikasjon-produsent-api.dev.intern.nav.no/api/graphql
     lenke: https://arbeidsgiver.nav.no/tiltaksgjennomforing/avtale/
+  legacy-context-path:
+    # Transparent URL rewrite from old /tiltaksgjennomforing-api prefix to new root path
+    # Both paths work simultaneously without redirects
+    # TODO: Disable after migration period (e.g., 6 months after deployment)
+    rewrite-enabled: true
 
 no.nav.security.jwt:
   client:

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/infrastruktur/LegacyContextPathRedirectFilterTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/infrastruktur/LegacyContextPathRedirectFilterTest.java
@@ -1,0 +1,126 @@
+package no.nav.tag.tiltaksgjennomforing.infrastruktur;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.io.IOException;
+
+import static org.mockito.Mockito.argThat;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+class LegacyContextPathRedirectFilterTest {
+
+    private LegacyContextPathRedirectFilter filter;
+    private MockHttpServletRequest request;
+    private MockHttpServletResponse response;
+    private FilterChain filterChain;
+
+    @BeforeEach
+    void setUp() {
+        filter = new LegacyContextPathRedirectFilter(new SimpleMeterRegistry());
+        ReflectionTestUtils.setField(filter, "rewriteEnabled", true);
+        request = new MockHttpServletRequest();
+        response = new MockHttpServletResponse();
+        filterChain = mock(FilterChain.class);
+    }
+
+    @Test
+    void shouldRewriteLegacyContextPath() throws ServletException, IOException {
+        // Given
+        request.setRequestURI("/tiltaksgjennomforing-api/avtaler");
+
+        // When
+        filter.doFilterInternal(request, response, filterChain);
+
+        // Then
+        verify(filterChain, times(1)).doFilter(argThat(req -> {
+            HttpServletRequest httpReq = (HttpServletRequest) req;
+            return "/avtaler".equals(httpReq.getRequestURI()) &&
+                   "/avtaler".equals(httpReq.getServletPath());
+        }), eq(response));
+    }
+
+    @Test
+    void shouldRewriteLegacyContextPathWithQueryString() throws ServletException, IOException {
+        // Given
+        request.setRequestURI("/tiltaksgjennomforing-api/avtaler/123");
+        request.setQueryString("page=1&size=10");
+
+        // When
+        filter.doFilterInternal(request, response, filterChain);
+
+        // Then
+        verify(filterChain, times(1)).doFilter(argThat(req -> {
+            HttpServletRequest httpReq = (HttpServletRequest) req;
+            return "/avtaler/123".equals(httpReq.getRequestURI()) &&
+                   "page=1&size=10".equals(httpReq.getQueryString());
+        }), eq(response));
+    }
+
+    @Test
+    void shouldRewriteLegacyContextPathRootToRoot() throws ServletException, IOException {
+        // Given
+        request.setRequestURI("/tiltaksgjennomforing-api");
+
+        // When
+        filter.doFilterInternal(request, response, filterChain);
+
+        // Then
+        verify(filterChain, times(1)).doFilter(argThat(req -> {
+            HttpServletRequest httpReq = (HttpServletRequest) req;
+            return "/".equals(httpReq.getRequestURI());
+        }), eq(response));
+    }
+
+    @Test
+    void shouldNotRewriteNonLegacyPaths() throws ServletException, IOException {
+        // Given
+        request.setRequestURI("/avtaler");
+
+        // When
+        filter.doFilterInternal(request, response, filterChain);
+
+        // Then
+        verify(filterChain, times(1)).doFilter(eq(request), eq(response));
+    }
+
+    @Test
+    void shouldNotRewriteWhenDisabled() throws ServletException, IOException {
+        // Given
+        ReflectionTestUtils.setField(filter, "rewriteEnabled", false);
+        request.setRequestURI("/tiltaksgjennomforing-api/avtaler");
+
+        // When
+        filter.doFilterInternal(request, response, filterChain);
+
+        // Then
+        verify(filterChain, times(1)).doFilter(eq(request), eq(response));
+    }
+
+    @Test
+    void shouldRewriteInternalHealthcheckPath() throws ServletException, IOException {
+        // Given
+        request.setRequestURI("/tiltaksgjennomforing-api/internal/healthcheck");
+
+        // When
+        filter.doFilterInternal(request, response, filterChain);
+
+        // Then
+        verify(filterChain, times(1)).doFilter(argThat(req -> {
+            HttpServletRequest httpReq = (HttpServletRequest) req;
+            return "/internal/healthcheck".equals(httpReq.getRequestURI());
+        }), eq(response));
+    }
+}
+
+

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/infrastruktur/LegacyContextPathRedirectFilterTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/infrastruktur/LegacyContextPathRedirectFilterTest.java
@@ -28,7 +28,6 @@ class LegacyContextPathRedirectFilterTest {
     @BeforeEach
     void setUp() {
         filter = new LegacyContextPathRedirectFilter(new SimpleMeterRegistry());
-        ReflectionTestUtils.setField(filter, "rewriteEnabled", true);
         request = new MockHttpServletRequest();
         response = new MockHttpServletResponse();
         filterChain = mock(FilterChain.class);
@@ -86,19 +85,6 @@ class LegacyContextPathRedirectFilterTest {
     void shouldNotRewriteNonLegacyPaths() throws ServletException, IOException {
         // Given
         request.setRequestURI("/avtaler");
-
-        // When
-        filter.doFilterInternal(request, response, filterChain);
-
-        // Then
-        verify(filterChain, times(1)).doFilter(eq(request), eq(response));
-    }
-
-    @Test
-    void shouldNotRewriteWhenDisabled() throws ServletException, IOException {
-        // Given
-        ReflectionTestUtils.setField(filter, "rewriteEnabled", false);
-        request.setRequestURI("/tiltaksgjennomforing-api/avtaler");
 
         // When
         filter.doFilterInternal(request, response, filterChain);

--- a/src/test/resources/admin-kall.http
+++ b/src/test/resources/admin-kall.http
@@ -1,25 +1,25 @@
 ### Annuller en tilskuddsperiode
 # Husk å bytte ut UUID med tilskuddsperiodens id, og TOKEN med ad-tokenet man lager i az-cli
-POST http://localhost:12345/tiltaksgjennomforing-api/utvikler-admin/annuller-tilskuddsperiode/<TILSKUDDSPERIODE_ID>
+POST https://tiltaksgjennomforing-api.intern.nav.no/tiltaksgjennomforing-api/utvikler-admin/annuller-tilskuddsperiode/<TILSKUDDSPERIODE_ID>
 Authorization: Bearer <TOKEN>
 
 ### Lag tilskuddsperioder for en enkelt avtale
 # Husk å bytte ut UUID med avtalens id, og SESSION_ID med sesjons-id'en du får fra cookies i frontend
-POST https://tiltaksgjennomforing.intern.nav.no/tiltaksgjennomforing/api/utvikler-admin/lag-tilskuddsperioder-for-en-avtale/<UUID>/2023-02-01
+POST https://tiltaksgjennomforing-api.intern.nav.no/tiltaksgjennomforing-api/utvikler-admin/lag-tilskuddsperioder-for-en-avtale/<UUID>/2023-02-01
 Cookie: io.nais.wonderwall.session=<SESSION_ID>
 
 ### Reberegn ubehandlet perioder
-POST https://tiltaksgjennomforing.intern.nav.no/tiltaksgjennomforing/api/utvikler-admin/reberegn-ubehandlede-tilskuddsperioder/<UUID>
+POST https://tiltaksgjennomforing-api.intern.nav.no/tiltaksgjennomforing-api/utvikler-admin/reberegn-ubehandlede-tilskuddsperioder/<UUID>
 Cookie: io.nais.wonderwall.session=<SESSION_ID>
 
 
 ### Annuller perioder med sluttdato før oppgitt dato på avtale og lag nye med status behandlet i arena
-POST https://tiltaksgjennomforing.intern.nav.no/tiltaksgjennomforing/api/utvikler-admin/annuller-og-generer-behandlet-i-arena-perioder/58f5f3ff-fd7b-469b-9e7b-6c43b2888fba/2023-02-01
+POST https://tiltaksgjennomforing-api.intern.nav.no/tiltaksgjennomforing-api/utvikler-admin/annuller-og-generer-behandlet-i-arena-perioder/58f5f3ff-fd7b-469b-9e7b-6c43b2888fba/2023-02-01
 Cookie: io.nais.wonderwall.session=<SESSION_ID>
 
 
 ### Patch Dvh meldinger
-POST https://tiltaksgjennomforing.intern.nav.no/tiltaksgjennomforing/api/utvikler-admin/dvh-melding/patch
+POST https://tiltaksgjennomforing-api.intern.nav.no/tiltaksgjennomforing-api/utvikler-admin/dvh-melding/patch
 Content-Type: application/json
 Cookie: io.nais.wonderwall.session=<SESSION_ID>
 
@@ -30,7 +30,7 @@ Cookie: io.nais.wonderwall.session=<SESSION_ID>
 }
 
 ### Lage nye oppdaterte krav for arbeidsgivere
-POST http://localhost:12345/tiltaksgjennomforing-api/utvikler-admin/oppdaterte-avtalekrav
+POST https://tiltaksgjennomforing-api.intern.nav.no/tiltaksgjennomforing-api/utvikler-admin/oppdaterte-avtalekrav
 Content-Type: application/json
 Authorization: Bearer <TOKEN>
 
@@ -40,27 +40,27 @@ Authorization: Bearer <TOKEN>
 
 
 ### Oppdater gjeldende tilskuddsperiode på alle avtaler
-POST http://localhost:12345/tiltaksgjennomforing-api/utvikler-admin/oppdater-gjeldende-tilskuddsperiode-for-avtaler
+POST https://tiltaksgjennomforing-api.intern.nav.no/tiltaksgjennomforing-api/utvikler-admin/oppdater-gjeldende-tilskuddsperiode-for-avtaler
 Content-Type: application/json
 Authorization: Bearer <TOKEN>
 
 
 ### Tar over aktivietsplankortet fra Arena og sender siste melding på nytt.
 # Husk å bytte ut UUID med avtalens id
-POST http://localhost:12345/tiltaksgjennomforing-api/utvikler-admin/aktivitetsplan/avtale/<UUID>/ta-over-kort
+POST https://tiltaksgjennomforing-api.intern.nav.no/tiltaksgjennomforing-api/utvikler-admin/aktivitetsplan/avtale/<UUID>/ta-over-kort
 Content-Type: application/json
 Authorization: Bearer <TOKEN>
 
 ### Hent aktivitetsplan-id'en vi ville fått når vi tar over kort fra Arena/
 # Husk å bytte ut UUID med avtalens id
-POST http://localhost:12345/tiltaksgjennomforing-api/utvikler-admin/aktivitetsplan/avtale/<UUID>/hent-aktivitetsplan-id
+POST https://tiltaksgjennomforing-api.intern.nav.no/tiltaksgjennomforing-api/utvikler-admin/aktivitetsplan/avtale/<UUID>/hent-aktivitetsplan-id
 Content-Type: application/json
 Authorization: Bearer <TOKEN>
 
 
 ### Sender hendelsemelding for en avtale
 # Husk å bytte ut UUID med avtalens id
-POST http://localhost:12345/tiltaksgjennomforing-api/utvikler-admin/avtale-hendelse/send-melding-en-avtale/<UUID>
+POST https://tiltaksgjennomforing-api.intern.nav.no/tiltaksgjennomforing-api/utvikler-admin/avtale-hendelse/send-melding-en-avtale/<UUID>
 Content-Type: application/json
 Authorization: Bearer <TOKEN>
 


### PR DESCRIPTION
# Fjern base-path, midlertidig omskriving

Av historiske årsaker har server-appen hatt en base-path
som ikke lenger er nødvendig. Ønsker derfor å fjerne denne,
men det vil være en breaking change for både vår egen
frontend-app, og en ekstern konsument.

I en overgangsfase blir vi derfor nødt til å skrive om URL'er
på vei inn til appen, frem til alle har migrert til nye
paths.

Vi både logger og måler antall treff på gamle paths, og fjerner
dette omskrivingsfilteret når alle er migrert over.