### PR TITLE
Tillat trafikk direkte fra frackenden

### DIFF
--- a/nais/dev-fss.yaml
+++ b/nais/dev-fss.yaml
@@ -73,7 +73,10 @@ spec:
   accessPolicy:
     inbound:
       rules:
-        - application: tiltak-proxy
+        - application: tiltak-proxy # Fjernes etter frontend-app er migrert til ny path
+        - application: tiltaksgjennomforing
+          namespace: arbeidsgiver
+          cluster: dev-gcp
         - application: min-side-arbeidsgiver
           namespace: fager
           cluster: dev-gcp

--- a/nais/dev-fss.yaml
+++ b/nais/dev-fss.yaml
@@ -77,6 +77,9 @@ spec:
         - application: tiltaksgjennomforing
           namespace: arbeidsgiver
           cluster: dev-gcp
+        - application: tiltaksgjennomforing-intern
+          namespace: arbeidsgiver
+          cluster: dev-gcp
         - application: min-side-arbeidsgiver
           namespace: fager
           cluster: dev-gcp

--- a/nais/dev-fss.yaml
+++ b/nais/dev-fss.yaml
@@ -51,6 +51,7 @@ spec:
       memory: 600Mi
   ingresses:
     - https://tiltaksgjennomforing-api.intern.dev.nav.no/
+    - https://tiltaksgjennomforing-api.dev-fss-pub.nais.io/
   vault:
     enabled: true
   webproxy: true

--- a/nais/prod-fss.yaml
+++ b/nais/prod-fss.yaml
@@ -75,7 +75,10 @@ spec:
   accessPolicy:
     inbound:
       rules:
-        - application: tiltak-proxy
+        - application: tiltak-proxy # Fjernes etter frontend-app er migrert til ny path
+        - application: tiltaksgjennomforing
+          namespace: arbeidsgiver
+          cluster: prod-gcp
         - application: min-side-arbeidsgiver
           namespace: fager
           cluster: prod-gcp

--- a/nais/prod-fss.yaml
+++ b/nais/prod-fss.yaml
@@ -79,6 +79,9 @@ spec:
         - application: tiltaksgjennomforing
           namespace: arbeidsgiver
           cluster: prod-gcp
+        - application: tiltaksgjennomforing-intern
+          namespace: arbeidsgiver
+          cluster: prod-gcp
         - application: min-side-arbeidsgiver
           namespace: fager
           cluster: prod-gcp

--- a/nais/prod-fss.yaml
+++ b/nais/prod-fss.yaml
@@ -53,6 +53,7 @@ spec:
       memory: 6000Mi
   ingresses:
     - https://tiltaksgjennomforing-api.intern.nav.no/
+    - https://tiltaksgjennomforing-api.prod-fss-pub.nais.io/
   vault:
     enabled: true
   webproxy: true


### PR DESCRIPTION
Legger til tiltaksgjennomforing-appen i listen over godkjente inbound-apper. Dette skal gjøre det mulig å droppe rutingen via tiltak-proxy.