### PR TITLE
fix. Fikk ikke patchet til DVH

### DIFF
--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/TiltaksgjennomforingConfiguration.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/TiltaksgjennomforingConfiguration.java
@@ -9,10 +9,14 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 import org.springframework.core.env.Environment;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.web.client.RestTemplate;
 
 import javax.sql.DataSource;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ThreadPoolExecutor;
 
 @Slf4j
 @Configuration
@@ -40,6 +44,18 @@ class TiltaksgjennomforingConfiguration {
     @Bean
     public LockProvider lockProvider(DataSource dataSource) {
         return new JdbcTemplateLockProvider(dataSource);
+    }
+
+    @Primary
+    @Bean(name = "taskExecutor")
+    public Executor taskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(5);
+        executor.setMaxPoolSize(10);
+        executor.setRejectedExecutionHandler(new ThreadPoolExecutor.CallerRunsPolicy());
+        executor.setThreadNamePrefix("Async-");
+        executor.initialize();
+        return executor;
     }
 
 }

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/datavarehus/DvhAvtalePatchService.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/datavarehus/DvhAvtalePatchService.java
@@ -6,7 +6,6 @@ import no.nav.tag.tiltaksgjennomforing.avtale.Avtale;
 import no.nav.tag.tiltaksgjennomforing.avtale.AvtaleRepository;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -17,7 +16,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 public class DvhAvtalePatchService {
 
     private final AvtaleRepository avtaleRepository;
-    private final DvhMeldingEntitetRepository dvhRepository;
+    private final DvhAvtalePatcher dvhAvtalePatcher;
 
     @Async
     public void lagDvhPatchMeldingForAlleAvtaler() {
@@ -25,28 +24,22 @@ public class DvhAvtalePatchService {
         List<Avtale> alleAvtaler = avtaleRepository.findAllByGjeldendeInnhold_AvtaleInngåttNotNull();
 
         alleAvtaler.forEach(avtale -> {
-            if(skalPatches(avtale)) {
-                lagDvhPatchMelding(avtale);
+            if (!skalPatches(avtale)) {
+                log.info("Avtale {} skal ikke patches i DVH", avtale.getId());
+            } else {
+                dvhAvtalePatcher.lagDvhPatchMelding(avtale);
                 antallPatchet.getAndIncrement();
-                if(antallPatchet.get() % 100 == 0) {
+                if (antallPatchet.get() % 100 == 0) {
                     log.info("Migrert {} antall avtaler", antallPatchet.get());
                 }
             }
-            log.info("Avtale {} skal ikke patches i DVH", avtale.getId());
         });
         log.info("Migrert {} antall avtaler", antallPatchet.get());
     }
 
-    @Transactional
-    public void lagDvhPatchMelding(Avtale avtale) {
-        var melding = AvroTiltakHendelseFabrikk.konstruer(avtale, DvhHendelseType.PATCHING, "system");
-        DvhMeldingEntitet entitet = new DvhMeldingEntitet(avtale, melding);
-        dvhRepository.save(entitet);
-    }
-
     private boolean skalPatches(Avtale avtale) {
-        if(avtale.erAvtaleInngått()) {
-            if(!avtale.erGodkjentAvVeileder()) {
+        if (avtale.erAvtaleInngått()) {
+            if (!avtale.erGodkjentAvVeileder()) {
                 log.warn("Avtale {} er inngått men ikke godkjent av veileder", avtale.getId());
                 return false;
             }

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/datavarehus/DvhAvtalePatcher.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/datavarehus/DvhAvtalePatcher.java
@@ -1,0 +1,20 @@
+package no.nav.tag.tiltaksgjennomforing.datavarehus;
+
+import lombok.RequiredArgsConstructor;
+import no.nav.tag.tiltaksgjennomforing.avtale.Avtale;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class DvhAvtalePatcher {
+
+    private final DvhMeldingEntitetRepository dvhRepository;
+
+    @Transactional
+    public void lagDvhPatchMelding(Avtale avtale) {
+        var melding = AvroTiltakHendelseFabrikk.konstruer(avtale, DvhHendelseType.PATCHING, "system");
+        DvhMeldingEntitet entitet = new DvhMeldingEntitet(avtale, melding);
+        dvhRepository.save(entitet);
+    }
+}


### PR DESCRIPTION
* More than one TaskExecutor bean found within the context, and none is named 'taskExecutor'. Mark one of them as primary or name it 'taskExecutor' (possibly as an alias) in order to use it for async processing: [arenaThreadPoolExecutor, taskScheduler]