### PR TITLE
 feat. legg til retry og cache på Altinn 2 og Altinn 3 for å håndtere sporadiske 502-feil

### DIFF
--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/InnloggingService.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/InnloggingService.java
@@ -61,10 +61,11 @@ public class InnloggingService {
             return new Mentor(new Fnr(brukerOgIssuer.getBrukerIdent()));
         }
         if (issuer == Issuer.ISSUER_TOKENX && avtalerolle == Avtalerolle.ARBEIDSGIVER) {
-            AltinnTilgangerDto altinnTilganger = altinnTilgangsstyringService.hentAltinnTilganger();
+            Fnr arbeidsgiverFnr = new Fnr(brukerOgIssuer.getBrukerIdent());
+            AltinnTilgangerDto altinnTilganger = altinnTilgangsstyringService.hentAltinnTilganger(arbeidsgiverFnr);
             List<BedriftNr> adressesperreTilganger = altinnTilganger.adressesperreTilganger();
             return new Arbeidsgiver(
-                new Fnr(brukerOgIssuer.getBrukerIdent()),
+                arbeidsgiverFnr,
                 altinnTilganger,
                 adressesperreTilganger,
                 persondataService,

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/altinntilgangsstyring/AltinnTilgangsstyringKlient.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/altinntilgangsstyring/AltinnTilgangsstyringKlient.java
@@ -1,0 +1,56 @@
+package no.nav.tag.tiltaksgjennomforing.autorisasjon.altinntilgangsstyring;
+
+import lombok.extern.slf4j.Slf4j;
+import no.nav.tag.tiltaksgjennomforing.avtale.Fnr;
+import no.nav.tag.tiltaksgjennomforing.exceptions.AltinnFeilException;
+import no.nav.tag.tiltaksgjennomforing.infrastruktur.cache.CacheConfig;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestClientResponseException;
+import org.springframework.web.client.RestTemplate;
+
+import java.net.URI;
+
+@Service
+@Slf4j
+public class AltinnTilgangsstyringKlient {
+    private final URI arbeidsgiverAltinnTilgangerUri;
+    private final RestTemplate azureRestTemplate;
+
+    public AltinnTilgangsstyringKlient(
+            AltinnTilgangsstyringProperties altinnTilgangsstyringProperties,
+            RestTemplate azureRestTemplate
+    ) {
+        this.arbeidsgiverAltinnTilgangerUri = altinnTilgangsstyringProperties.getArbeidsgiverAltinnTilgangerUri();
+        this.azureRestTemplate = azureRestTemplate;
+    }
+
+    @Cacheable(CacheConfig.ALTINN_CACHE)
+    @Retryable(backoff = @Backoff(delayExpression = "${tiltaksgjennomforing.retry.delay}", maxDelayExpression = "${tiltaksgjennomforing.retry.max-delay}", multiplier = 2))
+    public AltinnTilgangerResponse kallAltinn3(Fnr fnrSomCacheParameter) {
+        AltinnTilgangerResponse response;
+        try {
+            response = azureRestTemplate.postForObject(
+                arbeidsgiverAltinnTilgangerUri,
+                null,
+                AltinnTilgangerResponse.class
+            );
+        } catch (RestClientResponseException e) {
+            log.error("HTTP-feil fra arbeidsgiver-altinn-tilganger: status={}, body={}", e.getStatusCode(), e.getResponseBodyAsString(), e);
+            throw new AltinnFeilException();
+        } catch (ResourceAccessException e) {
+            log.error("Nettverksfeil ved kall til arbeidsgiver-altinn-tilganger", e);
+            throw new AltinnFeilException();
+        }
+
+        if (response == null || response.isError() || response.orgNrTilTilganger() == null) {
+            log.warn("Ugyldig respons fra arbeidsgiver-altinn-tilganger, isError: {}", response != null ? response.isError() : "null");
+            throw new AltinnFeilException();
+        }
+
+        return response;
+    }
+}

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/altinntilgangsstyring/AltinnTilgangsstyringService.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/altinntilgangsstyring/AltinnTilgangsstyringService.java
@@ -2,14 +2,11 @@ package no.nav.tag.tiltaksgjennomforing.autorisasjon.altinntilgangsstyring;
 
 import lombok.extern.slf4j.Slf4j;
 import no.nav.tag.tiltaksgjennomforing.avtale.BedriftNr;
+import no.nav.tag.tiltaksgjennomforing.avtale.Fnr;
 import no.nav.tag.tiltaksgjennomforing.avtale.Tiltakstype;
-import no.nav.tag.tiltaksgjennomforing.exceptions.AltinnFeilException;
 import no.nav.tag.tiltaksgjennomforing.exceptions.TiltaksgjennomforingException;
 import no.nav.tag.tiltaksgjennomforing.utils.Utils;
 import org.springframework.stereotype.Service;
-import org.springframework.web.client.ResourceAccessException;
-import org.springframework.web.client.RestClientResponseException;
-import org.springframework.web.client.RestTemplate;
 
 import java.util.HashMap;
 import java.util.HashSet;
@@ -21,31 +18,34 @@ import java.util.Set;
 @Slf4j
 public class AltinnTilgangsstyringService {
     private final AltinnTilgangsstyringProperties altinnTilgangsstyringProperties;
-    private final RestTemplate azureRestTemplate;
+    private final AltinnTilgangsstyringKlient klient;
 
     public AltinnTilgangsstyringService(
-            AltinnTilgangsstyringProperties altinnTilgangsstyringProperties,
-            RestTemplate azureRestTemplate) {
+        AltinnTilgangsstyringProperties altinnTilgangsstyringProperties,
+        AltinnTilgangsstyringKlient klient
+    ) {
 
-        if (Utils.erNoenTomme(altinnTilgangsstyringProperties.getArbtreningServiceCode(),
-                altinnTilgangsstyringProperties.getArbtreningServiceEdition(),
-                altinnTilgangsstyringProperties.getLtsMidlertidigServiceCode(),
-                altinnTilgangsstyringProperties.getLtsMidlertidigServiceEdition(),
-                altinnTilgangsstyringProperties.getLtsVarigServiceCode(),
-                altinnTilgangsstyringProperties.getLtsVarigServiceEdition(),
-                altinnTilgangsstyringProperties.getSommerjobbServiceCode(),
-                altinnTilgangsstyringProperties.getSommerjobbServiceEdition(),
-                altinnTilgangsstyringProperties.getVtaoServiceCode(),
-                altinnTilgangsstyringProperties.getVtaoServiceEdition(),
-                altinnTilgangsstyringProperties.getArbeidsgiverAltinnTilgangerUri())) {
+        if (Utils.erNoenTomme(
+            altinnTilgangsstyringProperties.getArbtreningServiceCode(),
+            altinnTilgangsstyringProperties.getArbtreningServiceEdition(),
+            altinnTilgangsstyringProperties.getLtsMidlertidigServiceCode(),
+            altinnTilgangsstyringProperties.getLtsMidlertidigServiceEdition(),
+            altinnTilgangsstyringProperties.getLtsVarigServiceCode(),
+            altinnTilgangsstyringProperties.getLtsVarigServiceEdition(),
+            altinnTilgangsstyringProperties.getSommerjobbServiceCode(),
+            altinnTilgangsstyringProperties.getSommerjobbServiceEdition(),
+            altinnTilgangsstyringProperties.getVtaoServiceCode(),
+            altinnTilgangsstyringProperties.getVtaoServiceEdition(),
+            altinnTilgangsstyringProperties.getArbeidsgiverAltinnTilgangerUri()
+        )) {
             throw new TiltaksgjennomforingException("Altinn konfigurasjon ikke komplett");
         }
         this.altinnTilgangsstyringProperties = altinnTilgangsstyringProperties;
-        this.azureRestTemplate = azureRestTemplate;
+        this.klient = klient;
     }
 
-    public AltinnTilgangerDto hentAltinnTilganger() {
-        AltinnTilgangerResponse response = kallAltinn3();
+    public AltinnTilgangerDto hentAltinnTilganger(Fnr fnr) {
+        AltinnTilgangerResponse response = klient.kallAltinn3(fnr);
 
         return new AltinnTilgangerDto(
             response.hierarki(),
@@ -92,29 +92,5 @@ public class AltinnTilgangsstyringService {
         }
 
         return tilganger;
-    }
-
-    private AltinnTilgangerResponse kallAltinn3() {
-        AltinnTilgangerResponse response;
-        try {
-            response = azureRestTemplate.postForObject(
-                    altinnTilgangsstyringProperties.getArbeidsgiverAltinnTilgangerUri(),
-                    null,
-                    AltinnTilgangerResponse.class
-            );
-        } catch (RestClientResponseException e) {
-            log.error("HTTP-feil fra arbeidsgiver-altinn-tilganger: status={}, body={}", e.getStatusCode(), e.getResponseBodyAsString(), e);
-            throw new AltinnFeilException();
-        } catch (ResourceAccessException e) {
-            log.error("Nettverksfeil ved kall til arbeidsgiver-altinn-tilganger", e);
-            throw new AltinnFeilException();
-        }
-
-        if (response == null || response.isError() || response.orgNrTilTilganger() == null) {
-            log.warn("Ugyldig respons fra arbeidsgiver-altinn-tilganger, isError: {}", response != null ? response.isError() : "null");
-            throw new AltinnFeilException();
-        }
-
-        return response;
     }
 }

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/featuretoggles/ByOrgnummerStrategy.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/featuretoggles/ByOrgnummerStrategy.java
@@ -5,6 +5,7 @@ import io.getunleash.strategy.Strategy;
 import lombok.extern.slf4j.Slf4j;
 import no.nav.tag.tiltaksgjennomforing.autorisasjon.altinntilgangsstyring.AltinnTilgangsstyringService;
 import no.nav.tag.tiltaksgjennomforing.avtale.BedriftNr;
+import no.nav.tag.tiltaksgjennomforing.avtale.Fnr;
 import no.nav.tag.tiltaksgjennomforing.avtale.NavIdent;
 import org.springframework.stereotype.Component;
 
@@ -46,7 +47,7 @@ public class ByOrgnummerStrategy implements Strategy {
         }
         try {
             // Gir kun organisasjoner bruker har en tiltakstilgang på, ikke alle organisasjoner brukeren har tilgang til i Altinn. Tror det er ok 🥶
-            return altinnTilgangsstyringService.hentAltinnTilganger().tilganger().keySet().stream()
+            return altinnTilgangsstyringService.hentAltinnTilganger(new Fnr(currentUserId)).tilganger().keySet().stream()
                     .map(BedriftNr::asString)
                     .toList();
         } catch (Exception e) {

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/infrastruktur/cache/CacheConfig.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/infrastruktur/cache/CacheConfig.java
@@ -14,12 +14,10 @@ import java.time.Duration;
 public class CacheConfig {
 
     public static final String ENTRAPROXY_CACHE = "entraproxy_cache";
-
     public static final String NORGNAVN_CACHE = "norgnavn_cache";
-
     public static final String NORG_GEO_ENHET = "norggeoenhet_cache";
-
     public static final String VEILARBOPPFOLGING_CACHE = "veilarboppfolging_cache";
+    public static final String ALTINN_CACHE = "altinn_cache";
 
     @Bean
     public CacheManager cacheManager(CacheDto cacheDto) {

--- a/src/main/resources/config/application.yaml
+++ b/src/main/resources/config/application.yaml
@@ -108,3 +108,6 @@ caches:
     - name: entraproxy_cache
       expiryInMinutes: 60
       maximumSize: 1000
+    - name: altinn_cache
+      expiryInMinutes: 60
+      maximumSize: 1000

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/AltinnTilgangsstyringServiceTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/AltinnTilgangsstyringServiceTest.java
@@ -1,14 +1,16 @@
 package no.nav.tag.tiltaksgjennomforing.autorisasjon;
 
+import no.bekk.bekkopen.person.FodselsnummerValidator;
 import no.nav.tag.tiltaksgjennomforing.Miljø;
 import no.nav.tag.tiltaksgjennomforing.autorisasjon.altinntilgangsstyring.AltinnTilgangerDto;
 import no.nav.tag.tiltaksgjennomforing.autorisasjon.altinntilgangsstyring.AltinnTilgangsstyringProperties;
 import no.nav.tag.tiltaksgjennomforing.autorisasjon.altinntilgangsstyring.AltinnTilgangsstyringService;
 import no.nav.tag.tiltaksgjennomforing.avtale.BedriftNr;
+import no.nav.tag.tiltaksgjennomforing.avtale.Fnr;
 import no.nav.tag.tiltaksgjennomforing.avtale.Tiltakstype;
-import no.nav.tag.tiltaksgjennomforing.exceptions.AltinnFeilException;
 import no.nav.tag.tiltaksgjennomforing.exceptions.TiltaksgjennomforingException;
 import no.nav.tag.tiltaksgjennomforing.featuretoggles.FeatureToggleService;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -29,6 +31,8 @@ import static org.mockito.Mockito.when;
 @ActiveProfiles({ Miljø.TEST, Miljø.WIREMOCK })
 @DirtiesContext
 public class AltinnTilgangsstyringServiceTest {
+    private Fnr fnr;
+
     @Autowired
     private AltinnTilgangsstyringService altinnTilgangsstyringService;
 
@@ -40,12 +44,19 @@ public class AltinnTilgangsstyringServiceTest {
 
     @BeforeEach
     public void setup() {
+        FodselsnummerValidator.ALLOW_SYNTHETIC_NUMBERS = true;
         when(featureToggleService.isEnabled(anyString())).thenReturn(false);
+        fnr = Fnr.generer(25);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        FodselsnummerValidator.ALLOW_SYNTHETIC_NUMBERS = false;
     }
 
     @Test
     public void hentOrganisasjoner__gyldig_fnr_en_bedrift_på_hvert_tiltak() {
-        AltinnTilgangerDto dto = altinnTilgangsstyringService.hentAltinnTilganger();
+        AltinnTilgangerDto dto = altinnTilgangsstyringService.hentAltinnTilganger(fnr);
         Map<BedriftNr, Set<Tiltakstype>> tilganger = dto.tilganger();
 
         // Parents skal ikke være i tilgang-map
@@ -62,7 +73,7 @@ public class AltinnTilgangsstyringServiceTest {
 
     @Test
     public void hentOrganisasjoner__tilgang_bare_for_arbeidstrening() {
-        AltinnTilgangerDto dto = altinnTilgangsstyringService.hentAltinnTilganger();
+        AltinnTilgangerDto dto = altinnTilgangsstyringService.hentAltinnTilganger(fnr);
         Map<BedriftNr, Set<Tiltakstype>> tilganger = dto.tilganger();
 
         // Parents skal ikke være i tilgang-map
@@ -82,7 +93,7 @@ public class AltinnTilgangsstyringServiceTest {
 
     @Test
     public void hentAltinn3__Organisasjoner__returnerer_hierarki_og_tilgangsmappinger() {
-        AltinnTilgangerDto dto = altinnTilgangsstyringService.hentAltinnTilganger();
+        AltinnTilgangerDto dto = altinnTilgangsstyringService.hentAltinnTilganger(fnr);
 
         assertThat(dto).isNotNull();
 
@@ -105,7 +116,7 @@ public class AltinnTilgangsstyringServiceTest {
 
     @Test
     public void mapTilgangerFraAltinn3__returnerer_tilganger_per_bedrift() {
-        AltinnTilgangerDto dto = altinnTilgangsstyringService.hentAltinnTilganger();
+        AltinnTilgangerDto dto = altinnTilgangsstyringService.hentAltinnTilganger(fnr);
         Map<BedriftNr, Set<Tiltakstype>> tilganger = dto.tilganger();
 
         assertThat(tilganger).isNotEmpty();

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/InnloggingServiceTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/InnloggingServiceTest.java
@@ -21,20 +21,16 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 
 import static no.nav.tag.tiltaksgjennomforing.AssertFeilkode.assertFeilkode;
 import static no.nav.tag.tiltaksgjennomforing.avtale.TestData.ENHET_OPPFØLGING;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 public class InnloggingServiceTest {
-
     @InjectMocks
     private InnloggingService innloggingService;
 
@@ -52,7 +48,6 @@ public class InnloggingServiceTest {
 
     @Mock
     private AdGruppeProperties beslutterAdGruppeProperties;
-
 
     @BeforeEach
     public void setup() {
@@ -80,8 +75,9 @@ public class InnloggingServiceTest {
 
     @Test
     public void hentInnloggetBruker__selvbetjeningbruker_type_arbeidsgiver_skal_hente_organisasjoner() {
-        InnloggetArbeidsgiver selvbetjeningBruker = new InnloggetArbeidsgiver(new Fnr("11111111111"), new AltinnTilgangerDto(List.of(), Map.of(), List.of()));
-        when(altinnTilgangsstyringService.hentAltinnTilganger()).thenReturn(new AltinnTilgangerDto(List.of(), Map.of(), List.of()));
+        Fnr fnr = Fnr.generer(25);
+        InnloggetArbeidsgiver selvbetjeningBruker = new InnloggetArbeidsgiver(fnr, new AltinnTilgangerDto(List.of(), Map.of(), List.of()));
+        when(altinnTilgangsstyringService.hentAltinnTilganger(fnr)).thenReturn(new AltinnTilgangerDto(List.of(), Map.of(), List.of()));
         værInnloggetArbeidsgiver(selvbetjeningBruker);
 
 

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/altinntilgangsstyring/AltinnTilgangsstyringKlientTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/altinntilgangsstyring/AltinnTilgangsstyringKlientTest.java
@@ -1,0 +1,166 @@
+package no.nav.tag.tiltaksgjennomforing.autorisasjon.altinntilgangsstyring;
+
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.stubbing.Scenario;
+import no.bekk.bekkopen.person.FodselsnummerValidator;
+import no.nav.tag.tiltaksgjennomforing.IntegrasjonerMockServer;
+import no.nav.tag.tiltaksgjennomforing.Miljø;
+import no.nav.tag.tiltaksgjennomforing.avtale.Fnr;
+import no.nav.tag.tiltaksgjennomforing.exceptions.AltinnFeilException;
+import no.nav.tag.tiltaksgjennomforing.infrastruktur.cache.CacheConfig;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cache.CacheManager;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.Objects;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@SpringBootTest
+@ActiveProfiles({Miljø.TEST, Miljø.WIREMOCK})
+@DirtiesContext
+class AltinnTilgangsstyringKlientTest {
+
+    private static final String ALTINN_TILGANGER_PATH = "/altinn-tilganger";
+
+    private static final String SUCCESS_BODY_TEMPLATE = """
+        {
+          "isError": false,
+          "hierarki": [],
+          "orgNrTilTilganger": {"%s": []},
+          "tilgangTilOrgNr": {}
+        }
+        """;
+
+    @Autowired
+    private AltinnTilgangsstyringKlient klient;
+
+    @Autowired
+    private IntegrasjonerMockServer integrasjonerMockServer;
+
+    @Autowired
+    private CacheManager cacheManager;
+
+    @BeforeEach
+    void setup() {
+        FodselsnummerValidator.ALLOW_SYNTHETIC_NUMBERS = true;
+        integrasjonerMockServer.getServer().resetAll();
+        Objects.requireNonNull(cacheManager.getCache(CacheConfig.ALTINN_CACHE)).clear();
+    }
+
+    @AfterEach
+    void tearDown() {
+        FodselsnummerValidator.ALLOW_SYNTHETIC_NUMBERS = false;
+    }
+
+    @Test
+    void cache_returnerer_ulikt_resultat_for_ulike_fnr() {
+        integrasjonerMockServer.getServer()
+            .stubFor(WireMock.post(urlPathEqualTo(ALTINN_TILGANGER_PATH))
+                .atPriority(0)
+                .inScenario("cache-fnr-test")
+                .whenScenarioStateIs(Scenario.STARTED)
+                .willReturn(okJson(SUCCESS_BODY_TEMPLATE.formatted("111111111")))
+                .willSetStateTo("andre-kall"));
+
+        integrasjonerMockServer.getServer()
+            .stubFor(WireMock.post(urlPathEqualTo(ALTINN_TILGANGER_PATH))
+                .atPriority(0)
+                .inScenario("cache-fnr-test")
+                .whenScenarioStateIs("andre-kall")
+                .willReturn(okJson(SUCCESS_BODY_TEMPLATE.formatted("222222222"))));
+
+        Fnr fnr1 = Fnr.generer(25);
+        Fnr fnr2 = Fnr.generer(30);
+
+        AltinnTilgangerResponse response1 = klient.kallAltinn3(fnr1);
+        AltinnTilgangerResponse response2 = klient.kallAltinn3(fnr2);
+
+        assertThat(response1.orgNrTilTilganger()).containsKey("111111111");
+        assertThat(response2.orgNrTilTilganger()).containsKey("222222222");
+        assertThat(response1).isNotEqualTo(response2);
+    }
+
+    @Test
+    void cache_kaller_ikke_altinn_igjen_for_samme_fnr() {
+        integrasjonerMockServer.getServer()
+            .stubFor(WireMock.post(urlPathEqualTo(ALTINN_TILGANGER_PATH))
+                .atPriority(0)
+                .willReturn(okJson(SUCCESS_BODY_TEMPLATE.formatted("999999999"))));
+
+        Fnr fnr = Fnr.generer(25);
+
+        klient.kallAltinn3(fnr);
+        klient.kallAltinn3(fnr);
+
+        integrasjonerMockServer.getServer().verify(1, postRequestedFor(urlPathEqualTo(ALTINN_TILGANGER_PATH)));
+    }
+
+    @Test
+    void retry_forsøker_på_nytt_ved_502() {
+        integrasjonerMockServer.getServer()
+            .stubFor(WireMock.post(urlPathEqualTo(ALTINN_TILGANGER_PATH))
+                .atPriority(0)
+                .inScenario("retry-502")
+                .whenScenarioStateIs(Scenario.STARTED)
+                .willReturn(aResponse().withStatus(502))
+                .willSetStateTo("retry-1"));
+
+        integrasjonerMockServer.getServer()
+            .stubFor(WireMock.post(urlPathEqualTo(ALTINN_TILGANGER_PATH))
+                .atPriority(0)
+                .inScenario("retry-502")
+                .whenScenarioStateIs("retry-1")
+                .willReturn(okJson(SUCCESS_BODY_TEMPLATE.formatted("999999999"))));
+
+        AltinnTilgangerResponse response = klient.kallAltinn3(Fnr.generer(25));
+
+        assertThat(response).isNotNull();
+        assertThat(response.orgNrTilTilganger()).containsKey("999999999");
+        integrasjonerMockServer.getServer().verify(2, postRequestedFor(urlPathEqualTo(ALTINN_TILGANGER_PATH)));
+    }
+
+    @Test
+    void retry_forsøker_på_nytt_ved_503() {
+        integrasjonerMockServer.getServer()
+            .stubFor(WireMock.post(urlPathEqualTo(ALTINN_TILGANGER_PATH))
+                .atPriority(0)
+                .inScenario("retry-503")
+                .whenScenarioStateIs(Scenario.STARTED)
+                .willReturn(aResponse().withStatus(503))
+                .willSetStateTo("retry-1"));
+
+        integrasjonerMockServer.getServer()
+            .stubFor(WireMock.post(urlPathEqualTo(ALTINN_TILGANGER_PATH))
+                .atPriority(0)
+                .inScenario("retry-503")
+                .whenScenarioStateIs("retry-1")
+                .willReturn(okJson(SUCCESS_BODY_TEMPLATE.formatted("999999999"))));
+
+        AltinnTilgangerResponse response = klient.kallAltinn3(Fnr.generer(25));
+
+        assertThat(response).isNotNull();
+        assertThat(response.orgNrTilTilganger()).containsKey("999999999");
+        integrasjonerMockServer.getServer().verify(2, postRequestedFor(urlPathEqualTo(ALTINN_TILGANGER_PATH)));
+    }
+
+    @Test
+    void retry_kaster_exception_etter_maks_forsøk() {
+        integrasjonerMockServer.getServer()
+            .stubFor(WireMock.post(urlPathEqualTo(ALTINN_TILGANGER_PATH))
+                .atPriority(0)
+                .willReturn(aResponse().withStatus(502)));
+
+        assertThatThrownBy(() -> klient.kallAltinn3(Fnr.generer(25))).isInstanceOf(AltinnFeilException.class);
+
+        // Spring Retry default maxAttempts = 3
+        integrasjonerMockServer.getServer().verify(3, postRequestedFor(urlPathEqualTo(ALTINN_TILGANGER_PATH)));
+    }
+}

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/featuretoggles/ByOrgnummerStrategyTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/featuretoggles/ByOrgnummerStrategyTest.java
@@ -25,7 +25,7 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 public class ByOrgnummerStrategyTest {
-
+    private Fnr fnr;
     private UnleashContext unleashContext;
 
     @Mock
@@ -35,7 +35,7 @@ public class ByOrgnummerStrategyTest {
     public void setup() {
         FodselsnummerValidator.ALLOW_SYNTHETIC_NUMBERS = true;
 
-        Fnr fnr = Fnr.generer(2001, 11, 12);
+        fnr = Fnr.generer(2001, 11, 12);
         unleashContext = UnleashContext.builder().userId(fnr.asString()).build();
     }
 
@@ -46,13 +46,13 @@ public class ByOrgnummerStrategyTest {
 
     @Test
     public void skal_være_enablet_hvis_bruker_tilhører_organisasjon() {
-        when(altinnTilgangsstyringService.hentAltinnTilganger()).thenReturn(altinnTilganger("999999999"));
+        when(altinnTilgangsstyringService.hentAltinnTilganger(fnr)).thenReturn(altinnTilganger("999999999"));
         assertThat(new ByOrgnummerStrategy(altinnTilgangsstyringService).isEnabled(Map.of(ByOrgnummerStrategy.UNLEASH_PARAMETER_ORGNUMRE, "999999999"), unleashContext)).isTrue();
     }
 
     @Test
     public void skal_være_disablet_hvis_bruker_ikke_tilhører_organisasjon() {
-        when(altinnTilgangsstyringService.hentAltinnTilganger()).thenReturn(altinnTilganger("999999998"));
+        when(altinnTilgangsstyringService.hentAltinnTilganger(fnr)).thenReturn(altinnTilganger("999999998"));
         assertThat(new ByOrgnummerStrategy(altinnTilgangsstyringService).isEnabled(Map.of(ByOrgnummerStrategy.UNLEASH_PARAMETER_ORGNUMRE, "999999999"), unleashContext)).isFalse();
     }
 
@@ -60,18 +60,18 @@ public class ByOrgnummerStrategyTest {
     public void navIdent_skal_returnere_false() {
         UnleashContext unleashContext = UnleashContext.builder().userId("J154200").build();
         assertThat(new ByOrgnummerStrategy(altinnTilgangsstyringService).isEnabled(Map.of(ByOrgnummerStrategy.UNLEASH_PARAMETER_ORGNUMRE, "999999999"), unleashContext)).isFalse();
-        verify(altinnTilgangsstyringService, never()).hentAltinnTilganger();
+        verify(altinnTilgangsstyringService, never()).hentAltinnTilganger(fnr);
     }
 
     @Test
     public void byOrgnummmer_strategy_håndterer_flere_orgnummer() {
-        when(altinnTilgangsstyringService.hentAltinnTilganger()).thenReturn(altinnTilganger("999999999"));
+        when(altinnTilgangsstyringService.hentAltinnTilganger(fnr)).thenReturn(altinnTilganger("999999999"));
         assertThat(new ByOrgnummerStrategy(altinnTilgangsstyringService).isEnabled(Map.of(ByOrgnummerStrategy.UNLEASH_PARAMETER_ORGNUMRE, "910825526,999999999"), unleashContext)).isTrue();
     }
 
     @Test
     public void skal_være_disablet_hvis_feil_ved_oppslag_i_altinn() {
-        when(altinnTilgangsstyringService.hentAltinnTilganger()).thenThrow(RuntimeException.class);
+        when(altinnTilgangsstyringService.hentAltinnTilganger(fnr)).thenThrow(RuntimeException.class);
         assertThat(new ByOrgnummerStrategy(altinnTilgangsstyringService).isEnabled(Map.of(ByOrgnummerStrategy.UNLEASH_PARAMETER_ORGNUMRE, "999999999"), unleashContext)).isFalse();
     }
 


### PR DESCRIPTION
 Vi opplever sporadiske 502-feil fra Altinn som fører til at arbeidsgivere
 mister tilgangen sin. Løser dette med to tiltak på både Altinn 2 og Altinn 3:

 1. @Retryable med eksponentiell backoff på hentTilganger (Altinn 2) og hentAltinnTilganger (Altinn 3)
 2. @Cacheable med separate cacher (altinn_2_cache og altinn_3_cache), begge med 60 min TTL og maks 1000 innslag