### PR TITLE
Deaktiver feilmeldinger fra kafkaproducer

### DIFF
--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -26,6 +26,7 @@
             <OnMismatch>DENY</OnMismatch>
         </filter>
     </appender>
+    <logger name="org.springframework.kafka.support.LoggingProducerListener" level="off" />
     <logger name="no.nav.vault.jdbc.hikaricp.VaultUtil" level="WARN"/>
     <root level="INFO">
         <appender-ref ref="consoleAppender"/>

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -26,7 +26,7 @@
             <OnMismatch>DENY</OnMismatch>
         </filter>
     </appender>
-    <logger name="org.springframework.kafka.support.LoggingProducerListener" level="off" />
+    <logger name="org.springframework.kafka.support.LoggingProducerListener" level="OFF"/>
     <logger name="no.nav.vault.jdbc.hikaricp.VaultUtil" level="WARN"/>
     <root level="INFO">
         <appender-ref ref="consoleAppender"/>

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -26,6 +26,7 @@
             <OnMismatch>DENY</OnMismatch>
         </filter>
     </appender>
+    <!-- Feil fra denne loggeren resulterer i at kafka-payloads ender opp rett i loggene. Litt guffent -->
     <logger name="org.springframework.kafka.support.LoggingProducerListener" level="OFF"/>
     <logger name="no.nav.vault.jdbc.hikaricp.VaultUtil" level="WARN"/>
     <root level="INFO">


### PR DESCRIPTION
Vi har try-catcher som fanger opp feilmeldinger fra producere, men denne loggeren spyr ut selve meldingen som feilet i tillegg, som gjør at vi kan lekke
potensielt sensitive data ut i loggene.