### PR TITLE
Tillat resending av annullerte tilsagn

### DIFF
--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/Avtale.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/Avtale.java
@@ -1160,7 +1160,7 @@ public class Avtale extends AbstractAggregateRoot<Avtale> implements AuditerbarE
         }
     }
 
-    public TilskuddPeriode lagNyGodkjentTilskuddsperiodeFraAnnullertPeriode(TilskuddPeriode annullertTilskuddPeriode) {
+    public void lagNyGodkjentTilskuddsperiodeFraAnnullertPeriode(TilskuddPeriode annullertTilskuddPeriode) {
         if (!this.tiltakstype.skalBesluttes()) {
             throw new FeilkodeException(Feilkode.KAN_IKKE_ENDRE_FEIL_TILTAKSTYPE);
         }
@@ -1182,7 +1182,6 @@ public class Avtale extends AbstractAggregateRoot<Avtale> implements AuditerbarE
         ));
         tilskuddPeriode.add(nyTilskuddsperiode);
         setGjeldendeTilskuddsperiode(TilskuddPeriode.utledGjeldendeTilskuddsperiode(this).tilskuddPeriode());
-        return nyTilskuddsperiode;
     }
 
     private Integer finnResendingsNummer(TilskuddPeriode gjeldendePeriode) {

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/Avtale.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/Avtale.java
@@ -1160,7 +1160,7 @@ public class Avtale extends AbstractAggregateRoot<Avtale> implements AuditerbarE
         }
     }
 
-    public void lagNyGodkjentTilskuddsperiodeFraAnnullertPeriode(TilskuddPeriode annullertTilskuddPeriode) {
+    public TilskuddPeriode lagNyGodkjentTilskuddsperiodeFraAnnullertPeriode(TilskuddPeriode annullertTilskuddPeriode) {
         if (!this.tiltakstype.skalBesluttes()) {
             throw new FeilkodeException(Feilkode.KAN_IKKE_ENDRE_FEIL_TILTAKSTYPE);
         }
@@ -1182,6 +1182,7 @@ public class Avtale extends AbstractAggregateRoot<Avtale> implements AuditerbarE
         ));
         tilskuddPeriode.add(nyTilskuddsperiode);
         setGjeldendeTilskuddsperiode(TilskuddPeriode.utledGjeldendeTilskuddsperiode(this).tilskuddPeriode());
+        return nyTilskuddsperiode;
     }
 
     private Integer finnResendingsNummer(TilskuddPeriode gjeldendePeriode) {

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/Avtale.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/Avtale.java
@@ -1161,13 +1161,9 @@ public class Avtale extends AbstractAggregateRoot<Avtale> implements AuditerbarE
     }
 
     public void lagNyGodkjentTilskuddsperiodeFraAnnullertPeriode(TilskuddPeriode annullertTilskuddPeriode) {
-        krevEnAvTiltakstyper(
-            Tiltakstype.MIDLERTIDIG_LONNSTILSKUDD,
-            Tiltakstype.VARIG_LONNSTILSKUDD,
-            Tiltakstype.SOMMERJOBB,
-            Tiltakstype.VTAO,
-            Tiltakstype.MENTOR
-        );
+        if (!this.tiltakstype.skalBesluttes()) {
+            throw new FeilkodeException(Feilkode.KAN_IKKE_ENDRE_FEIL_TILTAKSTYPE);
+        }
         if (annullertTilskuddPeriode.getStatus() != TilskuddPeriodeStatus.ANNULLERT) {
             throw new FeilkodeException(Feilkode.TILSKUDDSPERIODE_ER_ALLEREDE_BEHANDLET);
         }

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/Avtale.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/Avtale.java
@@ -1200,12 +1200,9 @@ public class Avtale extends AbstractAggregateRoot<Avtale> implements AuditerbarE
     }
 
     public void lagNyTilskuddsperiodeFraAnnullertPeriode(TilskuddPeriode annullertTilskuddPeriode) {
-        krevEnAvTiltakstyper(
-            Tiltakstype.VTAO,
-            Tiltakstype.MIDLERTIDIG_LONNSTILSKUDD,
-            Tiltakstype.VARIG_LONNSTILSKUDD,
-            Tiltakstype.SOMMERJOBB
-        );
+        if (!tiltakstype.skalBesluttes()) {
+            throw new FeilkodeException(Feilkode.KAN_IKKE_ENDRE_FEIL_TILTAKSTYPE);
+        }
         if (annullertTilskuddPeriode.getStatus() != TilskuddPeriodeStatus.ANNULLERT) {
             throw new FeilkodeException(Feilkode.TILSKUDDSPERIODE_ER_ALLEREDE_BEHANDLET);
         }

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/admin/AdminController.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/admin/AdminController.java
@@ -430,9 +430,22 @@ public class AdminController {
         return ResponseEntity.ok(nyAvtale.getId());
     }
 
-    @PostMapping("/opprett-ny-godkjent-tilskuddsperiode-fra-annullert/{tilskuddsperiodeId}")
+    /**
+     * Brukes for å resende tilskuddsperioder som enten har blitt annullert ved en feil, eller som har feil i data og må resendes.
+     * Noen eksempler på når dette er nødvendig:
+     * <ul>
+     *   <li>En automatisk utbetaling ble annullert fordi vi ikke fikk hentet kontonummer i tide.</li>
+     *   <li>Oebs ber oss resende i enkelte tilfeller hvor juridisk enhet har endret seg (overtakelser eller organisatoriske endringer)</li>
+     *   <li>Automatisk utbetaling har feil kid-nummer (eller burde ikke hatt kid-nummer). Resend etter dette har blitt rettet i avtalen</li>
+     * </ul>
+     * Resending anses som en teknisk detalj, og <b>vi tar derfor med beslutters godkjenning fra den gamle tilskuddsperioden
+     * til den nye</b>.
+     *
+     * @param dryRun Vi defaulter til å ikke utføre endringer for ekstra sikkerhet
+     */
+    @PostMapping("/resend-tilskuddsperiode/{tilskuddsperiodeId}")
     @Transactional
-    public ResponseEntity<?> opprettNyGodkjentTilskuddsperiodeFraAnnullert(
+    public ResponseEntity<?> resendTilskuddsperiode(
         @PathVariable("tilskuddsperiodeId") UUID id,
         @RequestParam(required = false, defaultValue = "true") boolean dryRun
     ) {

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/admin/AdminController.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/admin/AdminController.java
@@ -465,6 +465,65 @@ public class AdminController {
         return ResponseEntity.ok(nyAvtale.getId());
     }
 
+    @PostMapping("/opprett-ny-godkjent-tilskuddsperiode-fra-annullert/{tilskuddsperiodeId}")
+    @Transactional
+    public ResponseEntity<?> opprettNyGodkjentTilskuddsperiodeFraAnnullert(
+        @PathVariable("tilskuddsperiodeId") UUID id,
+        @RequestParam(required = false, defaultValue = "true") boolean dryRun
+    ) {
+        log.info("Oppretter ny tilskuddsperiode fra annullert periode {}", id);
+        TilskuddPeriode tilskuddPeriode = tilskuddPeriodeRepository.findById(id)
+            .orElseThrow(RessursFinnesIkkeException::new);
+
+        // Sjekk refusjonstatus
+        if (tilskuddPeriode.getRefusjonStatus() != null && List.of(
+            RefusjonStatus.SENDT_KRAV,
+            RefusjonStatus.UTBETALT,
+            RefusjonStatus.UTBETALING_FEILET
+        ).contains(tilskuddPeriode.getRefusjonStatus())) {
+            var feilmelding = "Kan ikke opprette ny tilskuddsperiode fra en periode som er sendt til Oebs eller utbetalt.";
+            log.error(feilmelding);
+            return ResponseEntity.badRequest().body(feilmelding);
+        }
+
+        Avtale avtale = tilskuddPeriode.getAvtale();
+        Integer løpenummer = tilskuddPeriode.getLøpenummer();
+
+        // Annuller perioden hvis den ikke allerede er annullert
+        if (tilskuddPeriode.getStatus() != TilskuddPeriodeStatus.ANNULLERT) {
+            if (!dryRun) {
+                avtale.annullerTilskuddsperiode(tilskuddPeriode);
+            }
+        }
+
+        // Finn alle tilskuddsperioder med samme løpenummer
+        List<TilskuddPeriode> perioderMedSammeLøpenummer = avtale.getTilskuddPeriode().stream()
+            .filter(tp -> tp.getLøpenummer().equals(løpenummer))
+            .toList();
+
+        // Sjekk om det finnes en annen aktiv og ikke-annullert tilskuddsperiode med samme løpenummer
+        boolean finnesAnnenAktiv = perioderMedSammeLøpenummer.stream()
+            .filter(tp -> !tp.getId().equals(id)) // Ekskluder den nåværende perioden
+            .anyMatch(tp -> tp.isAktiv() && tp.getStatus() != TilskuddPeriodeStatus.ANNULLERT);
+
+        if (finnesAnnenAktiv) {
+            var feilmelding = "Kan ikke opprette ny tilskuddsperiode. Det finnes allerede en annen aktiv tilskuddsperiode med løpenummer " + løpenummer;
+            log.error(feilmelding);
+            return ResponseEntity.badRequest().body(feilmelding);
+        }
+
+        // Opprett ny tilskuddsperiode
+        if (!dryRun) {
+            avtale.lagNyGodkjentTilskuddsperiodeFraAnnullertPeriode(tilskuddPeriode);
+            avtaleRepository.save(avtale);
+        }
+
+        return ResponseEntity.ok(Map.of(
+            "message", dryRun ? "Dry run: ingen endringer ble utført" : "Ny tilskuddsperiode har blitt opprettet",
+            "dryRun", dryRun
+        ));
+    }
+
     /**
      * En feil har ført til at mange VTAO-avtaler mangler kreverOppfolgingFom, som igjen fører til at veileder ikke
      * får ny oppfølgingsperiode. Dette endepunktet fikser opp i feilen ved å sette kreverOppfolgingFom til tidligst

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/admin/AdminController.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/admin/AdminController.java
@@ -112,41 +112,6 @@ public class AdminController {
         avtaleRepository.save(avtale);
     }
 
-    @PostMapping("/annuller-og-resend-tilskuddsperiode-som-godkjent/{tilskuddsperiodeId}")
-    @Transactional
-    public ResponseEntity<String> annullerOgResendTilskuddsperiodeSomGodkjent(
-        @RequestParam(value = "tillat-allerede-annullert", required = false, defaultValue = "false") boolean tillatAlleredeAnnullert,
-        @PathVariable("tilskuddsperiodeId") UUID id
-    ) {
-        log.info("Annullerer tilskuddsperiode {} og resender som godkjent", id);
-        TilskuddPeriode tilskuddPeriode = tilskuddPeriodeRepository.findById(id)
-            .orElseThrow(RessursFinnesIkkeException::new);
-        if (tilskuddPeriode.getRefusjonStatus() != null && List.of(
-            RefusjonStatus.UTBETALT,
-            RefusjonStatus.SENDT_KRAV,
-            RefusjonStatus.UTBETALING_FEILET
-        ).contains(tilskuddPeriode.getRefusjonStatus())) {
-            var feilmelding = "Kan ikke annullere en periode som er sendt til Oebs for utbetaling.";
-            log.error(feilmelding);
-            return ResponseEntity.badRequest().body(feilmelding);
-        }
-        var erAnnullertTilskuddsperiodeSomSkalSlippeIgjennom = tilskuddPeriode.getStatus() == TilskuddPeriodeStatus.ANNULLERT && tillatAlleredeAnnullert;
-        if (tilskuddPeriode.getStatus() != TilskuddPeriodeStatus.GODKJENT && !erAnnullertTilskuddsperiodeSomSkalSlippeIgjennom) {
-            var feilmelding = "Kan kun annullere og resende en periode som er godkjent. Denne perioden har status: %s".formatted(
-                tilskuddPeriode.getStatus()
-            );
-            log.error(feilmelding);
-            return ResponseEntity.badRequest().body(feilmelding);
-        }
-        Avtale avtale = tilskuddPeriode.getAvtale();
-        if (tilskuddPeriode.getStatus() != TilskuddPeriodeStatus.ANNULLERT) {
-            avtale.annullerTilskuddsperiode(tilskuddPeriode);
-        }
-        var nyTilskuddsperiode = avtale.lagNyGodkjentTilskuddsperiodeFraAnnullertPeriode(tilskuddPeriode);
-        avtaleRepository.save(avtale);
-        return ResponseEntity.ok("Tilskuddsperiode har blitt resendt! Ny id: %s".formatted(nyTilskuddsperiode.getId()));
-    }
-
     @PostMapping("/annuller-og-generer-tilskuddsperiode/{tilskuddsperiodeId}")
     @Transactional
     public void annullerOgGenererTilskuddsperiode(@PathVariable("tilskuddsperiodeId") UUID id) {

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/admin/AdminController.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/admin/AdminController.java
@@ -451,6 +451,13 @@ public class AdminController {
             return ResponseEntity.badRequest().body(feilmelding);
         }
 
+        if (!List.of(TilskuddPeriodeStatus.GODKJENT, TilskuddPeriodeStatus.ANNULLERT).contains(tilskuddPeriode.getStatus())) {
+            var feilmelding = "Kan kun opprette ny tilskuddsperiode fra perioder med status GODKJENT eller ANNULLERT. Denne perioden har status: %s"
+                .formatted(tilskuddPeriode.getStatus());
+            log.error(feilmelding);
+            return ResponseEntity.badRequest().body(feilmelding);
+        }
+
         Avtale avtale = tilskuddPeriode.getAvtale();
         Integer løpenummer = tilskuddPeriode.getLøpenummer();
 

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/admin/AdminController.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/admin/AdminController.java
@@ -112,25 +112,39 @@ public class AdminController {
         avtaleRepository.save(avtale);
     }
 
-    @PostMapping("/annuller-og-resend-tilskuddsperiode/{tilskuddsperiodeId}")
+    @PostMapping("/annuller-og-resend-tilskuddsperiode-som-godkjent/{tilskuddsperiodeId}")
     @Transactional
-    public void annullerOgResendTilskuddsperiode(@PathVariable("tilskuddsperiodeId") UUID id) {
+    public ResponseEntity<String> annullerOgResendTilskuddsperiodeSomGodkjent(
+        @RequestParam(value = "tillat-allerede-annullert", required = false, defaultValue = "false") boolean tillatAlleredeAnnullert,
+        @PathVariable("tilskuddsperiodeId") UUID id
+    ) {
         log.info("Annullerer tilskuddsperiode {} og resender som godkjent", id);
-        TilskuddPeriode tilskuddPeriode = tilskuddPeriodeRepository.findById(id).orElseThrow(RessursFinnesIkkeException::new);
+        TilskuddPeriode tilskuddPeriode = tilskuddPeriodeRepository.findById(id)
+            .orElseThrow(RessursFinnesIkkeException::new);
         if (tilskuddPeriode.getRefusjonStatus() != null && List.of(
             RefusjonStatus.UTBETALT,
             RefusjonStatus.SENDT_KRAV,
-            RefusjonStatus.ANNULLERT
+            RefusjonStatus.UTBETALING_FEILET
         ).contains(tilskuddPeriode.getRefusjonStatus())) {
-            throw new IllegalStateException("Kan ikke annullere en periode som er sendt til utbetaling eller allerede er annullert.");
+            var feilmelding = "Kan ikke annullere en periode som er sendt til Oebs for utbetaling.";
+            log.error(feilmelding);
+            return ResponseEntity.badRequest().body(feilmelding);
         }
-        if (tilskuddPeriode.getStatus() != TilskuddPeriodeStatus.GODKJENT) {
-            throw new IllegalStateException("Kan kun annullere og resende en periode som er godkjent. Denne perioden har status: " + tilskuddPeriode.getStatus());
+        var erAnnullertTilskuddsperiodeSomSkalSlippeIgjennom = tilskuddPeriode.getStatus() == TilskuddPeriodeStatus.ANNULLERT && tillatAlleredeAnnullert;
+        if (tilskuddPeriode.getStatus() != TilskuddPeriodeStatus.GODKJENT && !erAnnullertTilskuddsperiodeSomSkalSlippeIgjennom) {
+            var feilmelding = "Kan kun annullere og resende en periode som er godkjent. Denne perioden har status: %s".formatted(
+                tilskuddPeriode.getStatus()
+            );
+            log.error(feilmelding);
+            return ResponseEntity.badRequest().body(feilmelding);
         }
         Avtale avtale = tilskuddPeriode.getAvtale();
-        avtale.annullerTilskuddsperiode(tilskuddPeriode);
-        avtale.lagNyGodkjentTilskuddsperiodeFraAnnullertPeriode(tilskuddPeriode);
+        if (tilskuddPeriode.getStatus() != TilskuddPeriodeStatus.ANNULLERT) {
+            avtale.annullerTilskuddsperiode(tilskuddPeriode);
+        }
+        var nyTilskuddsperiode = avtale.lagNyGodkjentTilskuddsperiodeFraAnnullertPeriode(tilskuddPeriode);
         avtaleRepository.save(avtale);
+        return ResponseEntity.ok("Tilskuddsperiode har blitt resendt! Ny id: %s".formatted(nyTilskuddsperiode.getId()));
     }
 
     @PostMapping("/annuller-og-generer-tilskuddsperiode/{tilskuddsperiodeId}")

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/admin/AdminController.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/admin/AdminController.java
@@ -464,6 +464,7 @@ public class AdminController {
             return ResponseEntity.badRequest().body(feilmelding);
         }
 
+        // Kan kun resende tilskuddsperioder som har vært godkjent
         if (!List.of(TilskuddPeriodeStatus.GODKJENT, TilskuddPeriodeStatus.ANNULLERT).contains(tilskuddPeriode.getStatus())) {
             var feilmelding = "Kan kun opprette ny tilskuddsperiode fra perioder med status GODKJENT eller ANNULLERT. Denne perioden har status: %s"
                 .formatted(tilskuddPeriode.getStatus());

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/admin/AdminController.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/admin/AdminController.java
@@ -482,15 +482,15 @@ public class AdminController {
             }
         }
 
-        // Finn alle tilskuddsperioder med samme løpenummer
-        List<TilskuddPeriode> perioderMedSammeLøpenummer = avtale.getTilskuddPeriode().stream()
-            .filter(tp -> tp.getLøpenummer().equals(løpenummer))
-            .toList();
-
         // Sjekk om det finnes en annen aktiv og ikke-annullert tilskuddsperiode med samme løpenummer
-        boolean finnesAnnenAktiv = perioderMedSammeLøpenummer.stream()
-            .filter(tp -> !tp.getId().equals(id)) // Ekskluder den nåværende perioden
-            .anyMatch(tp -> tp.isAktiv() && tp.getStatus() != TilskuddPeriodeStatus.ANNULLERT);
+        boolean finnesAnnenAktiv = avtale.getTilskuddPeriode().stream()
+            .anyMatch(tp -> {
+                var sammeLøpenummer = tp.getLøpenummer().equals(løpenummer);
+                var ikkeSammeTilskuddsperiode = !tp.getId().equals(id);
+                var erAktivOgIkkeAnnullert = tp.isAktiv() && tp.getStatus() != TilskuddPeriodeStatus.ANNULLERT;
+
+                return sammeLøpenummer && ikkeSammeTilskuddsperiode && erAktivOgIkkeAnnullert;
+            });
 
         if (finnesAnnenAktiv) {
             var feilmelding = "Kan ikke opprette ny tilskuddsperiode. Det finnes allerede en annen aktiv tilskuddsperiode med løpenummer " + løpenummer;

--- a/src/test/resources/admin-kall.http
+++ b/src/test/resources/admin-kall.http
@@ -71,7 +71,7 @@ Accept: application/json
 Authorization: Bearer <TOKEN>
 
 ### Resend tilskuddsperiode som godkjent
-POST https://tiltaksgjennomforing-api.intern.nav.no/tiltaksgjennomforing-api/utvikler-admin/opprett-ny-godkjent-tilskuddsperiode-fra-annullert/<TILSKUDDSPERIODE_ID>
+POST https://tiltaksgjennomforing-api.intern.nav.no/tiltaksgjennomforing-api/utvikler-admin/opprett-ny-godkjent-tilskuddsperiode-fra-annullert/<TILSKUDDSPERIODE_ID>?dryRun=true
 Content-Type: application/json
 Authorization: Bearer <TOKEN>
 

--- a/src/test/resources/admin-kall.http
+++ b/src/test/resources/admin-kall.http
@@ -71,7 +71,7 @@ Accept: application/json
 Authorization: Bearer <TOKEN>
 
 ### Resend tilskuddsperiode som godkjent
-POST https://tiltaksgjennomforing-api.intern.nav.no/tiltaksgjennomforing-api/utvikler-admin/annuller-og-resend-tilskuddsperiode-som-godkjent/<TILSKUDDSPERIODE_ID>
+POST https://tiltaksgjennomforing-api.intern.nav.no/tiltaksgjennomforing-api/utvikler-admin/opprett-ny-godkjent-tilskuddsperiode-fra-annullert/<TILSKUDDSPERIODE_ID>
 Content-Type: application/json
 Authorization: Bearer <TOKEN>
 

--- a/src/test/resources/admin-kall.http
+++ b/src/test/resources/admin-kall.http
@@ -70,8 +70,10 @@ Content-Type: application/json
 Accept: application/json
 Authorization: Bearer <TOKEN>
 
-### Resend tilskuddsperiode som godkjent
-POST https://tiltaksgjennomforing-api.intern.nav.no/tiltaksgjennomforing-api/utvikler-admin/opprett-ny-godkjent-tilskuddsperiode-fra-annullert/<TILSKUDDSPERIODE_ID>?dryRun=true
+### Resend tilskuddsperiode
+# Brukes når en tilskuddsperiode har feilet av ulike årsaker, og vi skal opprette ny tilskuddsperiode som vi også
+# godkjenner på beslutters vegne
+POST https://tiltaksgjennomforing-api.intern.nav.no/tiltaksgjennomforing-api/utvikler-admin/resend-tilskuddsperiode/<TILSKUDDSPERIODE_ID>?dryRun=true
 Content-Type: application/json
 Authorization: Bearer <TOKEN>
 

--- a/src/test/resources/admin-kall.http
+++ b/src/test/resources/admin-kall.http
@@ -70,6 +70,11 @@ Content-Type: application/json
 Accept: application/json
 Authorization: Bearer <TOKEN>
 
+### Resend tilskuddsperiode som godkjent
+POST https://tiltaksgjennomforing-api.intern.nav.no/tiltaksgjennomforing-api/utvikler-admin/annuller-og-resend-tilskuddsperiode-som-godkjent/<TILSKUDDSPERIODE_ID>
+Content-Type: application/json
+Authorization: Bearer <TOKEN>
+
 ### ADMIN HJEM!
 GET http://localhost:8080/tiltaksgjennomforing-api/utvikler-admin
 Authorization: Bearer <TOKEN>


### PR DESCRIPTION
Fjern gammelt endepunkt for resending av tilskudds-
perioder og introduser et nytt som forhåpentligvis er
mer forståelig. Hovedårsaken er at det forrige ende-
punktet ikke tillot resending av allerede annullerte
tilsagn, som vi nå trenger for å håndtere en spesifikk
feilsituasjon hvor automatiske utbetalinger har feilet
så lenge at de har blitt annullert.

For å unngå at flere kall mot endepunktet fører til en
haug av resendingeri har vi lagt på et krav om at det
kun er lov å ha en enkelt aktiv tilskuddsperiode per 
løpenummer.

En ekstra endring: To metoder i Avtale for å generere
nye tilskuddsperioder håndterte ikke alle tiltakstyper
som har tilskuddsperioder, fordi vi manuelt definerte
et nøyaktig sett av tiltak. I stedet kan vi bruke en av
metodene på Tiltakstype som forteller oss om tiltaket
"skal besluttes" (som kun gjelder tiltak med
tilskuddsperioder)