### PR TITLE
Resending feiler pga allerede annullert

### DIFF
--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/Avtale.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/Avtale.java
@@ -1160,20 +1160,17 @@ public class Avtale extends AbstractAggregateRoot<Avtale> implements AuditerbarE
         }
     }
 
-    public void lagNyGodkjentTilskuddsperiodeFraAnnullertPeriode(TilskuddPeriode annullertTilskuddPeriode) {
+    public void lagNyGodkjentTilskuddsperiodeFra(TilskuddPeriode gammelTilskuddPeriode) {
         if (!this.tiltakstype.skalBesluttes()) {
             throw new FeilkodeException(Feilkode.KAN_IKKE_ENDRE_FEIL_TILTAKSTYPE);
         }
-        if (annullertTilskuddPeriode.getStatus() != TilskuddPeriodeStatus.ANNULLERT) {
-            throw new FeilkodeException(Feilkode.TILSKUDDSPERIODE_ER_ALLEREDE_BEHANDLET);
-        }
-        TilskuddPeriode nyTilskuddsperiode = annullertTilskuddPeriode.deaktiverOgLagNyUbehandlet();
-        annullertTilskuddPeriode.setAktiv(true);
+        TilskuddPeriode nyTilskuddsperiode = gammelTilskuddPeriode.deaktiverOgLagNyUbehandlet();
+        gammelTilskuddPeriode.setAktiv(true);
         nyTilskuddsperiode.setStatus(TilskuddPeriodeStatus.GODKJENT);
-        nyTilskuddsperiode.setGodkjentAvNavIdent(annullertTilskuddPeriode.getGodkjentAvNavIdent());
-        nyTilskuddsperiode.setGodkjentTidspunkt(annullertTilskuddPeriode.getGodkjentTidspunkt());
-        nyTilskuddsperiode.setEnhet(annullertTilskuddPeriode.getEnhet());
-        Integer resendingsnummer = finnResendingsNummer(annullertTilskuddPeriode);
+        nyTilskuddsperiode.setGodkjentAvNavIdent(gammelTilskuddPeriode.getGodkjentAvNavIdent());
+        nyTilskuddsperiode.setGodkjentTidspunkt(gammelTilskuddPeriode.getGodkjentTidspunkt());
+        nyTilskuddsperiode.setEnhet(gammelTilskuddPeriode.getEnhet());
+        Integer resendingsnummer = finnResendingsNummer(gammelTilskuddPeriode);
         registerEvent(new TilskuddsperiodeGodkjent(
             this,
             nyTilskuddsperiode,

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/admin/AdminController.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/admin/AdminController.java
@@ -500,7 +500,7 @@ public class AdminController {
 
         // Opprett ny tilskuddsperiode
         if (!dryRun) {
-            avtale.lagNyGodkjentTilskuddsperiodeFraAnnullertPeriode(tilskuddPeriode);
+            avtale.lagNyGodkjentTilskuddsperiodeFra(tilskuddPeriode);
             avtaleRepository.save(avtale);
         }
 


### PR DESCRIPTION
En hjelpemetode som genererer nye tilskuddsperioder fra en gammel tilskuddsperiode hadde et krav om at gammel tilskuddsperiode måtte være annullert.

Denne sjekken kan vi fjerne. Vi kunne også vurdert å' flytte en del av logikken i admin-endepunktet ned, feks den delen som feiler dersom det fins en aktiv tilskudds- periode med samme løpenummer.