### PR TITLE
fix(datavarehus): logg feil i async DVH-patchjobb

### DIFF
--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/datavarehus/AsyncDvhAvtalePatchService.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/datavarehus/AsyncDvhAvtalePatchService.java
@@ -11,7 +11,6 @@ import org.springframework.data.domain.Sort;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 
-import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
 @Service
@@ -31,19 +30,29 @@ public class AsyncDvhAvtalePatchService {
     public CompletableFuture<Void> lagDvhPatchMeldingForAlleAvtaler(Tiltakstype tiltakstype) {
         log.info("Jobb for å patche meldinger til DVH startet...");
 
-        Slice<Avtale> slice = null;
+        Slice<Avtale> slice;
         int antallAvtalerSendt = 0;
+        Pageable nesteSide = DEFAULT_PAGE;
 
-        do {
-            DvhAvtalePatcherRespons respons = dvhAvtalePatcher.patch(
+        try {
+            do {
+                DvhAvtalePatcherRespons respons = dvhAvtalePatcher.patch(tiltakstype, nesteSide);
+                slice = respons.slice();
+                antallAvtalerSendt += respons.antallAvtalerSendt();
+                nesteSide = slice.nextPageable();
+            } while (slice.hasNext());
+
+            log.info("Jobb for å patche alle avtaler til DVH fullført! {} avtaler ble sendt.", antallAvtalerSendt);
+            return CompletableFuture.completedFuture(null);
+        } catch (Exception e) {
+            log.error(
+                "Jobb for å patche avtaler til DVH feilet for tiltakstype {} på side {} etter {} sendte avtaler",
                 tiltakstype,
-                Optional.ofNullable(slice).map(Slice::nextPageable).orElse(DEFAULT_PAGE)
+                nesteSide.getPageNumber(),
+                antallAvtalerSendt,
+                e
             );
-            slice = respons.slice();
-            antallAvtalerSendt += respons.antallAvtalerSendt();
-        } while (slice.hasNext());
-
-        log.info("Jobb for å patche alle avtaler til DVH fullført! {} avtaler ble sendt.", antallAvtalerSendt);
-        return CompletableFuture.completedFuture(null);
+            return CompletableFuture.failedFuture(e);
+        }
     }
 }

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/datavarehus/AsyncDvhAvtalePatchServiceTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/datavarehus/AsyncDvhAvtalePatchServiceTest.java
@@ -1,0 +1,58 @@
+package no.nav.tag.tiltaksgjennomforing.datavarehus;
+
+import no.nav.tag.tiltaksgjennomforing.avtale.Avtale;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.SliceImpl;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AsyncDvhAvtalePatchServiceTest {
+
+    @Mock
+    private DvhAvtalePatchService dvhAvtalePatcher;
+
+    @InjectMocks
+    private AsyncDvhAvtalePatchService asyncDvhAvtalePatchService;
+
+    @Test
+    void lagDvhPatchMeldingForAlleAvtaler_fullforer_exceptionally_nar_patch_feiler() {
+        RuntimeException feil = new RuntimeException("boom");
+        when(dvhAvtalePatcher.patch(eq(null), any())).thenThrow(feil);
+
+        assertThatThrownBy(() -> asyncDvhAvtalePatchService.lagDvhPatchMeldingForAlleAvtaler().join())
+            .hasCause(feil);
+    }
+
+    @Test
+    void lagDvhPatchMeldingForAlleAvtaler_patcher_alle_sider() {
+        var førstePageable = PageRequest.of(0, 100).withSort(Sort.Direction.ASC, "id");
+        var andrePageable = PageRequest.of(1, 100).withSort(Sort.Direction.ASC, "id");
+        var førsteSide = new SliceImpl<Avtale>(List.of(), førstePageable, true);
+        var andreSide = new SliceImpl<Avtale>(List.of(), andrePageable, false);
+
+        when(dvhAvtalePatcher.patch(eq(null), eq(førstePageable)))
+            .thenReturn(new DvhAvtalePatcherRespons(førsteSide, 100));
+        when(dvhAvtalePatcher.patch(eq(null), eq(andrePageable)))
+            .thenReturn(new DvhAvtalePatcherRespons(andreSide, 50));
+
+        asyncDvhAvtalePatchService.lagDvhPatchMeldingForAlleAvtaler().join();
+
+        verify(dvhAvtalePatcher).patch(eq(null), eq(førstePageable));
+        verify(dvhAvtalePatcher).patch(eq(null), eq(andrePageable));
+        verify(dvhAvtalePatcher, times(2)).patch(eq(null), any());
+    }
+}


### PR DESCRIPTION
Gjør at patchjobben logger hvor den feiler i stedet for å avslutte stille i @Async-flyten.

Returnerer failed future ved runtime-feil og legger til test som verifiserer både feilhåndtering og paging.