### PR TITLE
fix. gjøre det mulig å sende null på tidspunkt

### DIFF
--- a/src/main/resources/avro/tiltaksgjennomforing.avsc
+++ b/src/main/resources/avro/tiltaksgjennomforing.avsc
@@ -295,24 +295,36 @@
     },
     {
       "name": "godkjentAvDeltaker",
-      "type": {
-        "type": "long",
-        "logicalType": "timestamp-millis"
-      }
+      "type": [
+        "null",
+        {
+          "type": "long",
+          "logicalType": "timestamp-millis"
+        }
+      ],
+      "default": null
     },
     {
       "name": "godkjentAvArbeidsgiver",
-      "type": {
-        "type": "long",
-        "logicalType": "timestamp-millis"
-      }
+      "type": [
+        "null",
+        {
+          "type": "long",
+          "logicalType": "timestamp-millis"
+        }
+      ],
+      "default": null
     },
     {
       "name": "godkjentAvVeileder",
-      "type": {
-        "type": "long",
-        "logicalType": "timestamp-millis"
-      }
+      "type": [
+        "null",
+        {
+          "type": "long",
+          "logicalType": "timestamp-millis"
+        }
+      ],
+      "default": null
     },
     {
       "name": "godkjentAvBeslutter",
@@ -322,14 +334,19 @@
           "type": "long",
           "logicalType": "timestamp-millis"
         }
-      ]
+      ],
+      "default": null
     },
     {
       "name": "avtaleInngaatt",
-      "type": {
-        "type": "long",
-        "logicalType": "timestamp-millis"
-      }
+      "type": [
+        "null",
+        {
+          "type": "long",
+          "logicalType": "timestamp-millis"
+        }
+      ],
+      "default": null
     },
     {
       "name": "enhetOppfolging",

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/datavarehus/AvroTiltakHendelseFabrikkTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/datavarehus/AvroTiltakHendelseFabrikkTest.java
@@ -69,6 +69,25 @@ class AvroTiltakHendelseFabrikkTest {
                 .isEqualTo(AvroTiltakHendelseFabrikk.beregnNokkel(hendelse2));
     }
 
+    @Test
+    void konstruer_handterer_nullable_godkjenningstidspunkt_og_avtaleinngaatt() {
+        Avtale avtale = TestData.enAvtaleMedAltUtfyltGodkjentAvVeileder();
+        avtale.getGjeldendeInnhold().setGodkjentAvArbeidsgiver(null);
+        avtale.getGjeldendeInnhold().setGodkjentAvBeslutter(null);
+        avtale.getGjeldendeInnhold().setGodkjentAvDeltaker(null);
+        avtale.getGjeldendeInnhold().setGodkjentAvVeileder(null);
+        avtale.getGjeldendeInnhold().setAvtaleInngått(null);
+
+        AvroTiltakHendelse hendelse = AvroTiltakHendelseFabrikk.konstruer(avtale, DvhHendelseType.PATCHING, "system");
+
+        assertThat(hendelse.getGodkjentAvArbeidsgiver()).isNull();
+        assertThat(hendelse.getGodkjentAvBeslutter()).isNull();
+        assertThat(hendelse.getGodkjentAvDeltaker()).isNull();
+        assertThat(hendelse.getGodkjentAvVeileder()).isNull();
+        assertThat(hendelse.getAvtaleInngaatt()).isNull();
+        assertThat(hendelse.getMeldingId()).isNotBlank();
+    }
+
     private static AvroTiltakHendelse enHendelse(String hendelseType) {
         AvroTiltakHendelse hendelse = new AvroTiltakHendelse();
         hendelse.setMeldingId(UUID.randomUUID().toString());


### PR DESCRIPTION
Problemet har oppstått nå som vi har åpnet for å sende meldinger til dvh dersom avtalene har vært innom Arena og nå blitt annullert eller avsluttet