### PR TITLE
fix. sett enhet på nye ubehandlede tilskuddsperioder etter deaktivering

### DIFF
--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/Avtale.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/Avtale.java
@@ -993,24 +993,29 @@ public class Avtale extends AbstractAggregateRoot<Avtale> implements AuditerbarE
         this.gjeldendeTilskuddsperiode = tilskuddPeriode;
     }
 
-    public void oppdatereKostnadsstedForTilskuddsperioder(String enhet, String enhetsnavn) {
-        if (enhet.equals(gjeldendeInnhold.getEnhetKostnadssted())) {
-            return;
-        }
-
+    void oppdatereKostnadsstedForTilskuddsperioder(String enhet, String enhetsnavn) {
         sjekkAtIkkeAvtaleErAnnullert();
 
-        gjeldendeInnhold.setEnhetKostnadssted(enhet);
-        gjeldendeInnhold.setEnhetsnavnKostnadssted(enhetsnavn);
+        boolean avtaleManglerKostnadssted = !enhet.equals(gjeldendeInnhold.getEnhetKostnadssted());
+        if (avtaleManglerKostnadssted) {
+            gjeldendeInnhold.setEnhetKostnadssted(enhet);
+            gjeldendeInnhold.setEnhetsnavnKostnadssted(enhetsnavn);
+        }
 
-        tilskuddPeriode.stream()
-            .filter(periode -> TilskuddPeriodeStatus.UBEHANDLET.equals(periode.getStatus()))
-            .forEach(periode -> {
-                periode.setEnhet(enhet);
-                periode.setEnhetsnavn(enhetsnavn);
-            });
+        List<TilskuddPeriode> tilskuddsperioderUtenEnhet = tilskuddPeriode.stream()
+            .filter(ts -> TilskuddPeriodeStatus.UBEHANDLET.equals(ts.getStatus()))
+            .filter(ts -> !enhet.equals(ts.getEnhet()))
+            .toList();
 
-        utforEndring();
+        tilskuddsperioderUtenEnhet.forEach(ts -> {
+            ts.setEnhet(enhet);
+            ts.setEnhetsnavn(enhetsnavn);
+        });
+
+        boolean tilskuddsperioderManglerEnhet = !tilskuddsperioderUtenEnhet.isEmpty();
+        if (avtaleManglerKostnadssted || tilskuddsperioderManglerEnhet) {
+            utforEndring();
+        }
     }
 
     private void annullerTilskuddsperioder() {


### PR DESCRIPTION
Dersom en tilskuddsperiode ble deaktivert og en ny ubehandlet ble opprettet via deaktiverOgLagNyUbehandlet, ville enhet på den nye perioden være null. Tidligere returnerte metoden tidlig dersom kostnadssted allerede var satt på avtalen, slik at nye tilskuddsperioder uten enhet ikke ble oppdatert.

Fikser dette ved å sjekke enhet på hver enkelt tilskuddsperiode uavhengig av om avtalen allerede har riktig kostnadssted. utforEndring() kalles nå kun dersom det faktisk ble gjort endringer.