### PR TITLE
fix. øk timeout og legg til retry for poao-tilgang-kall

### DIFF
--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/abac/TilgangskontrollService.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/abac/TilgangskontrollService.java
@@ -2,7 +2,7 @@ package no.nav.tag.tiltaksgjennomforing.autorisasjon.abac;
 
 import lombok.extern.slf4j.Slf4j;
 import no.nav.tag.tiltaksgjennomforing.autorisasjon.Avslagskode;
-import no.nav.tag.tiltaksgjennomforing.autorisasjon.PoaoTilgangService;
+import no.nav.tag.tiltaksgjennomforing.autorisasjon.poaotilgang.PoaoTilgangService;
 import no.nav.tag.tiltaksgjennomforing.autorisasjon.Tilgang;
 import no.nav.tag.tiltaksgjennomforing.autorisasjon.Tilgangsattributter;
 import no.nav.tag.tiltaksgjennomforing.avtale.Avtale;

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/poaotilgang/PoaoTilgangHttpRetryKlient.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/poaotilgang/PoaoTilgangHttpRetryKlient.java
@@ -13,31 +13,43 @@ import java.util.concurrent.TimeUnit;
 public class PoaoTilgangHttpRetryKlient {
     private static final int HTTP_TIMEOUT_SECONDS = 15;
     private static final int MAX_RETRIES = 2;
+    private static final long RETRY_DELAY_MS = 500;
 
     private PoaoTilgangHttpRetryKlient() {}
 
     public static OkHttpClient hentKlient() {
         return RestClient.baseClientBuilder()
-                .connectTimeout(HTTP_TIMEOUT_SECONDS, TimeUnit.SECONDS)
-                .readTimeout(HTTP_TIMEOUT_SECONDS, TimeUnit.SECONDS)
-                .writeTimeout(HTTP_TIMEOUT_SECONDS, TimeUnit.SECONDS)
-                .addInterceptor(new RetryInterceptor())
-                .build();
+            .connectTimeout(HTTP_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+            .readTimeout(HTTP_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+            .writeTimeout(HTTP_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+            .addInterceptor(PoaoTilgangHttpRetryKlient::retryIntercept)
+            .build();
     }
 
-    private static class RetryInterceptor implements Interceptor {
-        @Override
-        public Response intercept(Chain chain) throws IOException {
-            IOException lastException = null;
-            for (int attempt = 0; attempt <= MAX_RETRIES; attempt++) {
-                try {
-                    return chain.proceed(chain.request());
-                } catch (IOException e) {
-                    lastException = e;
-                    log.warn("poao-tilgang kall feilet (forsøk {}/{}): {}", attempt + 1, MAX_RETRIES + 1, e.getMessage());
+    private static Response retryIntercept(Interceptor.Chain chain) throws IOException {
+        IOException lastException = null;
+        for (int attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+            try {
+                return chain.proceed(chain.request());
+            } catch (IOException e) {
+                lastException = e;
+                log.warn(
+                    "poao-tilgang kall feilet (forsøk {}/{}): {} - {}",
+                    attempt + 1,
+                    MAX_RETRIES + 1,
+                    e.getClass().getSimpleName(),
+                    e.getMessage()
+                );
+                if (attempt < MAX_RETRIES) {
+                    try {
+                        Thread.sleep(RETRY_DELAY_MS);
+                    } catch (InterruptedException ie) {
+                        Thread.currentThread().interrupt();
+                        throw new IOException("Retry avbrutt", ie);
+                    }
                 }
             }
-            throw lastException;
         }
+        throw lastException;
     }
 }

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/poaotilgang/PoaoTilgangHttpRetryKlient.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/poaotilgang/PoaoTilgangHttpRetryKlient.java
@@ -1,0 +1,43 @@
+package no.nav.tag.tiltaksgjennomforing.autorisasjon.poaotilgang;
+
+import lombok.extern.slf4j.Slf4j;
+import no.nav.common.rest.client.RestClient;
+import okhttp3.Interceptor;
+import okhttp3.OkHttpClient;
+import okhttp3.Response;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+public class PoaoTilgangHttpRetryKlient {
+    private static final int HTTP_TIMEOUT_SECONDS = 15;
+    private static final int MAX_RETRIES = 2;
+
+    private PoaoTilgangHttpRetryKlient() {}
+
+    public static OkHttpClient hentKlient() {
+        return RestClient.baseClientBuilder()
+                .connectTimeout(HTTP_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+                .readTimeout(HTTP_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+                .writeTimeout(HTTP_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+                .addInterceptor(new RetryInterceptor())
+                .build();
+    }
+
+    private static class RetryInterceptor implements Interceptor {
+        @Override
+        public Response intercept(Chain chain) throws IOException {
+            IOException lastException = null;
+            for (int attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+                try {
+                    return chain.proceed(chain.request());
+                } catch (IOException e) {
+                    lastException = e;
+                    log.warn("poao-tilgang kall feilet (forsøk {}/{}): {}", attempt + 1, MAX_RETRIES + 1, e.getMessage());
+                }
+            }
+            throw lastException;
+        }
+    }
+}

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/poaotilgang/PoaoTilgangService.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/poaotilgang/PoaoTilgangService.java
@@ -1,5 +1,7 @@
-package no.nav.tag.tiltaksgjennomforing.autorisasjon;
+package no.nav.tag.tiltaksgjennomforing.autorisasjon.poaotilgang;
 
+import no.nav.tag.tiltaksgjennomforing.autorisasjon.Tilgang;
+import no.nav.tag.tiltaksgjennomforing.autorisasjon.Tilgangsattributter;
 import no.nav.tag.tiltaksgjennomforing.avtale.Fnr;
 
 import java.util.Map;

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/poaotilgang/PoaoTilgangServiceFake.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/poaotilgang/PoaoTilgangServiceFake.java
@@ -1,6 +1,8 @@
-package no.nav.tag.tiltaksgjennomforing.autorisasjon;
+package no.nav.tag.tiltaksgjennomforing.autorisasjon.poaotilgang;
 
 import no.nav.tag.tiltaksgjennomforing.Miljø;
+import no.nav.tag.tiltaksgjennomforing.autorisasjon.Tilgang;
+import no.nav.tag.tiltaksgjennomforing.autorisasjon.Tilgangsattributter;
 import no.nav.tag.tiltaksgjennomforing.avtale.Fnr;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/poaotilgang/PoaoTilgangServiceImpl.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/poaotilgang/PoaoTilgangServiceImpl.java
@@ -1,7 +1,6 @@
-package no.nav.tag.tiltaksgjennomforing.autorisasjon;
+package no.nav.tag.tiltaksgjennomforing.autorisasjon.poaotilgang;
 
 import lombok.extern.slf4j.Slf4j;
-import no.nav.common.rest.client.RestClient;
 import no.nav.poao_tilgang.api.dto.response.TilgangsattributterResponse;
 import no.nav.poao_tilgang.client.Decision;
 import no.nav.poao_tilgang.client.NavAnsattTilgangTilEksternBrukerPolicyInput;
@@ -15,6 +14,9 @@ import no.nav.security.token.support.client.core.ClientProperties;
 import no.nav.security.token.support.client.core.oauth2.OAuth2AccessTokenService;
 import no.nav.security.token.support.client.spring.ClientConfigurationProperties;
 import no.nav.tag.tiltaksgjennomforing.Miljø;
+import no.nav.tag.tiltaksgjennomforing.autorisasjon.Avslagskode;
+import no.nav.tag.tiltaksgjennomforing.autorisasjon.Tilgang;
+import no.nav.tag.tiltaksgjennomforing.autorisasjon.Tilgangsattributter;
 import no.nav.tag.tiltaksgjennomforing.avtale.Fnr;
 import no.nav.team_tiltak.felles.persondata.pdl.domene.Diskresjonskode;
 import org.springframework.beans.factory.annotation.Value;
@@ -46,7 +48,7 @@ public class PoaoTilgangServiceImpl implements PoaoTilgangService {
                 new PoaoTilgangHttpClient(
                     poaoTilgangUrl,
                     () -> oAuth2AccessTokenService.getAccessToken(clientProperties).getAccessToken(),
-                    RestClient.baseClient()
+                    PoaoTilgangHttpRetryKlient.hentKlient()
                 )
         );
     }


### PR DESCRIPTION
Kall mot poao-tilgang tidsavbrutt etter 5 sekunder i produksjon. Standardklienten (RestClient.baseClient()) hardkoder timeout til 5s, noe som samsvarer med feilene som ble observert (time=5001ms).

- Øker connect/read/write-timeout fra 5s til 15s
- Legger til RetryInterceptor som gjentar mislykkede kall opptil 2 ganger ved IOException