### PR TITLE
fix. valider at virksomhet er aktiv i EREG ved forlengelse av avtale

### DIFF
--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/Veileder.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/Veileder.java
@@ -417,6 +417,7 @@ public class Veileder extends Avtalepart<NavIdent> implements InternBruker {
     public void forlengAvtale(LocalDate sluttDato, Avtale avtale) {
         super.sjekkTilgang(avtale);
         sjekkOgOppdaterOppfølgningsstatusForAvtale(avtale);
+        eregService.hentVirksomhet(avtale.getBedriftNr());
         avtale.forlengAvtale(sluttDato, getIdentifikator());
     }
 


### PR DESCRIPTION
Legger til kall mot EREG i forlengAvtale-metoden for å sikre at virksomheten fortsatt er aktiv og gyldig før en avtale kan forlenges. Kallet kaster unntak dersom virksomheten er slettet, er en juridisk enhet eller et organisasjonsledd.