### PR TITLE
fix. ikke logg 14a-diff når arena er UKJENT og OBO mangler vedtak

### DIFF
--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/admin/AdminService.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/admin/AdminService.java
@@ -135,29 +135,28 @@ public class AdminService {
                     return;
                 }
                 try {
-                    var innsatsgruppe = veilarbService.hentInnsatsgruppe(avtale.getDeltakerFnr());
-
-                    Innsatsgruppe innsatsgruppeFraKvalifiseringsgruppe = Optional.ofNullable(avtale.getKvalifiseringsgruppe())
+                    var innsatsgruppeObo = veilarbService.hentInnsatsgruppe(avtale.getDeltakerFnr());
+                    Innsatsgruppe innsatsgruppeArena = Optional.ofNullable(avtale.getKvalifiseringsgruppe())
                         .map(Kvalifiseringsgruppe::getInnsatsgruppe)
                         .orElse(null);
 
                     antallPerKombinasjon.merge(
                         new Sammenligning14aKombinasjon(
                             avtale.getKvalifiseringsgruppe(),
-                            innsatsgruppe
+                            innsatsgruppeObo
                         ),
                         1L,
                         Long::sum
                     );
 
-                    boolean beggeErNull = innsatsgruppe == null && innsatsgruppeFraKvalifiseringsgruppe == null;
-                    if (innsatsgruppeFraKvalifiseringsgruppe != innsatsgruppe || beggeErNull) {
+                    boolean manglerGyldigInnsatsgruppe = innsatsgruppeArena == Innsatsgruppe.UKJENT && innsatsgruppeObo == null;
+                    if (innsatsgruppeArena != innsatsgruppeObo && !manglerGyldigInnsatsgruppe) {
                         log.info(
                             "14a-diff for avtale={} kvalifiseringsgruppe(arena)={} (som tilsvarer {}), vedtak(obo)={}",
                             avtale.getId(),
                             avtale.getKvalifiseringsgruppe(),
-                            innsatsgruppeFraKvalifiseringsgruppe,
-                            innsatsgruppe
+                            innsatsgruppeArena,
+                            innsatsgruppeObo
                         );
                     }
                     antallBehandlet.incrementAndGet();

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/admin/AdminService.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/admin/AdminService.java
@@ -136,7 +136,7 @@ public class AdminService {
                 }
                 try {
                     var innsatsgruppeObo = veilarbService.hentInnsatsgruppe(avtale.getDeltakerFnr());
-                    Innsatsgruppe innsatsgruppeArena = Optional.ofNullable(avtale.getKvalifiseringsgruppe())
+                    var innsatsgruppeArena = Optional.ofNullable(avtale.getKvalifiseringsgruppe())
                         .map(Kvalifiseringsgruppe::getInnsatsgruppe)
                         .orElse(null);
 
@@ -149,8 +149,7 @@ public class AdminService {
                         Long::sum
                     );
 
-                    boolean manglerGyldigInnsatsgruppe = innsatsgruppeArena == Innsatsgruppe.UKJENT && innsatsgruppeObo == null;
-                    if (innsatsgruppeArena != innsatsgruppeObo && !manglerGyldigInnsatsgruppe) {
+                    if (!Innsatsgruppe.isArenaOboEqual(innsatsgruppeArena, innsatsgruppeObo)) {
                         log.info(
                             "14a-diff for avtale={} kvalifiseringsgruppe(arena)={} (som tilsvarer {}), vedtak(obo)={}",
                             avtale.getId(),

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/enhet/Innsatsgruppe.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/enhet/Innsatsgruppe.java
@@ -1,10 +1,27 @@
 package no.nav.tag.tiltaksgjennomforing.enhet;
 
+import java.util.Set;
+
 public enum Innsatsgruppe {
     GODE_MULIGHETER,
     TRENGER_VEILEDNING,
     TRENGER_VEILEDNING_NEDSATT_ARBEIDSEVNE,
     JOBBE_DELVIS,
     LITEN_MULIGHET_TIL_A_JOBBE,
-    UKJENT
+    UKJENT;
+
+    private static final Set<Innsatsgruppe> VARIG_TILPASSET_VARIANTER = Set.of(JOBBE_DELVIS, LITEN_MULIGHET_TIL_A_JOBBE);
+
+    public static boolean isArenaOboEqual(Innsatsgruppe innsatsgruppeArena, Innsatsgruppe innsatsgruppeObo) {
+        if (innsatsgruppeObo == UKJENT) {
+            return false;
+        }
+        if (innsatsgruppeArena == innsatsgruppeObo) {
+            return true;
+        }
+        if (innsatsgruppeArena == UKJENT && innsatsgruppeObo == null) {
+            return true;
+        }
+        return VARIG_TILPASSET_VARIANTER.contains(innsatsgruppeArena) && VARIG_TILPASSET_VARIANTER.contains(innsatsgruppeObo);
+    }
 }

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/enhet/veilarb/VeilarbService.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/enhet/veilarb/VeilarbService.java
@@ -95,16 +95,19 @@ public class VeilarbService {
 
     private Oppfølgingsstatus hentOppfolging(UUID avtaleId, Fnr fnr) {
         Oppfølgingsstatus oppfølgingsstatus = hentOppfølgingstatus(fnr);
-        Innsatsgruppe innsatsgruppe = hentInnsatsgruppe(fnr);
+        Innsatsgruppe innsatsgruppeObo = hentInnsatsgruppe(fnr);
 
         Kvalifiseringsgruppe kvalifiseringsgruppe = oppfølgingsstatus.getKvalifiseringsgruppe();
-        if (kvalifiseringsgruppe.getInnsatsgruppe() != innsatsgruppe) {
+        Innsatsgruppe innsatsgruppeArena = kvalifiseringsgruppe.getInnsatsgruppe();
+
+        boolean manglerGyldigInnsatsgruppe = innsatsgruppeArena == Innsatsgruppe.UKJENT && innsatsgruppeObo == null;
+        if (innsatsgruppeArena != innsatsgruppeObo && !manglerGyldigInnsatsgruppe) {
             log.warn(
                 "14a-diff{} kvalifiseringsgruppe(arena)={} (som tilsvarer {}), vedtak(obo)={}",
                 avtaleId != null ? " for avtale=" + avtaleId + " -" : " -",
                 kvalifiseringsgruppe,
-                kvalifiseringsgruppe.getInnsatsgruppe(),
-                innsatsgruppe
+                innsatsgruppeArena,
+                innsatsgruppeObo
             );
         }
 

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/enhet/veilarb/VeilarbService.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/enhet/veilarb/VeilarbService.java
@@ -100,8 +100,7 @@ public class VeilarbService {
         Kvalifiseringsgruppe kvalifiseringsgruppe = oppfølgingsstatus.getKvalifiseringsgruppe();
         Innsatsgruppe innsatsgruppeArena = kvalifiseringsgruppe.getInnsatsgruppe();
 
-        boolean manglerGyldigInnsatsgruppe = innsatsgruppeArena == Innsatsgruppe.UKJENT && innsatsgruppeObo == null;
-        if (innsatsgruppeArena != innsatsgruppeObo && !manglerGyldigInnsatsgruppe) {
+        if (!Innsatsgruppe.isArenaOboEqual(innsatsgruppeArena, innsatsgruppeObo)) {
             log.warn(
                 "14a-diff{} kvalifiseringsgruppe(arena)={} (som tilsvarer {}), vedtak(obo)={}",
                 avtaleId != null ? " for avtale=" + avtaleId + " -" : " -",

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/enhet/InnsatsgruppeTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/enhet/InnsatsgruppeTest.java
@@ -1,0 +1,55 @@
+package no.nav.tag.tiltaksgjennomforing.enhet;
+
+import org.junit.jupiter.api.Test;
+
+import static no.nav.tag.tiltaksgjennomforing.enhet.Innsatsgruppe.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+class InnsatsgruppeTest {
+
+    @Test
+    void is_equal_returnerer_true_naar_begge_er_null() {
+        assertTrue(isArenaOboEqual(null, null));
+    }
+
+    @Test
+    void is_equal_returnerer_true_naar_begge_er_samme_verdi() {
+        Innsatsgruppe innsatsgruppeArena = TRENGER_VEILEDNING;
+        Innsatsgruppe innsatsgruppeObo = TRENGER_VEILEDNING;
+        assertTrue(isArenaOboEqual(innsatsgruppeArena, innsatsgruppeObo));
+    }
+
+    @Test
+    void is_equal_returnerer_true_naar_arena_er_ukjent_og_obo_er_null() {
+        Innsatsgruppe innsatsgruppeArena = UKJENT;
+        Innsatsgruppe innsatsgruppeObo = null;
+        assertTrue(isArenaOboEqual(innsatsgruppeArena, innsatsgruppeObo));
+    }
+
+    @Test
+    void is_equal_returnerer_true_naar_begge_er_variant_av_varig_tilpasset() {
+        assertTrue(isArenaOboEqual(JOBBE_DELVIS, LITEN_MULIGHET_TIL_A_JOBBE));
+        assertTrue(isArenaOboEqual(LITEN_MULIGHET_TIL_A_JOBBE, JOBBE_DELVIS));
+        assertTrue(isArenaOboEqual(JOBBE_DELVIS, JOBBE_DELVIS));
+        assertTrue(isArenaOboEqual(LITEN_MULIGHET_TIL_A_JOBBE, LITEN_MULIGHET_TIL_A_JOBBE));
+    }
+
+    @Test
+    void is_equal_returnerer_false_naar_ulik_vanlig_innsatsgruppe() {
+        assertFalse(isArenaOboEqual(TRENGER_VEILEDNING, GODE_MULIGHETER));
+        assertFalse(isArenaOboEqual(GODE_MULIGHETER, TRENGER_VEILEDNING_NEDSATT_ARBEIDSEVNE));
+    }
+
+    @Test
+    void is_equal_returnerer_false_naar_arena_ikke_er_ukjent_og_obo_er_null() {
+        Innsatsgruppe innsatsgruppeArena = TRENGER_VEILEDNING;
+        Innsatsgruppe innsatsgruppeObo = null;
+        assertFalse(isArenaOboEqual(innsatsgruppeArena, innsatsgruppeObo));
+    }
+
+    @Test
+    void is_equal_returnerer_false_naar_kun_en_er_variant_av_varig_tilpasset() {
+        assertFalse(isArenaOboEqual(JOBBE_DELVIS, TRENGER_VEILEDNING));
+        assertFalse(isArenaOboEqual(TRENGER_VEILEDNING, LITEN_MULIGHET_TIL_A_JOBBE));
+    }
+}

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/enhet/InnsatsgruppeTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/enhet/InnsatsgruppeTest.java
@@ -52,4 +52,11 @@ class InnsatsgruppeTest {
         assertFalse(isArenaOboEqual(JOBBE_DELVIS, TRENGER_VEILEDNING));
         assertFalse(isArenaOboEqual(TRENGER_VEILEDNING, LITEN_MULIGHET_TIL_A_JOBBE));
     }
+
+    @Test
+    void is_equal_returnerer_false_naar_obo_er_ukjent() {
+        assertFalse(isArenaOboEqual(TRENGER_VEILEDNING, UKJENT));
+        assertFalse(isArenaOboEqual(UKJENT, UKJENT));
+        assertFalse(isArenaOboEqual(null, UKJENT));
+    }
 }


### PR DESCRIPTION
Kombinasjonen Innsatsgruppe.UKJENT fra Arena og null fra OBO er ikke en reell diskrepans – deltakeren mangler bare et gyldig 14a-vedtak. Tidligere logikk behandlet dette som en diff og genererte støy i loggene.

Variablene er også omdøpt til innsatsgruppeArena og innsatsgruppeObo for å gjøre kilden til hver verdi eksplisitt i koden.