### PR TITLE
fix. unngår NullPointerException i VarselController når varsel ikke finnes

### DIFF
--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/varsel/VarselController.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/varsel/VarselController.java
@@ -61,8 +61,10 @@ public class VarselController {
     public ResponseEntity<?> settTilLest(@PathVariable("varselId") UUID varselId, @CookieValue("innlogget-part") Avtalerolle innloggetPart) {
         Avtalepart avtalepart = innloggingService.hentAvtalepart(innloggetPart);
         Varsel varsel = varselRepository.findByIdAndIdentifikatorIn(varselId, avtalepart.identifikatorer());
-        varsel.settTilLest();
-        varselRepository.save(varsel);
+        if (varsel != null) {
+            varsel.settTilLest();
+            varselRepository.save(varsel);
+        }
         return ResponseEntity.ok().build();
     }
 


### PR DESCRIPTION
Legger til null-sjekk i settTilLest-endepunktet slik at koden ikke krasjer dersom findByIdAndIdentifikatorIn returnerer null.