### PR TITLE
fix. filtrer ut gyldige innsatsgruppe/tiltakstype-kombinasjoner fra 1…

### DIFF
--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/admin/AdminService.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/admin/AdminService.java
@@ -4,10 +4,12 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import no.nav.tag.tiltaksgjennomforing.avtale.Avtale;
 import no.nav.tag.tiltaksgjennomforing.avtale.AvtaleRepository;
+import no.nav.tag.tiltaksgjennomforing.avtale.Avtaleopphav;
 import no.nav.tag.tiltaksgjennomforing.avtale.Avtalerolle;
 import no.nav.tag.tiltaksgjennomforing.avtale.HendelseType;
 import no.nav.tag.tiltaksgjennomforing.avtale.Identifikator;
 import no.nav.tag.tiltaksgjennomforing.avtale.Status;
+import no.nav.tag.tiltaksgjennomforing.avtale.Tiltakstype;
 import no.nav.tag.tiltaksgjennomforing.datadeling.AvtaleHendelseUtførtAv;
 import no.nav.tag.tiltaksgjennomforing.enhet.Innsatsgruppe;
 import no.nav.tag.tiltaksgjennomforing.enhet.Kvalifiseringsgruppe;
@@ -114,7 +116,8 @@ public class AdminService {
 
     private record Sammenligning14aKombinasjon(
         Kvalifiseringsgruppe kvalifiseringsgruppe,
-        Innsatsgruppe vedtakInnsatsgruppe
+        Innsatsgruppe vedtakInnsatsgruppe,
+        Tiltakstype tiltakstype
     ) {
     }
 
@@ -131,7 +134,8 @@ public class AdminService {
         );
         try (Stream<Avtale> avtaler = avtaleRepository.streamAllByStatusIn(aktiveStatuser)) {
             avtaler.forEach(avtale -> {
-                if (avtale.getDeltakerFnr() == null) {
+                boolean erOpprettetAvArbeidsgiverOgIkkeTattOver = Avtaleopphav.ARBEIDSGIVER == avtale.getOpphav() && avtale.getVeilederNavIdent() == null;
+                if (avtale.getDeltakerFnr() == null || erOpprettetAvArbeidsgiverOgIkkeTattOver) {
                     return;
                 }
                 try {
@@ -140,22 +144,26 @@ public class AdminService {
                         .map(Kvalifiseringsgruppe::getInnsatsgruppe)
                         .orElse(null);
 
-                    antallPerKombinasjon.merge(
-                        new Sammenligning14aKombinasjon(
-                            avtale.getKvalifiseringsgruppe(),
-                            innsatsgruppeObo
-                        ),
-                        1L,
-                        Long::sum
-                    );
+                    var erLike = Innsatsgruppe.isArenaOboEqual(innsatsgruppeArena, innsatsgruppeObo);
+                    var erGyldig = Optional.ofNullable(innsatsgruppeObo).map(gruppe -> gruppe.erGyldig(avtale.getTiltakstype())).orElse(false);
 
-                    if (!Innsatsgruppe.isArenaOboEqual(innsatsgruppeArena, innsatsgruppeObo)) {
+                    if (!erLike && !erGyldig) {
                         log.info(
-                            "14a-diff for avtale={} kvalifiseringsgruppe(arena)={} (som tilsvarer {}), vedtak(obo)={}",
+                            "14a-diff for avtale={} kvalifiseringsgruppe(arena)={} (som tilsvarer {}), vedtak(obo)={}, tiltakstype={}",
                             avtale.getId(),
                             avtale.getKvalifiseringsgruppe(),
                             innsatsgruppeArena,
-                            innsatsgruppeObo
+                            innsatsgruppeObo,
+                            avtale.getTiltakstype()
+                        );
+                        antallPerKombinasjon.merge(
+                            new Sammenligning14aKombinasjon(
+                                avtale.getKvalifiseringsgruppe(),
+                                innsatsgruppeObo,
+                                avtale.getTiltakstype()
+                            ),
+                            1L,
+                            Long::sum
                         );
                     }
                     antallBehandlet.incrementAndGet();
@@ -173,9 +181,10 @@ public class AdminService {
             .forEach(entry -> {
                 Sammenligning14aKombinasjon kombinasjon = entry.getKey();
                 rader.append('\n').append(String.format(
-                    "kvalifiseringsgruppe=%s, innsatsgruppe(obo)=%s, antall=%d",
+                    "kvalifiseringsgruppe=%s, innsatsgruppe(obo)=%s, tiltakstype=%s, antall=%d",
                     kombinasjon.kvalifiseringsgruppe(),
                     kombinasjon.vedtakInnsatsgruppe(),
+                    kombinasjon.tiltakstype(),
                     entry.getValue()
                 ));
             });

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/enhet/Innsatsgruppe.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/enhet/Innsatsgruppe.java
@@ -1,5 +1,7 @@
 package no.nav.tag.tiltaksgjennomforing.enhet;
 
+import no.nav.tag.tiltaksgjennomforing.avtale.Tiltakstype;
+
 import java.util.Set;
 
 public enum Innsatsgruppe {
@@ -25,5 +27,25 @@ public enum Innsatsgruppe {
         return innsatsgruppeArena != null && innsatsgruppeObo != null
             && VARIG_TILPASSET_VARIANTER.contains(innsatsgruppeArena)
             && VARIG_TILPASSET_VARIANTER.contains(innsatsgruppeObo);
+    }
+
+    public boolean erGyldig(Tiltakstype tiltakstype) {
+        return switch (tiltakstype) {
+            case ARBEIDSTRENING, INKLUDERINGSTILSKUDD, MIDLERTIDIG_LONNSTILSKUDD, SOMMERJOBB, MENTOR -> switch (this) {
+                case TRENGER_VEILEDNING_NEDSATT_ARBEIDSEVNE,
+                     TRENGER_VEILEDNING,
+                     LITEN_MULIGHET_TIL_A_JOBBE,
+                     JOBBE_DELVIS -> true;
+                default -> false;
+            };
+            case FIREARIG_LONNSTILSKUDD -> switch (this) {
+                case TRENGER_VEILEDNING_NEDSATT_ARBEIDSEVNE, LITEN_MULIGHET_TIL_A_JOBBE, JOBBE_DELVIS -> true;
+                default -> false;
+            };
+            case VARIG_LONNSTILSKUDD, VTAO -> switch (this) {
+                case LITEN_MULIGHET_TIL_A_JOBBE, JOBBE_DELVIS -> true;
+                default -> false;
+            };
+        };
     }
 }

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/enhet/Kvalifiseringsgruppe.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/enhet/Kvalifiseringsgruppe.java
@@ -67,11 +67,11 @@ public enum Kvalifiseringsgruppe {
     }
 
     public boolean isKvalifisererTilVariglonnstilskudd() {
-        return this == VARIG_TILPASSET_INNSATS;
+        return this == VARIG_TILPASSET_INNSATS || this == GRADERT_VARIG_TILPASSET_INNSATS;
     }
 
     public boolean isKvalifisererTilVTAO(){
-        return this == VARIG_TILPASSET_INNSATS;
+        return this == VARIG_TILPASSET_INNSATS || this == GRADERT_VARIG_TILPASSET_INNSATS;
     }
 
     public Integer finnLonntilskuddProsentsatsUtifraKvalifiseringsgruppe(Integer prosentsatsLiten, Integer prosentsatsStor) {


### PR DESCRIPTION
…4a-diff-rapport

Utvider 14a-sammenligningsjobben til å ta hensyn til at visse kombinasjoner av innsatsgruppe og tiltakstype er gyldige selv om Arena og OBO ikke er like. Disse filtreres nå vekk slik at rapporten kun viser faktiske avvik.

- Legger til `erGyldig(Tiltakstype)`-metode i `Innsatsgruppe` som definerer hvilke innsatsgrupper som er tillatt per tiltakstype
- Hopper over avtaler opprettet av arbeidsgiver som ikke er tatt over av veileder
- Inkluderer tiltakstype i loggmeldinger og i `Sammenligning14aKombinasjon` slik at rapporten viser tiltakstype per kombinasjon
- Teller og logger kun kombinasjoner som er ulike *og* ugyldige