### PR TITLE
feat. legg til FeatureToggleHolder og ny toggle for VTAO-veiledertilgang

### DIFF
--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/startOgSluttDatoStrategy/VtaoStartOgSluttdatoStrategy.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/startOgSluttDatoStrategy/VtaoStartOgSluttdatoStrategy.java
@@ -25,10 +25,10 @@ public class VtaoStartOgSluttdatoStrategy extends StartOgSluttdatoStrategy {
         if (sluttDato != null && deltakerFnr != null && deltakerFnr.erOver67ÅrFraSluttDato(sluttDato)) {
             throw new FeilkodeException(Feilkode.DELTAKER_67_AAR);
         }
-
-        boolean vtaoVeilederTilgang = FeatureToggleHolder.get().isEnabled(FeatureToggle.VTAO_VEILEDER_TILGANG);
-        if (!vtaoVeilederTilgang && !avtale.erAvtaleInngått() && startDato != null && startDato.isAfter(SISTE_MULIGE_STARTDATO)) {
-            throw new FeilkodeException(Feilkode.FOR_SEN_STARTDATO_VTAO);
+        if (!avtale.erAvtaleInngått() && startDato != null && startDato.isAfter(SISTE_MULIGE_STARTDATO)) {
+            if (!FeatureToggleHolder.get().isEnabled(FeatureToggle.VTAO_VEILEDER_TILGANG)) {
+                throw new FeilkodeException(Feilkode.FOR_SEN_STARTDATO_VTAO);
+            }
         }
     }
 }

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/startOgSluttDatoStrategy/VtaoStartOgSluttdatoStrategy.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/startOgSluttDatoStrategy/VtaoStartOgSluttdatoStrategy.java
@@ -5,6 +5,8 @@ import no.nav.tag.tiltaksgjennomforing.avtale.Fnr;
 import no.nav.tag.tiltaksgjennomforing.avtale.Stillingstype;
 import no.nav.tag.tiltaksgjennomforing.exceptions.Feilkode;
 import no.nav.tag.tiltaksgjennomforing.exceptions.FeilkodeException;
+import no.nav.tag.tiltaksgjennomforing.featuretoggles.FeatureToggle;
+import no.nav.tag.tiltaksgjennomforing.featuretoggles.FeatureToggleHolder;
 
 import java.time.LocalDate;
 
@@ -23,7 +25,9 @@ public class VtaoStartOgSluttdatoStrategy extends StartOgSluttdatoStrategy {
         if (sluttDato != null && deltakerFnr != null && deltakerFnr.erOver67ÅrFraSluttDato(sluttDato)) {
             throw new FeilkodeException(Feilkode.DELTAKER_67_AAR);
         }
-        if (!avtale.erAvtaleInngått() && startDato != null && startDato.isAfter(SISTE_MULIGE_STARTDATO)) {
+
+        boolean vtaoVeilederTilgang = FeatureToggleHolder.get().isEnabled(FeatureToggle.VTAO_VEILEDER_TILGANG);
+        if (!vtaoVeilederTilgang && !avtale.erAvtaleInngått() && startDato != null && startDato.isAfter(SISTE_MULIGE_STARTDATO)) {
             throw new FeilkodeException(Feilkode.FOR_SEN_STARTDATO_VTAO);
         }
     }

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/featuretoggles/FeatureToggle.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/featuretoggles/FeatureToggle.java
@@ -1,5 +1,7 @@
 package no.nav.tag.tiltaksgjennomforing.featuretoggles;
 
+import com.fasterxml.jackson.annotation.JsonValue;
+
 public enum FeatureToggle {
     SMS_TIL_MOBILNUMMER("sms-til-mobilnummer"),
     ARENA_AVTALE_JOBB("arenaAvtaleJobb"),
@@ -14,7 +16,9 @@ public enum FeatureToggle {
     MIGRERING_SKRIVEBESKYTTET("migreringSkrivebeskyttet"),
     FIREARIG_LONNSTILSKUDD("firearigLonnstilskudd"),
     REFUSJON_KLAR_I_TILTAK_NOTIFIKASJON("refusjon-klar-i-tiltak-notifikasjon"),
-    VTAO_VEILEDER_TILGANG("vtaoVeilederTilgang");
+    VTAO_VEILEDER_TILGANG("vtaoVeilederTilgang"),
+    VIS_HVEM_HAR_GODKJENT("visHvemHarGodkjent"),
+    VIS_NEDETID_BANNER("visNedetidBanner");
 
     private String toggleNavn;
 
@@ -22,6 +26,7 @@ public enum FeatureToggle {
         this.toggleNavn = toggleNavn;
     }
 
+    @JsonValue
     public String getToggleNavn() {
         return toggleNavn;
     }

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/featuretoggles/FeatureToggle.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/featuretoggles/FeatureToggle.java
@@ -13,7 +13,8 @@ public enum FeatureToggle {
     SJEKK_OM_DELTAKER_KAN_MOTTA_POST("sjekkOmDeltakerKanMottaPost"),
     MIGRERING_SKRIVEBESKYTTET("migreringSkrivebeskyttet"),
     FIREARIG_LONNSTILSKUDD("firearigLonnstilskudd"),
-    REFUSJON_KLAR_I_TILTAK_NOTIFIKASJON("refusjon-klar-i-tiltak-notifikasjon");
+    REFUSJON_KLAR_I_TILTAK_NOTIFIKASJON("refusjon-klar-i-tiltak-notifikasjon"),
+    VTAO_VEILEDER_TILGANG("vtaoVeilederTilgang");
 
     private String toggleNavn;
 

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/featuretoggles/FeatureToggleController.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/featuretoggles/FeatureToggleController.java
@@ -23,7 +23,7 @@ public class FeatureToggleController {
     }
 
     @GetMapping
-    public Map<String, Boolean> feature(@RequestParam("feature") List<String> features) {
+    public Map<FeatureToggle, Boolean> feature(@RequestParam("feature") List<FeatureToggle> features) {
         return featureToggleService.hentFeatureToggles(features);
     }
 

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/featuretoggles/FeatureToggleController.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/featuretoggles/FeatureToggleController.java
@@ -28,8 +28,8 @@ public class FeatureToggleController {
     }
 
     @GetMapping("/variant")
-    public Map<String, Variant> variant(@RequestParam("feature") List<String> features) {
-        return  featureToggleService.hentVarianter(features);
+    public Map<FeatureToggle, Variant> variant(@RequestParam("feature") List<FeatureToggle> features) {
+        return featureToggleService.hentVarianter(features);
     }
 
 }

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/featuretoggles/FeatureToggleHolder.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/featuretoggles/FeatureToggleHolder.java
@@ -1,0 +1,20 @@
+package no.nav.tag.tiltaksgjennomforing.featuretoggles;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class FeatureToggleHolder {
+
+    private static volatile FeatureToggleService instance;
+
+    public FeatureToggleHolder(FeatureToggleService featureToggleService) {
+        FeatureToggleHolder.instance = featureToggleService;
+    }
+
+    public static FeatureToggleService get() {
+        if (instance == null) {
+            throw new IllegalStateException("FeatureToggleHolder er ikke initialisert — Spring-konteksten er ikke startet");
+        }
+        return instance;
+    }
+}

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/featuretoggles/FeatureToggleService.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/featuretoggles/FeatureToggleService.java
@@ -31,10 +31,10 @@ public class FeatureToggleService {
         return features.stream().collect(Collectors.toMap(feature -> feature, this::isEnabled));
     }
 
-    public Map<String, Variant> hentVarianter(List<String> features) {
+    public Map<FeatureToggle, Variant> hentVarianter(List<FeatureToggle> features) {
         return features.stream().collect(Collectors.toMap(
                 feature -> feature,
-                feature -> unleash.getVariant(feature, contextMedInnloggetBruker())
+                feature -> unleash.getVariant(feature.getToggleNavn(), contextMedInnloggetBruker())
         ));
     }
 

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/featuretoggles/FeatureToggleService.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/featuretoggles/FeatureToggleService.java
@@ -27,7 +27,7 @@ public class FeatureToggleService {
         this.tokenUtils = tokenUtils;
     }
 
-    public Map<String, Boolean> hentFeatureToggles(List<String> features) {
+    public Map<FeatureToggle, Boolean> hentFeatureToggles(List<FeatureToggle> features) {
         return features.stream().collect(Collectors.toMap(feature -> feature, this::isEnabled));
     }
 
@@ -36,11 +36,6 @@ public class FeatureToggleService {
                 feature -> feature,
                 feature -> unleash.getVariant(feature, contextMedInnloggetBruker())
         ));
-    }
-
-    @Deprecated
-    public Boolean isEnabled(String feature) {
-        return unleash.isEnabled(feature, contextMedInnloggetBruker());
     }
 
     public Boolean isEnabled(FeatureToggle feature) {
@@ -60,7 +55,7 @@ public class FeatureToggleService {
         if (!tiltakstype.isFirearigLonnstilskudd()) {
             return true;
         }
-        return rolle.erInternBruker() ? isEnabled(FeatureToggle.FIREARIG_LONNSTILSKUDD) : false;
+        return rolle.erInternBruker() && isEnabled(FeatureToggle.FIREARIG_LONNSTILSKUDD);
     }
 
     public boolean kanOppretteAvtale(Avtale avtale) {

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/AltinnTilgangsstyringServiceTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/autorisasjon/AltinnTilgangsstyringServiceTest.java
@@ -9,6 +9,7 @@ import no.nav.tag.tiltaksgjennomforing.avtale.BedriftNr;
 import no.nav.tag.tiltaksgjennomforing.avtale.Fnr;
 import no.nav.tag.tiltaksgjennomforing.avtale.Tiltakstype;
 import no.nav.tag.tiltaksgjennomforing.exceptions.TiltaksgjennomforingException;
+import no.nav.tag.tiltaksgjennomforing.featuretoggles.FeatureToggle;
 import no.nav.tag.tiltaksgjennomforing.featuretoggles.FeatureToggleService;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -24,7 +25,7 @@ import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 @SpringBootTest
@@ -45,7 +46,7 @@ public class AltinnTilgangsstyringServiceTest {
     @BeforeEach
     public void setup() {
         FodselsnummerValidator.ALLOW_SYNTHETIC_NUMBERS = true;
-        when(featureToggleService.isEnabled(anyString())).thenReturn(false);
+        when(featureToggleService.isEnabled(any(FeatureToggle.class))).thenReturn(false);
         fnr = Fnr.generer(25);
     }
 

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/startOgSluttDatoStrategy/VtaoStartOgSluttDatoStrategyTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/startOgSluttDatoStrategy/VtaoStartOgSluttDatoStrategyTest.java
@@ -7,6 +7,9 @@ import no.nav.tag.tiltaksgjennomforing.avtale.Fnr;
 import no.nav.tag.tiltaksgjennomforing.avtale.OpprettAvtale;
 import no.nav.tag.tiltaksgjennomforing.avtale.TestData;
 import no.nav.tag.tiltaksgjennomforing.exceptions.Feilkode;
+import no.nav.tag.tiltaksgjennomforing.featuretoggles.FeatureToggle;
+import no.nav.tag.tiltaksgjennomforing.featuretoggles.FeatureToggleHolder;
+import no.nav.tag.tiltaksgjennomforing.featuretoggles.FeatureToggleService;
 import no.nav.tag.tiltaksgjennomforing.utils.Now;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -16,12 +19,17 @@ import java.time.LocalDate;
 
 import static no.nav.tag.tiltaksgjennomforing.AssertFeilkode.assertFeilkode;
 import static no.nav.tag.tiltaksgjennomforing.avtale.Tiltakstype.VTAO;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 class VtaoStartOgSluttDatoStrategyTest {
 
     @BeforeEach
     public void setup() {
         FodselsnummerValidator.ALLOW_SYNTHETIC_NUMBERS = true;
+        FeatureToggleService featureToggleService = mock(FeatureToggleService.class);
+        when(featureToggleService.isEnabled(FeatureToggle.VTAO_VEILEDER_TILGANG)).thenReturn(false);
+        new FeatureToggleHolder(featureToggleService);
     }
 
     @AfterEach

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/featuretoggles/FeatureToggleServiceTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/featuretoggles/FeatureToggleServiceTest.java
@@ -42,7 +42,7 @@ public class FeatureToggleServiceTest {
     }
 
     @Test
-    public void hentFeatureToggles__skal_returnere_false_hvis_feature_ikke_finnes() {
+    public void hentFeatureToggles__skal_default_returnere_false() {
         Map<FeatureToggle, Boolean> toggles = featureToggleService.hentFeatureToggles(List.of(FeatureToggle.SJEKK_OM_DELTAKER_KAN_MOTTA_POST));
         assertThat(toggles.get(FeatureToggle.SJEKK_OM_DELTAKER_KAN_MOTTA_POST)).isFalse();
     }

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/featuretoggles/FeatureToggleServiceTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/featuretoggles/FeatureToggleServiceTest.java
@@ -29,35 +29,36 @@ public class FeatureToggleServiceTest {
 
     @Test
     public void hentFeatureToggles__skal_returnere_true_hvis_feature_er_på() {
-        when(unleash.isEnabled(eq("feature_som_er_på"), any(UnleashContext.class))).thenReturn(true);
-        Map<String, Boolean> toggles = featureToggleService.hentFeatureToggles(List.of("feature_som_er_på"));
-        assertThat(toggles.get("feature_som_er_på")).isTrue();
+        when(unleash.isEnabled(eq(FeatureToggle.SJEKK_OM_DELTAKER_KAN_MOTTA_POST.getToggleNavn()), any(UnleashContext.class))).thenReturn(true);
+        Map<FeatureToggle, Boolean> toggles = featureToggleService.hentFeatureToggles(List.of(FeatureToggle.SJEKK_OM_DELTAKER_KAN_MOTTA_POST));
+        assertThat(toggles.get(FeatureToggle.SJEKK_OM_DELTAKER_KAN_MOTTA_POST)).isTrue();
     }
 
     @Test
     public void hentFeatureToggles__skal_returnere_false_hvis_feature_er_av() {
-        when(unleash.isEnabled(eq("feature_som_er_av"), any(UnleashContext.class))).thenReturn(false);
-        Map<String, Boolean> toggles = featureToggleService.hentFeatureToggles(List.of("feature_som_er_av"));
-        assertThat(toggles.get("feature_som_er_av")).isFalse();
+        when(unleash.isEnabled(eq(FeatureToggle.SJEKK_OM_DELTAKER_KAN_MOTTA_POST.getToggleNavn()), any(UnleashContext.class))).thenReturn(false);
+        Map<FeatureToggle, Boolean> toggles = featureToggleService.hentFeatureToggles(List.of(FeatureToggle.SJEKK_OM_DELTAKER_KAN_MOTTA_POST));
+        assertThat(toggles.get(FeatureToggle.SJEKK_OM_DELTAKER_KAN_MOTTA_POST)).isFalse();
     }
 
     @Test
     public void hentFeatureToggles__skal_returnere_false_hvis_feature_ikke_finnes() {
-        Map<String, Boolean> toggles = featureToggleService.hentFeatureToggles(List.of("feature_som_ikke_finnes"));
-        assertThat(toggles.get("feature_som_ikke_finnes")).isFalse();
+        Map<FeatureToggle, Boolean> toggles = featureToggleService.hentFeatureToggles(List.of(FeatureToggle.SJEKK_OM_DELTAKER_KAN_MOTTA_POST));
+        assertThat(toggles.get(FeatureToggle.SJEKK_OM_DELTAKER_KAN_MOTTA_POST)).isFalse();
     }
 
     @Test
     public void hentFeatureToggles__skal_kunne_returnere_flere_toggles() {
-        List<String> features = Arrays.asList("feature1", "feature2", "feature3");
-        when(unleash.isEnabled(eq("feature1"), any(UnleashContext.class))).thenReturn(true);
-        when(unleash.isEnabled(eq("feature2"), any(UnleashContext.class))).thenReturn(false);
+        List<FeatureToggle> features = Arrays.asList(FeatureToggle.KODE_6_SPERRE, FeatureToggle.ARENA_KAFKA, FeatureToggle.SMS_TIL_MOBILNUMMER);
+        when(unleash.isEnabled(eq(FeatureToggle.KODE_6_SPERRE.getToggleNavn()), any(UnleashContext.class))).thenReturn(true);
+        when(unleash.isEnabled(eq(FeatureToggle.ARENA_KAFKA.getToggleNavn()), any(UnleashContext.class))).thenReturn(false);
+        when(unleash.isEnabled(eq(FeatureToggle.SMS_TIL_MOBILNUMMER.getToggleNavn()), any(UnleashContext.class))).thenReturn(false);
 
-        Map<String, Boolean> toggles = featureToggleService.hentFeatureToggles(features);
+        Map<FeatureToggle, Boolean> toggles = featureToggleService.hentFeatureToggles(features);
 
-        assertThat(toggles.get("feature1")).isTrue();
-        assertThat(toggles.get("feature2")).isFalse();
-        assertThat(toggles.get("feature3")).isFalse();
+        assertThat(toggles.get(FeatureToggle.KODE_6_SPERRE)).isTrue();
+        assertThat(toggles.get(FeatureToggle.ARENA_KAFKA)).isFalse();
+        assertThat(toggles.get(FeatureToggle.SMS_TIL_MOBILNUMMER)).isFalse();
         assertThat(toggles.size()).isEqualTo(3);
     }
 }

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/tilskuddsperiode/TilskuddsperiodeAnnullertKafkaProducerTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/tilskuddsperiode/TilskuddsperiodeAnnullertKafkaProducerTest.java
@@ -1,6 +1,7 @@
 package no.nav.tag.tiltaksgjennomforing.tilskuddsperiode;
 
 import no.nav.tag.tiltaksgjennomforing.Miljø;
+import no.nav.tag.tiltaksgjennomforing.featuretoggles.FeatureToggle;
 import no.nav.tag.tiltaksgjennomforing.featuretoggles.FeatureToggleService;
 import no.nav.tag.tiltaksgjennomforing.infrastruktur.kafka.Topics;
 import org.apache.kafka.clients.consumer.Consumer;
@@ -24,7 +25,7 @@ import org.springframework.test.context.ActiveProfiles;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 @SpringBootTest(properties = { "tiltaksgjennomforing.kafka.enabled=true" })
@@ -44,7 +45,7 @@ class TilskuddsperiodeAnnullertKafkaProducerTest {
 
     @Test
     public void skal_kunne_sende_tilskuddperiode_annullert_på_kafka_topic() throws JSONException {
-        when(featureToggleService.isEnabled(anyString())).thenReturn(true);
+        when(featureToggleService.isEnabled(any(FeatureToggle.class))).thenReturn(true);
 
         var consumerProps = KafkaTestUtils.consumerProps("testGroup", "false", embeddedKafka);
         consumerProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/tilskuddsperiode/TilskuddsperiodeGodkjentKafkaProducerTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/tilskuddsperiode/TilskuddsperiodeGodkjentKafkaProducerTest.java
@@ -6,6 +6,7 @@ import no.nav.tag.tiltaksgjennomforing.avtale.Fnr;
 import no.nav.tag.tiltaksgjennomforing.avtale.Identifikator;
 import no.nav.tag.tiltaksgjennomforing.avtale.NavIdent;
 import no.nav.tag.tiltaksgjennomforing.avtale.Tiltakstype;
+import no.nav.tag.tiltaksgjennomforing.featuretoggles.FeatureToggle;
 import no.nav.tag.tiltaksgjennomforing.featuretoggles.FeatureToggleService;
 import no.nav.tag.tiltaksgjennomforing.infrastruktur.kafka.Topics;
 import no.nav.tag.tiltaksgjennomforing.utils.Now;
@@ -30,7 +31,7 @@ import java.util.Map;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.anyString;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 @SpringBootTest(properties = { "tiltaksgjennomforing.kafka.enabled=true" })
@@ -50,7 +51,7 @@ class TilskuddsperiodeGodkjentKafkaProducerTest {
 
     @Test
     public void skal_kunne_sende_tilskuddperiode_godkjent_på_kafka_topic() throws JSONException {
-        when(featureToggleService.isEnabled(anyString())).thenReturn(true);
+        when(featureToggleService.isEnabled(any(FeatureToggle.class))).thenReturn(true);
 
         Map<String, Object> consumerProps = KafkaTestUtils.consumerProps("testGroup", "false", embeddedKafka);
         consumerProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/tilskuddsperiode/TilskuddsperiodeResendingTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/tilskuddsperiode/TilskuddsperiodeResendingTest.java
@@ -4,6 +4,7 @@ import no.nav.tag.tiltaksgjennomforing.Miljø;
 import no.nav.tag.tiltaksgjennomforing.avtale.Avtale;
 import no.nav.tag.tiltaksgjennomforing.avtale.AvtaleRepository;
 import no.nav.tag.tiltaksgjennomforing.avtale.TestData;
+import no.nav.tag.tiltaksgjennomforing.featuretoggles.FeatureToggle;
 import no.nav.tag.tiltaksgjennomforing.featuretoggles.FeatureToggleService;
 import no.nav.tag.tiltaksgjennomforing.infrastruktur.kafka.Topics;
 import no.nav.tag.tiltaksgjennomforing.utils.Now;
@@ -27,7 +28,7 @@ import java.time.LocalDate;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 @SpringBootTest(properties = { "tiltaksgjennomforing.kafka.enabled=true" })
@@ -47,7 +48,7 @@ public class TilskuddsperiodeResendingTest {
 
     @Test
     public void sjekk_at_godkjent_med_samme_løpenummer_får_resendings_nummer() {
-        when(featureToggleService.isEnabled(anyString())).thenReturn(true);
+        when(featureToggleService.isEnabled(any(FeatureToggle.class))).thenReturn(true);
 
         Map<String, Object> consumerProps = KafkaTestUtils.consumerProps("testGroup", "false", embeddedKafka);
         consumerProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);


### PR DESCRIPTION
Introduserer FeatureToggleHolder som gjør FeatureToggleService tilgjengelig statisk, slik at domeneklasser uten Spring-kontekst kan sjekke feature toggles.

Legger til ny toggle 'vtaoVeilederTilgang' som, når aktivert, omgår valideringsregelen FOR_SEN_STARTDATO_VTAO i VtaoStartOgSluttdatoStrategy. Dette gjør det mulig for veiledere å opprette VTAO-avtaler med startdato etter SISTE_MULIGE_STARTDATO.

I tillegg er FeatureToggleService og tilhørende tester oppdatert til å bruke FeatureToggle-enum i stedet for fritekststrenger i hentFeatureToggles og isEnabled, og den utdaterte isEnabled(String)-metoden er fjernet.