### PR TITLE
feat. oppdater 14a-innsatsgruppe på aktive avtaler

### DIFF
--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/admin/AdminController.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/admin/AdminController.java
@@ -564,8 +564,8 @@ public class AdminController {
         return resultat;
     }
 
-    @GetMapping("/sammenlign-14a-innsatsgruppe")
-    public void sammenlign14aInnsatsgruppe() {
-        adminService.sammenlign14aInnsatsgruppe();
+    @PostMapping("/avtale/oppdater-14a-innsatsgruppe")
+    public void oppdater14aInnsatsgruppe() {
+        adminService.oppdater14aInnsatsgruppe();
     }
 }

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/admin/AdminService.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/admin/AdminService.java
@@ -9,7 +9,6 @@ import no.nav.tag.tiltaksgjennomforing.avtale.Avtalerolle;
 import no.nav.tag.tiltaksgjennomforing.avtale.HendelseType;
 import no.nav.tag.tiltaksgjennomforing.avtale.Identifikator;
 import no.nav.tag.tiltaksgjennomforing.avtale.Status;
-import no.nav.tag.tiltaksgjennomforing.avtale.Tiltakstype;
 import no.nav.tag.tiltaksgjennomforing.datadeling.AvtaleHendelseUtførtAv;
 import no.nav.tag.tiltaksgjennomforing.enhet.Innsatsgruppe;
 import no.nav.tag.tiltaksgjennomforing.enhet.Kvalifiseringsgruppe;
@@ -24,9 +23,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -114,17 +111,9 @@ public class AdminService {
         }
     }
 
-    private record Sammenligning14aKombinasjon(
-        Kvalifiseringsgruppe kvalifiseringsgruppe,
-        Innsatsgruppe vedtakInnsatsgruppe,
-        Tiltakstype tiltakstype
-    ) {
-    }
-
     @Async
-    @Transactional(readOnly = true)
-    public void sammenlign14aInnsatsgruppe() {
-        Map<Sammenligning14aKombinasjon, Long> antallPerKombinasjon = new HashMap<>();
+    @Transactional
+    public void oppdater14aInnsatsgruppe() {
         AtomicInteger antallBehandlet = new AtomicInteger(0);
         Set<Status> aktiveStatuser = Set.of(
             Status.GJENNOMFØRES,
@@ -134,38 +123,27 @@ public class AdminService {
         );
         try (Stream<Avtale> avtaler = avtaleRepository.streamAllByStatusIn(aktiveStatuser)) {
             avtaler.forEach(avtale -> {
-                boolean erOpprettetAvArbeidsgiverOgIkkeTattOver = Avtaleopphav.ARBEIDSGIVER == avtale.getOpphav() && avtale.getVeilederNavIdent() == null;
-                if (avtale.getDeltakerFnr() == null || erOpprettetAvArbeidsgiverOgIkkeTattOver) {
+                var erOpprettetAvArbeidsgiverOgIkkeTattOver = Avtaleopphav.ARBEIDSGIVER == avtale.getOpphav() && avtale.getVeilederNavIdent() == null;
+                var harInnsatsgruppe = avtale.getInnsatsgruppe() != null;
+
+                if (avtale.getDeltakerFnr() == null || erOpprettetAvArbeidsgiverOgIkkeTattOver || harInnsatsgruppe) {
                     return;
                 }
+
                 try {
                     var innsatsgruppeObo = veilarbService.hentInnsatsgruppe(avtale.getDeltakerFnr());
                     var innsatsgruppeArena = Optional.ofNullable(avtale.getKvalifiseringsgruppe())
                         .map(Kvalifiseringsgruppe::getInnsatsgruppe)
                         .orElse(null);
 
-                    var erLike = Innsatsgruppe.isArenaOboEqual(innsatsgruppeArena, innsatsgruppeObo);
-                    var erGyldig = Optional.ofNullable(innsatsgruppeObo).map(gruppe -> gruppe.erGyldig(avtale.getTiltakstype())).orElse(false);
+                    var erNyInnsatsgruppeLikGammel = Innsatsgruppe.isArenaOboEqual(innsatsgruppeArena, innsatsgruppeObo);
+                    var erNyInnsatsgruppeGyldigForTiltakstypen = Optional.ofNullable(innsatsgruppeObo).map(gruppe -> gruppe.erGyldig(avtale.getTiltakstype())).orElse(false);
 
-                    if (!erLike && !erGyldig) {
-                        log.info(
-                            "14a-diff for avtale={} kvalifiseringsgruppe(arena)={} (som tilsvarer {}), vedtak(obo)={}, tiltakstype={}",
-                            avtale.getId(),
-                            avtale.getKvalifiseringsgruppe(),
-                            innsatsgruppeArena,
-                            innsatsgruppeObo,
-                            avtale.getTiltakstype()
-                        );
-                        antallPerKombinasjon.merge(
-                            new Sammenligning14aKombinasjon(
-                                avtale.getKvalifiseringsgruppe(),
-                                innsatsgruppeObo,
-                                avtale.getTiltakstype()
-                            ),
-                            1L,
-                            Long::sum
-                        );
+                    if (erNyInnsatsgruppeLikGammel || erNyInnsatsgruppeGyldigForTiltakstypen) {
+                        avtale.setInnsatsgruppe(innsatsgruppeObo);
+                        avtaleRepository.save(avtale);
                     }
+
                     antallBehandlet.incrementAndGet();
                 } catch (Exception e) {
                     log.warn("Feil ved henting av 14a-vedtak for avtale {}: {}", avtale.getId(), e.getMessage());
@@ -173,23 +151,7 @@ public class AdminService {
             });
         }
 
-        log.info("Sammenligner 14a innsatsgruppe for {} avtaler", antallBehandlet.get());
-
-        StringBuilder rader = new StringBuilder();
-        antallPerKombinasjon.entrySet().stream()
-            .sorted(Map.Entry.<Sammenligning14aKombinasjon, Long>comparingByValue().reversed())
-            .forEach(entry -> {
-                Sammenligning14aKombinasjon kombinasjon = entry.getKey();
-                rader.append('\n').append(String.format(
-                    "kvalifiseringsgruppe=%s, innsatsgruppe(obo)=%s, tiltakstype=%s, antall=%d",
-                    kombinasjon.kvalifiseringsgruppe(),
-                    kombinasjon.vedtakInnsatsgruppe(),
-                    kombinasjon.tiltakstype(),
-                    entry.getValue()
-                ));
-            });
-
-        log.info("Oppsummering av 14a-sammenligning:{}", rader);
+        log.info("14a innsatsgruppe oppdatert for {} avtaler", antallBehandlet.get());
     }
 
     private Varsel lagHendelse(Avtale avtale) {


### PR DESCRIPTION
Erstatter sammenligning av 14a-innsatsgruppe med faktisk oppdatering. Henter innsatsgruppe fra OBO-tjenesten og lagrer den på avtalen dersom den er lik Arena-verdien eller gyldig for tiltakstypen.

Avtaler som allerede har innsatsgruppe satt, mangler deltakerFnr, eller er opprettet av arbeidsgiver uten veileder, hoppes over.