### PR TITLE
feat. legg til innsatsgruppe i AvtaleDTO

### DIFF
--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/Arbeidsgiver.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/Arbeidsgiver.java
@@ -185,6 +185,7 @@ public class Arbeidsgiver extends Avtalepart<Fnr> {
             .annullertGrunn(null)
             .kvalifiseringsgruppe(null)
             .formidlingsgruppe(null)
+            .innsatsgruppe(null)
             .build();
     }
 

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/transportlag/AvtaleDTO.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/transportlag/AvtaleDTO.java
@@ -50,6 +50,7 @@ public record AvtaleDTO(
     boolean godkjentForEtterregistrering,
     Kvalifiseringsgruppe kvalifiseringsgruppe,
     Formidlingsgruppe formidlingsgruppe,
+    InnsatsgruppeDTO innsatsgruppe,
     SortedSet<TilskuddPeriodeDTO> tilskuddPeriode,
     boolean feilregistrert,
     @Deprecated
@@ -90,6 +91,7 @@ public record AvtaleDTO(
             avtale.isGodkjentForEtterregistrering(),
             avtale.getKvalifiseringsgruppe(),
             avtale.getFormidlingsgruppe(),
+            InnsatsgruppeDTO.map(avtale),
             avtale.getTilskuddPeriode()
                 .stream()
                 .map(TilskuddPeriodeDTO::new)

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/transportlag/InnsatsgruppeDTO.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/transportlag/InnsatsgruppeDTO.java
@@ -15,6 +15,6 @@ public record InnsatsgruppeDTO(
                 innsatsgruppe,
                 innsatsgruppe.erGyldig(avtale.getTiltakstype())
             ))
-            .orElse(new InnsatsgruppeDTO(null, false));
+            .orElse(null);
     }
 }

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/transportlag/InnsatsgruppeDTO.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/avtale/transportlag/InnsatsgruppeDTO.java
@@ -1,0 +1,20 @@
+package no.nav.tag.tiltaksgjennomforing.avtale.transportlag;
+
+import no.nav.tag.tiltaksgjennomforing.avtale.Avtale;
+import no.nav.tag.tiltaksgjennomforing.enhet.Innsatsgruppe;
+
+import java.util.Optional;
+
+public record InnsatsgruppeDTO(
+    Innsatsgruppe type,
+    boolean erGyldigForTiltakstype
+) {
+    public static InnsatsgruppeDTO map(Avtale avtale) {
+        return Optional.ofNullable(avtale.getInnsatsgruppe())
+            .map(innsatsgruppe -> new InnsatsgruppeDTO(
+                innsatsgruppe,
+                innsatsgruppe.erGyldig(avtale.getTiltakstype())
+            ))
+            .orElse(new InnsatsgruppeDTO(null, false));
+    }
+}

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/TestData.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/TestData.java
@@ -380,7 +380,7 @@ public class TestData {
             avtale.setInnsatsgruppe(Innsatsgruppe.LITEN_MULIGHET_TIL_A_JOBBE);
         } else {
             avtale.setKvalifiseringsgruppe(Kvalifiseringsgruppe.SITUASJONSBESTEMT_INNSATS);
-            avtale.setInnsatsgruppe(Innsatsgruppe.LITEN_MULIGHET_TIL_A_JOBBE);
+            avtale.setInnsatsgruppe(Innsatsgruppe.TRENGER_VEILEDNING);
         }
         if (tiltakstype == Tiltakstype.FIREARIG_LONNSTILSKUDD) {
             LocalDate start = Now.localDate().isBefore(LocalDate.of(2026, 8, 1)) ? LocalDate.of(2026, 8, 1) : Now.localDate();

--- a/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/TestData.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforing/avtale/TestData.java
@@ -245,6 +245,7 @@ public class TestData {
         Avtale avtale = TestData.enMidlertidigLonnstilskuddAvtaleMedAltUtfylt();
         setOppfølgingOgGeografiskPåAvtale(avtale);
         avtale.setKvalifiseringsgruppe(Kvalifiseringsgruppe.VARIG_TILPASSET_INNSATS);
+        avtale.setInnsatsgruppe(Innsatsgruppe.LITEN_MULIGHET_TIL_A_JOBBE);
         EndreAvtale endring = TestData.endringPåAlleLønnstilskuddFelter(startDato, sluttDato);
         avtale.setGodkjentForEtterregistrering(true);
         avtale.endreAvtale(endring, Avtalerolle.VEILEDER);
@@ -259,6 +260,7 @@ public class TestData {
         avtale.setArenaRyddeAvtale(new ArenaRyddeAvtale());
         setOppfølgingOgGeografiskPåAvtale(avtale);
         avtale.setKvalifiseringsgruppe(Kvalifiseringsgruppe.VARIG_TILPASSET_INNSATS);
+        avtale.setInnsatsgruppe(Innsatsgruppe.LITEN_MULIGHET_TIL_A_JOBBE);
         EndreAvtale endring = TestData.endringPåAlleLønnstilskuddFelter(startDato, sluttDato);
         avtale.setGodkjentForEtterregistrering(true);
         avtale.endreAvtale(endring, Avtalerolle.VEILEDER);
@@ -273,6 +275,7 @@ public class TestData {
         avtale.setArenaRyddeAvtale(new ArenaRyddeAvtale());
         setOppfølgingOgGeografiskPåAvtale(avtale);
         avtale.setKvalifiseringsgruppe(Kvalifiseringsgruppe.VARIG_TILPASSET_INNSATS);
+        avtale.setInnsatsgruppe(Innsatsgruppe.LITEN_MULIGHET_TIL_A_JOBBE);
         EndreAvtale endring = TestData.endringPåAlleLønnstilskuddFelter(startDato, sluttDato);
         avtale.setGodkjentForEtterregistrering(true);
         avtale.endreAvtale(endring, Avtalerolle.VEILEDER);
@@ -374,8 +377,10 @@ public class TestData {
         setOppfølgingPåAvtale(avtale);
         if (tiltakstype == Tiltakstype.VARIG_LONNSTILSKUDD) {
             avtale.setKvalifiseringsgruppe(Kvalifiseringsgruppe.VARIG_TILPASSET_INNSATS);
+            avtale.setInnsatsgruppe(Innsatsgruppe.LITEN_MULIGHET_TIL_A_JOBBE);
         } else {
             avtale.setKvalifiseringsgruppe(Kvalifiseringsgruppe.SITUASJONSBESTEMT_INNSATS);
+            avtale.setInnsatsgruppe(Innsatsgruppe.LITEN_MULIGHET_TIL_A_JOBBE);
         }
         if (tiltakstype == Tiltakstype.FIREARIG_LONNSTILSKUDD) {
             LocalDate start = Now.localDate().isBefore(LocalDate.of(2026, 8, 1)) ? LocalDate.of(2026, 8, 1) : Now.localDate();
@@ -402,6 +407,7 @@ public class TestData {
         Avtale avtale = Avtale.opprett(lagOpprettAvtale(Tiltakstype.MIDLERTIDIG_LONNSTILSKUDD), Avtaleopphav.VEILEDER, veilderNavIdent);
         setOppfølgingPåAvtale(avtale);
         avtale.setKvalifiseringsgruppe(Kvalifiseringsgruppe.VARIG_TILPASSET_INNSATS);
+        avtale.setInnsatsgruppe(Innsatsgruppe.LITEN_MULIGHET_TIL_A_JOBBE);
         EndreAvtale endreAvtale = endringPåAlleLønnstilskuddFelter();
         endreAvtale.setSluttDato(Now.localDate().plusMonths(23).minusDays(2));
         avtale.endreAvtale(endreAvtale, Avtalerolle.VEILEDER);
@@ -423,6 +429,7 @@ public class TestData {
         Avtale avtale = Avtale.opprett(lagOpprettAvtale(tiltakstype), Avtaleopphav.VEILEDER, veilderNavIdent);
         setOppfølgingPåAvtale(avtale);
         avtale.setKvalifiseringsgruppe(Kvalifiseringsgruppe.SPESIELT_TILPASSET_INNSATS);
+        avtale.setInnsatsgruppe(Innsatsgruppe.LITEN_MULIGHET_TIL_A_JOBBE);
         avtale.endreAvtale(endringPåAlleLønnstilskuddFelter(), Avtalerolle.VEILEDER);
         avtale.setTiltakstype(tiltakstype);
         avtale.getGjeldendeInnhold().setDeltakerFornavn("Lilly");
@@ -490,6 +497,7 @@ public class TestData {
     public static Avtale enLonnstilskuddAvtaleGodkjentAvVeilederUtenTilskuddsperioder() {
         Avtale avtale = enMidlertidigLonnstilskuddAvtaleMedAltUtfyltUtenTilskuddsperioder();
         avtale.setKvalifiseringsgruppe(Kvalifiseringsgruppe.VARIG_TILPASSET_INNSATS);
+        avtale.setInnsatsgruppe(Innsatsgruppe.LITEN_MULIGHET_TIL_A_JOBBE);
         avtale.getGjeldendeInnhold().setGodkjentAvArbeidsgiver(Now.instant());
         avtale.getGjeldendeInnhold().setGodkjentAvDeltaker(Now.instant());
         avtale.getGjeldendeInnhold().setGodkjentAvVeileder(Now.instant());
@@ -717,6 +725,7 @@ public class TestData {
     public static Avtale enLonnstilskuddAvtaleMedAltUtfyltMedGodkjentForEtterregistrering(LocalDate avtaleStart, LocalDate avtaleSlutt) {
         Avtale avtale = TestData.enMidlertidigLonnstilskuddAvtaleMedAltUtfylt();
         avtale.setKvalifiseringsgruppe(Kvalifiseringsgruppe.VARIG_TILPASSET_INNSATS);
+        avtale.setInnsatsgruppe(Innsatsgruppe.LITEN_MULIGHET_TIL_A_JOBBE);
         EndreAvtale endring = TestData.endringPåAlleLønnstilskuddFelter(avtaleStart, avtaleSlutt);
         avtale.setGodkjentForEtterregistrering(true);
         avtale.endreAvtale(endring, Avtalerolle.VEILEDER);


### PR DESCRIPTION
Introduserer InnsatsgruppeDTO som inneholder innsatsgruppetype og om den er gyldig for avtalens tiltakstype. Feltet legges til i AvtaleDTO slik at konsumenter får tilgang til denne informasjonen uten å gjøre oppslag på egen hånd.

Testdata oppdatert med LITEN_MULIGHET_TIL_A_JOBBE for relevante lønnstilskuddavtaler.